### PR TITLE
solved no points in data! for knnImpute error 

### DIFF
--- a/pkg/caret/R/preProcess.R
+++ b/pkg/caret/R/preProcess.R
@@ -142,7 +142,7 @@ preProcess.default <- function(x, method = c("center", "scale"),
       scaleValue[which(scaleValue == 0)] <- 1
     }
 
-  cols <- if(any(method == "knnImpute")) which(apply(x, 2, function(x) !any(is.na(x)))) else NULL
+  cols <- if(any(method == "knnImpute")) which(apply(x, 2, function(x) any(is.na(x)))) else NULL
 
   if(any(method == "bagImpute"))
     {


### PR DESCRIPTION
The preProcess.R has been modified. The original "cols" contains the columns that do not have missing values, which is not right for nn2() function for further imputation. 
