### PR TITLE
fixed travis build file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ before_install:
   - echo 'R_LIBS=/usr/lib/R/library:/usr/lib/R/site-library/' > ~/.Renviron
   - sudo chmod 2777 /usr/lib/R/library
   - ./travis-tool.sh bootstrap
-  - ./travis-tool.sh r_binary_install covr
   - ./travis-tool.sh r_binary_install car
   - ./travis-tool.sh r_binary_install reshape2
   - ./travis-tool.sh r_binary_install foreach
@@ -59,6 +58,7 @@ before_install:
   - ./travis-tool.sh r_binary_install ggplot2
   - ./travis-tool.sh r_binary_install reshape2
   - ./travis-tool.sh r_binary_install data.table
+  - ./travis-tool.sh install_github jimhester/covr
 
 install:
   - ./travis-tool.sh install_deps 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,70 +1,74 @@
-# Sample .travis.yml for R projects from https://github.com/craigcitro/r-travis
-# http://docs.travis-ci.com/user/languages/r/
+# .travis.yml
+#
+# See README.md for instructions, or for more configuration options,
+# see the wiki:
+#   https://github.com/craigcitro/r-travis/wiki
 
-language: r
+language: c
 sudo: required
-warnings_are_errors: true
-r_build_args: "--no-build-vignettes --no-manual"
-r_check_args: "--no-build-vignettes --no-manual --as-cran"
 
 env:
-   global:
-     - CRAN: "http://cran.rstudio.com"
-   matrix:
-     - NOT_CRAN="true"
-     - NOT_CRAN="false"
-
-before_script:
+  global:
+    - R_CHECK_ARGS="--no-build-vignettes --no-manual --as-cran"
+    - R_BUILD_ARGS="--no-build-vignettes --no-manual"
+  matrix:
+    - NOT_CRAN="true"
+    - NOT_CRAN="false"
+  
+before_install:
   - cd pkg/caret
+  - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
+  - chmod 755 ./travis-tool.sh
+  - sudo mkdir -p /usr/lib/R/library
+  - echo 'R_LIBS=/usr/lib/R/library:/usr/lib/R/site-library/' > ~/.Renviron
+  - sudo chmod 2777 /usr/lib/R/library
+  - ./travis-tool.sh bootstrap
+  - ./travis-tool.sh r_binary_install covr
+  - ./travis-tool.sh r_binary_install car
+  - ./travis-tool.sh r_binary_install reshape2
+  - ./travis-tool.sh r_binary_install foreach
+  - ./travis-tool.sh r_binary_install plyr
+  - ./travis-tool.sh r_binary_install nlme
+  - ./travis-tool.sh r_binary_install BradleyTerry2
+  - ./travis-tool.sh r_binary_install e1071
+  - ./travis-tool.sh r_binary_install earth
+  - ./travis-tool.sh r_binary_install fastICA
+  - ./travis-tool.sh r_binary_install gam
+  - ./travis-tool.sh r_binary_install ipred
+  - ./travis-tool.sh r_binary_install kernlab
+  - ./travis-tool.sh r_binary_install klaR
+  - ./travis-tool.sh r_binary_install MASS
+  - ./travis-tool.sh r_binary_install ellipse
+  - ./travis-tool.sh r_binary_install mda
+  - ./travis-tool.sh r_binary_install mgcv
+  - ./travis-tool.sh r_binary_install mlbench
+  - ./travis-tool.sh r_binary_install nnet
+  - ./travis-tool.sh r_binary_install party
+  - ./travis-tool.sh r_binary_install pls
+  - ./travis-tool.sh r_binary_install pROC
+  - ./travis-tool.sh r_binary_install proxy
+  - ./travis-tool.sh r_binary_install randomForest
+  - ./travis-tool.sh r_binary_install RANN
+  - ./travis-tool.sh r_binary_install spls
+  - ./travis-tool.sh r_binary_install subselect
+  - ./travis-tool.sh r_binary_install pamr
+  - ./travis-tool.sh r_binary_install superpc
+  - ./travis-tool.sh r_binary_install Cubist
+  - ./travis-tool.sh r_binary_install testthat
+  - ./travis-tool.sh r_binary_install rARPACK
+  - ./travis-tool.sh r_binary_install ggplot2
+  - ./travis-tool.sh r_binary_install reshape2
+  - ./travis-tool.sh r_binary_install data.table
 
-r_packages:
-  - ROSE
-  - DMwR
+install:
+  - ./travis-tool.sh install_deps 
+  - ./travis-tool.sh install_r ROSE DMwR
 
-r_binary_packages:
-  - car
-  - reshape2
-  - foreach
-  - plyr
-  - nlme
-  - BradleyTerry2
-  - e1071
-  - earth
-  - fastICA
-  - gam
-  - ipred
-  - kernlab
-  - klaR
-  - MASS
-  - ellipse
-  - mda
-  - mgcv
-  - mlbench
-  - nnet
-  - party
-  - pls
-  - pROC
-  - proxy
-  - randomForest
-  - RANN
-  - spls
-  - subselect
-  - pamr
-  - superpc
-  - Cubist
-  - testthat
-  - rARPACK
-  - ggplot2
-  - reshape2
-  - data.table
-  - caret
-
-r_github_packages:
-  - hadley/devtools
-  - jimhester/covr
+script: 
+  - ./travis-tool.sh run_tests
 
 after_success:
   - Rscript -e 'library(covr);coveralls()'
 
 after_failure:
-  - Rscript -e 'devtools::load_all(); devtools::test()'
+  - ./travis-tool.sh dump_logs


### PR DESCRIPTION
I fixed the travis build file after seeing your question [here](http://stackoverflow.com/questions/31879011/r-cant-find-packages-installed-by-travis). `R CMD check --as-cran` is looking for packages (that are not explicitly stated as dependency) in `/usr/lib/R/library`. I then use the "old school" travis setup to install dependencies in `/usr/lib/R/library` so they can be found. I'm also installing a bunch of dependent packages as binaries to make the build faster. 