### PR TITLE
Example now preserves integrity of the data in when

### DIFF
--- a/pkg/caret/man/dummyVars.Rd
+++ b/pkg/caret/man/dummyVars.Rd
@@ -128,8 +128,11 @@ when <- data.frame(time = c("afternoon", "night", "afternoon",
                            "Wed", "Wed", "Fri",
                            "Sat", "Sat", "Fri"))
 
-levels(when$time) <- c("morning", "afternoon", "night")
-levels(when$day) <- c("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
+levels(when$time) <- list(morning="morning",
+                          afternoon="afternoon",
+                          night="night")
+levels(when$day) <- list(Mon="Mon", Tue="Tue", Wed="Wed", Thu="Thu",
+                         Fri="Fri", Sat="Sat", Sun="Sun")
 
 ## Default behavior:
 model.matrix(~day, when)


### PR DESCRIPTION
In caret 6.0-41, when running example(dummyVars), both steps that make use of the levels() function result in modifying the original data.

Before assigning levels, we have:
> when
       time day
1 afternoon Mon
2     night Mon
3 afternoon Mon
4   morning Wed
5   morning Wed
6   morning Fri
7   morning Sat
8 afternoon Sat
9 afternoon Fri


In the 6.0-41 release, setting levels changes the values like so:
> when
       time day
1   morning Tue
2     night Tue
3   morning Tue
4 afternoon Thu
5 afternoon Thu
6 afternoon Mon
7 afternoon Wed
8   morning Wed
9   morning Mon


The fix is to use named lists, rather than vectors, to set the levels as desired.