### PR TITLE
Call the generic function instead of the method

### DIFF
--- a/pkg/caret/R/aaa.R
+++ b/pkg/caret/R/aaa.R
@@ -220,7 +220,7 @@ twoClassSummary <- function (data, lev = NULL, model = NULL)
   requireNamespaceQuietStop('pROC')
   if (!all(levels(data[, "pred"]) == levels(data[, "obs"]))) 
     stop("levels of observed and predicted data do not match")
-  rocObject <- try(pROC::roc.default(data$obs, data[, lev[1]]), silent = TRUE)
+  rocObject <- try(pROC::roc(data$obs, data[, lev[1]]), silent = TRUE)
   rocAUC <- if(class(rocObject)[1] == "try-error") NA else rocObject$auc
   out <- c(rocAUC,
            sensitivity(data[, "pred"], data[, "obs"], lev[1]),


### PR DESCRIPTION
The upcoming pROC version 1.8 has a refactored NAMESPACE and won't allow direct calls to S3 methods. Instead, the generic function must be called. This fix is necessary to push fix xrobin/pROC#4 to CRAN.

Thanks!