### PR TITLE
Fix incorrect sampling in bagged avNNet.

### DIFF
--- a/pkg/caret/R/avNNet.R
+++ b/pkg/caret/R/avNNet.R
@@ -73,7 +73,7 @@ avNNet.default <- function(x, y, repeats = 5, bag = FALSE, allowParallel = TRUE,
         {
           if(theDots$trace) cat("\nFitting Repeat", i, "\n\n")
         } else cat("Fitting Repeat", i, "\n\n")
-      if(bag)  ind <- sample(1:nrow(x))
+      if(bag)  ind <- sample(1:nrow(x), replace = TRUE)
       thisMod <- if(is.null(classLev)) nnet::nnet(x[ind,,drop = FALSE], y[ind], ...) else nnet::nnet(x[ind,,drop = FALSE], y[ind,], ...)
       thisMod$lev <- classLev
       thisMod


### PR DESCRIPTION
avNNet with bag = TRUE currently samples without replacement. This therefore just reorders the rows.
avNNet now samples WITH replacement therefore giving proper bagging.

I don't think the same error occurs in other models but I'm not sure.