### PR TITLE
Added coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,15 @@ install:
   - ./travis-tool.sh aptget_install texlive-fonts-recommended
   - ./travis-tool.sh aptget_install texlive-fonts-extra
   - ./travis-tool.sh aptget_install texlive-science
+  - ./travis-tool.sh github_package jimhester/covr
 
 script: ./travis-tool.sh run_tests
 
 on_failure:
   - ./travis-tool.sh dump_logs
+
+after_success:
+  - Rscript -e 'library(covr);coveralls()'
 
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/topepo/caret.png?topepo=master)](https://travis-ci.org/topepo/caret)
+[![Coverage Status](https://coveralls.io/repos/topepo/caret/badge.svg)](https://coveralls.io/r/topepo/caret)
 
 # Classification and Regression Training
 


### PR DESCRIPTION
Coveralls.io looks at your test coverage for test_that() tests and
tells you what % of your code is covered by tests.

It’s cool, but not 100% necessary.  It works with travis.