### PR TITLE
added unit test for lfda model

### DIFF
--- a/pkg/caret/tests/testthat/test_models_lfda.R
+++ b/pkg/caret/tests/testthat/test_models_lfda.R
@@ -7,6 +7,12 @@ test_that('test lfda model training and prediction', {
   te_dat <- twoClassSim(200)
   
   lfda.model <- lfda(x=tr_dat[,-16],y=tr_dat[,16],r=3)
+  
+  transform.metric <- lfda.model$T
+  transformed.train <- lfda.model$Z
+
+  transformed.test <- predict(lfda.model, newdata=te_dat[,-16])
+
 })
 
 

--- a/pkg/caret/tests/testthat/test_models_lfda.R
+++ b/pkg/caret/tests/testthat/test_models_lfda.R
@@ -1,4 +1,5 @@
 library(caret)
+library(testthat)
 
 test_that('test lfda model training and prediction', {
   skip_on_cran()
@@ -12,7 +13,12 @@ test_that('test lfda model training and prediction', {
   transformed.train <- lfda.model$Z
 
   transformed.test <- predict(lfda.model, newdata=te_dat[,-16])
-
+  
+  # check dimensions
+  expect_that(dim(transformed.train)[2], equals(3))
+  expect_that(dim(transformed.test), equals(dim(transformed.train)))
+  expect_that(dim(transform.metric)[2], equals(dim(transformed.train)[2]))
+  expect_that(dim(tr_dat)[1], equals(dim(transformed.train)[1]))
 })
 
 

--- a/pkg/caret/tests/testthat/test_models_lfda.R
+++ b/pkg/caret/tests/testthat/test_models_lfda.R
@@ -1,0 +1,12 @@
+library(caret)
+
+test_that('test lfda model training and prediction', {
+  skip_on_cran()
+  set.seed(1)
+  tr_dat <- twoClassSim(200)
+  te_dat <- twoClassSim(200)
+  
+  lfda.model <- lfda(x=tr_dat[,-16],y=tr_dat[,16],r=3)
+})
+
+


### PR DESCRIPTION
I added the tests for lfda model. The following gives error:
```
> train(Class~., data=tr_dat, method="lfda")
Error in train.default(x, y, weights = w, ...) : 
  Model lfda is not in caret's built-in library
```
I am able to run `lfda()` or `lfda.default()` successfully but not through `train()` as seen above. Do you know how to include the model to the built-in library? 

Thanks,
Yuan