### PR TITLE
Add RWeka Tuning Parameters

### DIFF
--- a/models/files/J48.R
+++ b/models/files/J48.R
@@ -8,8 +8,8 @@ modelInfo <- list(label = "C4.5-like Trees",
                   grid = function(x, y, len = NULL, search = "grid"){
                     upperBound <- min(max(1, floor(nrow(x) / 2)), 50)
                     if(search == "grid"){
-                      out <- expand.grid(C = seq(0.01, 0.5, length.out = len / 2),
-                                         M = 1:upperBound)
+                      out <- expand.grid(C = seq(0.01, 0.5, length.out = len),
+                                         M = 1:min(upperBound, len))
                       if(len == 1){
                         out <- data.frame(C = 0.25, M = 2)
                       }
@@ -17,7 +17,6 @@ modelInfo <- list(label = "C4.5-like Trees",
                       out <- data.frame(C = runif(len , 0.0, 0.5),
                                         M = round(exp(runif(len, 0, log(upperBound)))))
                     }
-                    out <- out[1:len, ]
                     return(out)
                   } ,
                   fit = function(x, y, wts, param, lev, last, classProbs, ...) {

--- a/models/files/J48.R
+++ b/models/files/J48.R
@@ -2,10 +2,21 @@ modelInfo <- list(label = "C4.5-like Trees",
                   library = "RWeka",
                   loop = NULL,
                   type = c("Classification"),
-                  parameters = data.frame(parameter = "C",
-                                          class = "numeric",
-                                          label = "Confidence Threshold"),
-                  grid = function(x, y, len = NULL, search = "grid") data.frame(C = 0.25),
+                  parameters = data.frame(parameter = c("C", "M"),
+                                          class = c("numeric", "numeric"),
+                                          label = c("Confidence Threshold", "Minimum Instances Per Leaf")),
+                  grid = function(x, y, len = NULL, search = "grid"){
+                    upperBound <- min(max(1, floor(nrow(x) / 2)), 50)
+                    if(search == "grid"){
+                      out <- expand.grid(C = seq(0.01, 0.5, length.out = len / 2),
+                                         M = 1:upperBound)
+                    } else {
+                      out <- data.frame(C = runif(len , 0.0, 0.5),
+                                        M = round(exp(runif(len, 0, log(upperBound)))))
+                    }
+                    out <- out[1:len, ]
+                    return(out)
+                  } ,
                   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
                     dat <- if(is.data.frame(x)) x else as.data.frame(x)
                     dat$.outcome <- y
@@ -13,9 +24,10 @@ modelInfo <- list(label = "C4.5-like Trees",
                     
                     if(any(names(theDots) == "control")) {
                       theDots$control$C <- param$C 
+                      theDots$control$M <- param$M
                       ctl <- theDots$control
                       theDots$control <- NULL
-                    } else ctl <- Weka_control(C = param$C) 
+                    } else ctl <- Weka_control(C = param$C, M = param$M) 
                     
                     modelArgs <- c(list(formula = as.formula(".outcome ~ ."),
                                         data = dat,

--- a/models/files/J48.R
+++ b/models/files/J48.R
@@ -10,6 +10,9 @@ modelInfo <- list(label = "C4.5-like Trees",
                     if(search == "grid"){
                       out <- expand.grid(C = seq(0.01, 0.5, length.out = len / 2),
                                          M = 1:upperBound)
+                      if(len == 1){
+                        out <- data.frame(C = 0.25, M = 2)
+                      }
                     } else {
                       out <- data.frame(C = runif(len , 0.0, 0.5),
                                         M = round(exp(runif(len, 0, log(upperBound)))))
@@ -48,4 +51,4 @@ modelInfo <- list(label = "C4.5-like Trees",
                   levels = function(x) x$obsLevels,
                   predictors = function(x, ...) predictors(x$terms),
                   tags = c("Tree-Based Model", "Implicit Feature Selection"),
-                  sort = function(x) x[order(x[,1]),])
+                  sort = function(x) x[order(x$C, x$M),])

--- a/models/files/JRip.R
+++ b/models/files/JRip.R
@@ -8,17 +8,18 @@ modelInfo <- list(label = "Rule-Based Classifier",
                   grid = function(x, y, len = NULL, search = "grid"){
                     upperBound <- min(max(1, floor(nrow(x) / 2)), 50)
                     if(search == "grid"){
-                      out <- expand.grid(NumOpt = 1:sqrt(upperBound), NumFolds = 2:4, MinWeights = 1:sqrt(upperBound))
+                      out <- expand.grid(NumOpt = 1:min(len, sqrt(upperBound)), NumFolds = 2:min(len + 1, upperBound), MinWeights = 1:min(len, sqrt(upperBound)))
                       if(len == 1){
                         out <- data.frame(NumOpt = 2, NumFolds = 3, MinWeights = 2)
                       }
                     } else {
-                      out <- data.frame(NumOpt = round(exp(runif(10 * len, 0, log(len)))),
-                                        NumFolds = round(exp(runif(10 * len, 0, log(upperBound)))),
-                                        MinWeights = round(exp(runif(10 * len, 0, log(upperBound)))))
+                      out <- data.frame(NumOpt = round(exp(runif(5 * len, 0, log(len)))),
+                                        NumFolds = round(exp(runif(5 * len, 0, log(upperBound)))),
+                                        MinWeights = round(exp(runif(5 * len, 0, log(upperBound)))))
                       out <- unique(out)
+                      out <- out[1:min(nrow(out), len), ]
                     }
-                    return(out[1:min(nrow(out), len), ])
+                    return(out)
                   } ,
                   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
                     dat <- if(is.data.frame(x)) x else as.data.frame(x)

--- a/models/files/JRip.R
+++ b/models/files/JRip.R
@@ -9,6 +9,9 @@ modelInfo <- list(label = "Rule-Based Classifier",
                     upperBound <- min(max(1, floor(nrow(x) / 2)), 50)
                     if(search == "grid"){
                       out <- expand.grid(NumOpt = 1:sqrt(upperBound), NumFolds = 2:4, MinWeights = 1:sqrt(upperBound))
+                      if(len == 1){
+                        out <- data.frame(NumOpt = 2, NumFolds = 3, MinWeights = 2)
+                      }
                     } else {
                       out <- data.frame(NumOpt = round(exp(runif(10 * len, 0, log(len)))),
                                         NumFolds = round(exp(runif(10 * len, 0, log(upperBound)))),
@@ -55,4 +58,4 @@ modelInfo <- list(label = "Rule-Based Classifier",
                     rownames(out) <- dat$varUsage$Var
                     out
                   },
-                  sort = function(x) x[order(x[,1], decreasing = TRUE),])
+                  sort = function(x) x[order(x$NumOpt, x$NumFolds, x$MinWeights, decreasing = TRUE),])

--- a/models/files/PART.R
+++ b/models/files/PART.R
@@ -7,14 +7,13 @@ modelInfo <- list(label = "Rule-Based Classifier",
                                           label = c("Confidence Threshold", 'Pruning')),
                   grid = function(x, y, len = NULL, search = "grid"){
                     if(search == "grid"){
-                      out <- expand.grid(threshold = seq(0.01, 0.5, length.out = len / 2), pruned = c("yes", "no"))
+                      out <- expand.grid(threshold = seq(0.01, 0.5, length.out = len), pruned = c("yes", "no"))
                       if(len == 1){
                         out <- data.frame(threshold = 0.25, pruned = "yes")
                       }
                     } else{
                       out <- data.frame(threshold = runif(len, 0.0, 0.5), pruned = sample(c("yes", "no"), len, replace = TRUE))
-                    }
-                    out <- out[1:len, ]
+                      }
                     return(out)
                   } 
                     ,

--- a/models/files/PART.R
+++ b/models/files/PART.R
@@ -5,8 +5,16 @@ modelInfo <- list(label = "Rule-Based Classifier",
                   parameters = data.frame(parameter = c('threshold', 'pruned'),
                                           class = c("numeric", "character"),
                                           label = "Confidence Threshold", 'Pruning'),
-                  grid = function(x, y, len = NULL, search = "grid") 
-                    data.frame(threshold = 0.25, pruned = "yes"),
+                  grid = function(x, y, len = NULL, search = "grid"){
+                    if(search == "grid"){
+                      out <- expand.grid(threshold = seq(0.01, 0.5, length.out = len / 2), pruned = c("yes", "no"))
+                    } else{
+                      out <- data.frame(threshold = runif(len, 0.0, 0.5), pruned = sample(c("yes", "no"), len, replace = TRUE))
+                    }
+                    out <- out[1:len, ]
+                    return(out)
+                  } 
+                    ,
                   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
                     dat <- if(is.data.frame(x)) x else as.data.frame(x)
                     dat$.outcome <- y
@@ -14,12 +22,12 @@ modelInfo <- list(label = "Rule-Based Classifier",
                     
                     if(any(names(theDots) == "control"))
                     {
-                      theDots$control$U <- ifelse(param$pruned == "No", TRUE, FALSE)
+                      theDots$control$U <- ifelse(tolower(param$pruned) == "no", TRUE, FALSE)
                       theDots$control$C <- param$threshold
                       ctl <- theDots$control
                       theDots$control <- NULL
                       
-                    } else ctl <- Weka_control(N = ifelse(param$pruned == "No", TRUE, FALSE),
+                    } else ctl <- Weka_control(U = ifelse(tolower(param$pruned) == "no", TRUE, FALSE),
                                                C = param$threshold) 
                     
                     modelArgs <- c(list(formula = as.formula(".outcome ~ ."),

--- a/models/files/PART.R
+++ b/models/files/PART.R
@@ -4,7 +4,7 @@ modelInfo <- list(label = "Rule-Based Classifier",
                   type = c("Classification"),
                   parameters = data.frame(parameter = c('threshold', 'pruned'),
                                           class = c("numeric", "character"),
-                                          label = "Confidence Threshold", 'Pruning'),
+                                          label = c("Confidence Threshold", 'Pruning')),
                   grid = function(x, y, len = NULL, search = "grid"){
                     if(search == "grid"){
                       out <- expand.grid(threshold = seq(0.01, 0.5, length.out = len / 2), pruned = c("yes", "no"))

--- a/models/files/PART.R
+++ b/models/files/PART.R
@@ -8,6 +8,9 @@ modelInfo <- list(label = "Rule-Based Classifier",
                   grid = function(x, y, len = NULL, search = "grid"){
                     if(search == "grid"){
                       out <- expand.grid(threshold = seq(0.01, 0.5, length.out = len / 2), pruned = c("yes", "no"))
+                      if(len == 1){
+                        out <- data.frame(threshold = 0.25, pruned = "yes")
+                      }
                     } else{
                       out <- data.frame(threshold = runif(len, 0.0, 0.5), pruned = sample(c("yes", "no"), len, replace = TRUE))
                     }


### PR DESCRIPTION
Adding the tuning parameters as discussed in issue #468 . Some notes:
- See issue #468 for the model performance results of before and after.
- Tuning grids for many models did not implement a random search previously. Random search is now implemented, and the grid search is also improved to test more than a single model.
- Tuning grids for PART and J48 only tested `C = 0.25` previously. We now sample in `C` in [0, 0.5].
- Sampling for many tuning parameters is set to a maximum `upperBound <- min(50, nrow(data) / 2) ` to prevent models failing to train; even for very large `nrow(data)`, performance when the tuning parameters were set to >50 was uniformly poor. Furthermore, testing showed that although this was the upper possible values for which the model would train, optimal models usually had much lower values, so sampling is done on the log scale instead of uniform `1:upperBound` to increase the probability of each model fit being in a good region for that tuning parameter.
- I ran `parseModels.R` for testing, but the updated `models.RData` object isn't included in this PR, so you'll have to run this on your end.
- The grid search construction for JRip is a little funny since we need to sample integer values on three tuning parameters. If you can think of a cleaner way to implement sampling on an integer grid here, go for it. Ultimately I decided to sample effectively on two of them and vary `NumFolds = 2:4` since that is usually a good range for `NumFolds`.
- "Collisions" for some of the random tuning grids generated on whole numbers--not a problem when we're sampling a continuous instead of a discrete numbers--are resolved by generating additional models, selecting `unique()` models, and limiting to the desired `len` with subsetting.