### PR TITLE
Confusion matrix normalization

### DIFF
--- a/pkg/caret/R/confusionMatrix.R
+++ b/pkg/caret/R/confusionMatrix.R
@@ -194,19 +194,16 @@ confusionMatrix.train <- function(data, norm = "overall", dnn = c("Prediction", 
   ## get only best tune
   names(data$bestTune) <- gsub("^\\.", "", names(data$bestTune))
   resampledCM <- merge(data$bestTune, data$resampledCM)
-  counts <- as.matrix(resampledCM[,grep("^cell", colnames(resampledCM))])
+  counts <- as.matrix(resampledCM[, grep("^cell", colnames(resampledCM))])
   
   ## normalize?
-  if(norm == "none") 
+  if(norm == "none") {
     counts <- matrix(apply(counts, 2, sum), nrow = length(lev))
-  else 
-    counts <- matrix(apply(counts, 2, mean), nrow = length(lev))
+    #if(data$control$method == "repeatedcv") counts <- counts / data$control$repeats
+    #if(grepl("boot", data$control$method)) counts <- counts / data$control$number
+  } else counts <- matrix(apply(counts, 2, mean), nrow = length(lev))
   
-  if(data$control$method == "repeatedcv" && norm == "none")
-    counts <- counts / data$control$repeats
-  
-  if(norm == "overall")
-    counts <- counts / sum(counts) * 100
+  if(norm == "overall") counts <- counts / sum(counts) * 100
   
   ## names
   rownames(counts) <- colnames(counts) <- lev

--- a/pkg/caret/R/confusionMatrix.R
+++ b/pkg/caret/R/confusionMatrix.R
@@ -202,6 +202,9 @@ confusionMatrix.train <- function(data, norm = "overall", dnn = c("Prediction", 
   else 
     counts <- matrix(apply(counts, 2, mean), nrow = length(lev))
   
+  if(data$control$method == "repeatedcv" && norm == "none")
+    counts <- counts / data$control$repeats
+  
   if(norm == "overall")
     counts <- counts / sum(counts) * 100
   

--- a/pkg/caret/man/confusionMatrix.train.Rd
+++ b/pkg/caret/man/confusionMatrix.train.Rd
@@ -17,15 +17,15 @@ Using a \code{\link{train}}, \code{\link{rfe}}, \code{\link{sbf}} object, determ
 
 }
 \arguments{
-  \item{data}{an object of class \code{\link{train}}, \code{\link{rfe}}, \code{\link{sbf}} that did not use out-of-bag resampling or leave-one-out cross-validation.}
-  \item{norm}{a character string indicating how the table entries should be normalized. Valid values are "none", "overall" or "average". }
-  \item{dnn}{a character vector of dimnames for the table}
+  \item{data}{An object of class \code{\link{train}}, \code{\link{rfe}}, \code{\link{sbf}} that did not use out-of-bag resampling or leave-one-out cross-validation.}
+  \item{norm}{A character string indicating how the table entries should be normalized. Valid values are "none", "overall" or "average". }
+  \item{dnn}{A character vector of dimnames for the table}
   \item{\dots}{not used here}
 }
 \details{
 When \code{\link{train}} is used for tuning a model, it tracks the confusion matrix cell entries for the hold-out samples. These can be aggregated and used for diagnostic purposes. For \code{\link{train}}, the matrix is estimated for the final model tuning parameters determined by \code{\link{train}}. For \code{\link{rfe}}, the matrix is associated with the optimal number of variables.
 
-There are several ways to show the table entries. Using \code{norm = "none"} will show the frequencies of samples on each of the cells (across all resamples). \code{norm = "overall"} first divides the cell entries by the total number of data points in the table, then averages these percentages. \code{norm = "average"} takes the raw, aggregate cell counts across resamples and divides by the number of resamples (i.e. to yield an average count for each cell). 
+There are several ways to show the table entries. Using \code{norm = "none"} will show the aggregated counts of samples on each of the cells (across all resamples). For \code{norm = "average"}, the average number of cell counts across resamples is computed (this can help evaluate how many holdout samples there were on average). The default is \code{norm = "overall"}, which is equivalento to \code{"average"} but in percentages.
 }
 \value{
 a list of class \code{confusionMatrix.train}, \code{confusionMatrix.rfe} or \code{confusionMatrix.sbf} with elements

--- a/pkg/caret/man/trainControl.Rd
+++ b/pkg/caret/man/trainControl.Rd
@@ -77,11 +77,15 @@ Using adaptive resampling when \code{method} is either \code{"adaptive_cv"}, \co
 }
 
 The option \code{search = "grid"} uses the default grid search routine. When \code{search = "random"}, a random search procedure is used (Bergstra and Bengio, 2012). See \url{http://topepo.github.io/caret/random.html} for details and an example.
+
+The \code{"boot632"} method uses the 0.632 estimator presented in Efron (1983), not to be confused with the 0.632+ estimator proposed later by the same author.
 }
 
 \author{Max Kuhn}
 
 \references{
+Efron (1983). ``Estimating the error rate of a prediction rule: improvement on cross-validation''. Journal of the American Statistical Association, 78(382):316-331
+
 Bergstra and Bengio (2012), ``Random Search for Hyper-Parameter Optimization'', Journal of Machine Learning Research, 13(Feb):281-305
 
 Kuhn (2014), ``Futility Analysis in the Cross-Validation of Machine Learning Models'' \url{http://arxiv.org/abs/1405.6974},


### PR DESCRIPTION
I have been using the `caret` package for my thesis, which is why I'm messing with the code and reporting the issues I find, I hope that's ok. This time I was looking at the `confusionMatrix` function for `train` objects. I did a few tests *before* I changed anything.

Let's take a simple example, there are 150 observations in the `iris` dataset, so using 5-fold CV would result in training sets with 30 observations each

``` r
data(iris)
TrainData <- iris[,1:4]
TrainClasses <- iris[,5]

knnFit1 <- train(TrainData, TrainClasses,
                 method = "knn",
                 preProcess = c("center", "scale"),
                 tuneLength = 10,
                 trControl = trainControl(method = "cv", number = 5))

cell_cols <- grep("^cell", colnames(knnFit1$resampledCM))
data_per_fold <- apply(knnFit1$resampledCM[ , cell_cols], 1, sum)
all(data_per_fold == 30)
```

    ## [1] TRUE

Now let's calculate the available confusion matrices

``` r
CM.none <- confusionMatrix(knnFit1, norm = "none")
CM.avg <- confusionMatrix(knnFit1, norm = "average")
CM.ovr <- confusionMatrix(knnFit1, norm = "overall")
```

I understand `none` and `overall`, although I don't agree entirely with the description in the documentation. To me, `none` actually shows the average counts for each cell across resamples (what supposedly `average` does):

``` r
CM.none$table
```

    ##             Reference
    ## Prediction   setosa versicolor virginica
    ##   setosa       10.0        0.0       0.0
    ##   versicolor    0.0        9.6       0.8
    ##   virginica     0.0        0.4       9.2

``` r
sum(CM.none$table)
```

    ## [1] 30

And the `overall` one is just the same table but in percentages:

``` r
CM.ovr$table
```

    ##             Reference
    ## Prediction      setosa versicolor virginica
    ##   setosa     33.333333   0.000000  0.000000
    ##   versicolor  0.000000  32.000000  2.666667
    ##   virginica   0.000000   1.333333 30.666667

``` r
all.equal(CM.none$table / sum(CM.none$table) * 100,
          CM.ovr$table)
```

    ## [1] TRUE

But I simply don't understand what `average` does.

``` r
CM.avg$table
```

    ##             Reference
    ## Prediction   setosa versicolor virginica
    ##   setosa        200          0         0
    ##   versicolor      0        192        16
    ##   virginica       0          8       184

This is why I'm proposing these changes...

------

With the changes

-   `none` calculates aggregated un-normalized counts
-   `average` calculates average counts across resamples
-   `overall` calculates percentual average counts (stays the same)

``` r
confusionMatrix(knnFit1, norm = "none")
```

    ## Cross-Validated (5 fold) Confusion Matrix 
    ## 
    ## (entries are un-normalized aggregated counts)
    ##  
    ##             Reference
    ## Prediction   setosa versicolor virginica
    ##   setosa         50          0         0
    ##   versicolor      0         47         3
    ##   virginica       0          3        47

``` r
confusionMatrix(knnFit1, norm = "average")
```

    ## Cross-Validated (5 fold) Confusion Matrix 
    ## 
    ## (entries are average cell counts across resamples)
    ##  
    ##             Reference
    ## Prediction   setosa versicolor virginica
    ##   setosa       10.0        0.0       0.0
    ##   versicolor    0.0        9.4       0.6
    ##   virginica     0.0        0.6       9.4

``` r
confusionMatrix(knnFit1, norm = "overall")
```

    ## Cross-Validated (5 fold) Confusion Matrix 
    ## 
    ## (entries are percentual average cell counts across resamples)
    ##  
    ##             Reference
    ## Prediction   setosa versicolor virginica
    ##   setosa       33.3        0.0       0.0
    ##   versicolor    0.0       31.3       2.0
    ##   virginica     0.0        2.0      31.3

Let me know your thoughts. 

I don't know if this makes sense for `rfe` and `sbf`, but if it does, I could adapt the code so that those functions include the changes.
