### PR TITLE
Restrict generation of confusion matrix for resamples when number of classes is large

### DIFF
--- a/pkg/caret/R/workflows.R
+++ b/pkg/caret/R/workflows.R
@@ -274,7 +274,7 @@ nominalTrainWorkflow <- function(x, y, wts, info, method, ppOpts, ctrl, lev, tes
                            model = method)
     if(testing) print(head(thisResample))
     ## for classification, add the cell counts
-    if(length(lev) > 1)
+    if(length(lev) > 1 && length(lev) <= 50)
     {
       cells <- lapply(predicted,
                       function(x) flatTable(x$pred, x$obs))
@@ -311,7 +311,7 @@ nominalTrainWorkflow <- function(x, y, wts, info, method, ppOpts, ctrl, lev, tes
                                          model = method)
     
     ## if classification, get the confusion matrix
-    if(length(lev) > 1) thisResample <- c(thisResample, flatTable(tmp$pred, tmp$obs))
+    if(length(lev) > 1 && length(lev) <= 50) thisResample <- c(thisResample, flatTable(tmp$pred, tmp$obs))
     thisResample <- as.data.frame(t(thisResample))
     thisResample <- cbind(thisResample, info$loop[parm,,drop = FALSE])
     


### PR DESCRIPTION
Hi Max. 

When running caret on classification problems with huge number of classes (1000), we had terrible performance in the final aggregation of the resamples results. 

It turned out, that in nominalTrainWorkflow there is a complete confusion matrix added to thisResample, which results in a quadratic number of cells. 

The final problem then occurs some lines later (after the end of the foreach scope) : the rbind.fill has catastrophic runtime on these huge tables. For a problem with 1000 classes (and therefore a confusion matrix with 1mio elements), we stopped the rbind.fill after 12hours....

I have attached a small commit, which adds the confusion matrix only if length(lev) <= 50. Otherwise one could also add a parameter to train control() (with such a default).

Benedikt