### PR TITLE
call make.names on obsLevels to properly handle spaces in factors

### DIFF
--- a/pkg/caret/R/predict.train.R
+++ b/pkg/caret/R/predict.train.R
@@ -53,7 +53,7 @@ predict.train <- function(object, newdata = NULL, type = "raw", na.action = na.o
                        unkOnly = TRUE,
                        ...)
     obsLevels <- levels(object)
-    out <- out[, obsLevels, drop = FALSE]
+    out <- out[, make.names(obsLevels), drop = FALSE]
   } else {
     out <- extractPrediction(list(object),
                              unkX = newdata,


### PR DESCRIPTION
If the response is a factor which has levels which contain spaces, the
out object from extractProb() will have called make.names() to change
the column names to have periods instead of spaces.

This results in

Error in `[.data.frame`(out, , obsLevels, drop = FALSE) :
  undefined columns selected

when predict is called on an object.

An eventual real fix is to set check.names=FALSE in the right bit of
extractProb() which is having this effect.