### PR TITLE
Fix typo in docs' training page

### DIFF
--- a/html/training.Rhtml
+++ b/html/training.Rhtml
@@ -157,7 +157,7 @@ the process produces a profile of performance measures is available to
 guide the user as to which tuning parameter values should be
 chosen. By default, the function automatically chooses the tuning
 parameters associated with the best value, although different
-algorithms can be used (see details below below). 
+algorithms can be used (see details below). 
 </p>
 
 <div id="example"></div> 


### PR DESCRIPTION
Fixes a small typo in the training page where "below" is repeated twice.

Thanks for your amazing work on the package and the docs. They've been immensely helpful.