### PR TITLE
Fix #365 nearZeroVar + foreach behaviour.

### DIFF
--- a/pkg/caret/R/nearZeroVar.R
+++ b/pkg/caret/R/nearZeroVar.R
@@ -15,8 +15,11 @@ nearZeroVar <- function (x, freqCut = 95/5, uniqueCut = 10, saveMetrics = FALSE,
     res$column <- NULL
   } else {
     res <- foreach(name = colnames(x), .combine=c) %op% {
-      nzv(x[[name]], freqCut = freqCut, uniqueCut = uniqueCut, saveMetrics = FALSE)
+      r <- nzv(x[[name]], freqCut = freqCut, uniqueCut = uniqueCut, saveMetrics = FALSE)
+      ## needed because either integer() or 1, r is never 0
+      if (length(r) > 0 && r == 1) TRUE else FALSE
     }
+    res <- which(res)
     if(names){
       res <- colnames(x)[res]
     }
@@ -26,7 +29,7 @@ nearZeroVar <- function (x, freqCut = 95/5, uniqueCut = 10, saveMetrics = FALSE,
 
 nzv <- function (x, freqCut = 95/5, uniqueCut = 10, saveMetrics = FALSE, names = FALSE)
 {
-  if (is.vector(x)) x <- matrix(x, ncol = 1)
+  if (is.null(dim(x))) x <- matrix(x, ncol = 1)
   freqRatio <- apply(x, 2, function(data)
   {
     t <- table(data[!is.na(data)])

--- a/pkg/caret/tests/testthat/test_nearZeroVar.R
+++ b/pkg/caret/tests/testthat/test_nearZeroVar.R
@@ -1,0 +1,23 @@
+context("Test nearZeroVar")
+
+test_that("nearZeroVar works properly with foreach", {
+  ## shouldn't trigger error
+  r <- nearZeroVar(iris, foreach = T)
+
+  ## should pick up x, y and z
+  bad.iris <- cbind(iris,
+                    x = rep(-1, nrow(iris)),
+                    y = rep(0, nrow(iris)),
+                    z = rep(1, nrow(iris)))
+  r1 <- nearZeroVar(bad.iris)
+  r2 <- nearZeroVar(bad.iris, foreach = T)
+  expect_equal(r1, r2)
+
+  r1 <- nearZeroVar(bad.iris, names = T)
+  r2 <- nearZeroVar(bad.iris, names = T, foreach = T)
+  expect_equal(r1, r2)
+
+  r1 <- nearZeroVar(bad.iris, saveMetrics = T)
+  r2 <- nearZeroVar(bad.iris, saveMetrics = T, foreach = T)
+  expect_equal(r1, r2)
+})


### PR DESCRIPTION
In `nzv`, Instead of checking dimensionality using `is.vector`, check
for `NULL` result from `dim`.

Additionally, check the result of nzv for its length since `1` will be
returned if the vector has near zero variance, and an empty integer
vector will be returned otherwise.