### PR TITLE
Update lm.R

### DIFF
--- a/models/files/lm.R
+++ b/models/files/lm.R
@@ -6,7 +6,7 @@ modelInfo <- list(label = "Linear Regression",
                                           class = "logical",
                                           label = "intercept"),
                   grid = function(x, y, len = NULL, search = "grid") 
-                    data.frame(intercept = c(TRUE, FALSE)),
+                    data.frame(intercept = TRUE),
                   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
                     dat <- if(is.data.frame(x)) x else as.data.frame(x)
                     dat$.outcome <- y

--- a/models/files/lm.R
+++ b/models/files/lm.R
@@ -2,23 +2,33 @@ modelInfo <- list(label = "Linear Regression",
                   library = NULL,
                   loop = NULL,
                   type = "Regression",
-                  parameters = data.frame(parameter = "parameter",
-                                          class = "character",
-                                          label = "parameter"),
-                  grid = function(x, y, len = NULL, search = "grid") data.frame(parameter = "none"),
+                  parameters = data.frame(parameter = "intercept",
+                                          class = "logical",
+                                          label = "intercept"),
+                  grid = function(x, y, len = NULL, search = "grid") 
+                    data.frame(intercept = c(TRUE, FALSE)),
                   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
                     dat <- if(is.data.frame(x)) x else as.data.frame(x)
                     dat$.outcome <- y
                     if(!is.null(wts))
                     {
-                      out <- lm(.outcome ~ ., data = dat, weights = wts, ...)
-                    } else out <- lm(.outcome ~ ., data = dat, ...)
+                      if (param$intercept)
+                        out <- lm(.outcome ~ ., data = dat, weights = wts, ...)
+                      else
+                        out <- lm(.outcome ~ 0 + ., data = dat, weights = wts, ...)
+                    } else 
+                    {
+                      if (param$intercept)
+                        out <- lm(.outcome ~ ., data = dat, ...)
+                      else
+                        out <- lm(.outcome ~ 0 + ., data = dat, ...)
+                    }
                     out
                   },
                   predict = function(modelFit, newdata, submodels = NULL) {
                     if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata)
                     predict(modelFit, newdata)
-                    },
+                  },
                   prob = NULL,
                   predictors = function(x, ...) predictors(x$terms),
                   tags = c("Linear Regression", "Accepts Case Weights"),


### PR DESCRIPTION
Add ability to build model without intercept. Previous version always used intercept and there was no any way to build the model without it.

The documentation of `LM` says (see details):
>A formula has an implied intercept term. To remove this use either y ~ x - 1 or y ~ 0 + x. 

New parameter `intercept` is logical (TRUE/FALSE) 
TRUE - model with intercept (as the original version)
FALSE - model without intercept (was not possible to do it in caret)
