### PR TITLE
doRedis: could not find outcome_conversion function

### DIFF
--- a/pkg/caret/R/workflows.R
+++ b/pkg/caret/R/workflows.R
@@ -244,7 +244,7 @@ nominalTrainWorkflow <- function(x, y, wts, info, method, ppOpts, ctrl, lev, tes
         ## collate the predicitons across all the sub-models
         predicted <- lapply(predicted,
                             function(x, y, wts, lv, rows) {
-                              x <- outcome_conversion(x, lv = lev)
+                              x <- caret:::outcome_conversion(x, lv = lev)
                               out <- data.frame(pred = x, obs = y, stringsAsFactors = FALSE)
                               if(!is.null(wts)) out$weights <- wts
                               out$rowIndex <- rows


### PR DESCRIPTION
Using train with doRedis and multiple workers throws an error: could not find function outcome_conversion, even if .pkg is used to load caret. Fix is to call the function directly: caret::: outcome_conversion in the lapply function.
