### PR TITLE
predict.train documentation fix for type="prob"

### DIFF
--- a/pkg/caret/man/extractPrediction.Rd
+++ b/pkg/caret/man/extractPrediction.Rd
@@ -53,7 +53,7 @@ The two extraction functions can be used to get the predictions and observed out
 }
 \value{
 
-  For \code{predict.train}, a vector of predictions if \code{type =  "raw"} or a data frame of class probabilities for \code{type =  "probs"}. In the latter case, there are columns for each class.
+  For \code{predict.train}, a vector of predictions if \code{type =  "raw"} or a data frame of class probabilities for \code{type =  "prob"}. In the latter case, there are columns for each class.
 
   For \code{predict.list}, a list results. Each element is produced by \code{predict.train}.
 


### PR DESCRIPTION
Documentation for predict.train() references type="probs" but the actual argument should be type="prob", per the rest of the documentation file.