### PR TITLE
Fix missing skip parameter and fix timeslice documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,14 @@ pkg/caret/DESCRIPTION~
 
 .Rproj.user
 
+*~
+
+*\#*\#
+
+*.\#*
+
+TAGS
+
 pkg/caret/inst/NEWS.Rd~
 
 pkg/caret/src/symbols.rds

--- a/pkg/caret/R/train.default.R
+++ b/pkg/caret/R/train.default.R
@@ -365,7 +365,8 @@ train.default <- function(x, y,
                               timeslice = createTimeSlices(seq(along = y),
                                                            initialWindow = trControl$initialWindow,
                                                            horizon = trControl$horizon,
-                                                           fixedWindow = trControl$fixedWindow)$train,
+                                                           fixedWindow = trControl$fixedWindow,
+                                                           skip = trControl$skip)$train,
                               subsemble = subsemble_index(y, V = trControl$number, J = trControl$repeats))
   } else {
     index_types <- unlist(lapply(trControl$index, is.integer))

--- a/pkg/caret/R/trainControl.R
+++ b/pkg/caret/R/trainControl.R
@@ -43,7 +43,7 @@
 #' repeated training/test splits), \code{"none"} (only fits one model to the
 #' entire training set), \code{"oob"} (only for random forest, bagged trees,
 #' bagged earth, bagged flexible discriminant analysis, or conditional tree
-#' forest models), \code{"adaptive_cv"}, \code{"adaptive_boot"} or
+#' forest models), \code{timeslice}, \code{"adaptive_cv"}, \code{"adaptive_boot"} or
 #' \code{"adaptive_LGOCV"}
 #' @param number Either the number of folds or number of resampling iterations
 #' @param repeats For repeated k-fold cross-validation only: the number of
@@ -62,7 +62,7 @@
 #' @param search Either \code{"grid"} or \code{"random"}, describing how the
 #' tuning parameter grid is determined. See details below.
 #' @param initialWindow,horizon,fixedWindow,skip possible arguments to
-#' \code{\link{createTimeSlices}}
+#' \code{\link{createTimeSlices}} when method is \code{timeslice}.
 #' @param classProbs a logical; should class probabilities be computed for
 #' classification models (along with predicted values) in each resample?
 #' @param summaryFunction a function to compute performance metrics across

--- a/pkg/caret/man/trainControl.Rd
+++ b/pkg/caret/man/trainControl.Rd
@@ -23,7 +23,7 @@ trainControl(method = "boot", number = ifelse(grepl("cv", method), 10, 25),
 repeated training/test splits), \code{"none"} (only fits one model to the
 entire training set), \code{"oob"} (only for random forest, bagged trees,
 bagged earth, bagged flexible discriminant analysis, or conditional tree
-forest models), \code{"adaptive_cv"}, \code{"adaptive_boot"} or
+forest models), \code{timeslice}, \code{"adaptive_cv"}, \code{"adaptive_boot"} or
 \code{"adaptive_LGOCV"}}
 
 \item{number}{Either the number of folds or number of resampling iterations}
@@ -37,7 +37,7 @@ complete sets of folds to compute}
 tuning parameter grid is determined. See details below.}
 
 \item{initialWindow, horizon, fixedWindow, skip}{possible arguments to
-\code{\link{createTimeSlices}}}
+\code{\link{createTimeSlices}} when method is \code{timeslice}.}
 
 \item{verboseIter}{A logical for printing a training log.}
 


### PR DESCRIPTION
a3a9963 didn't add `skip` to the `train`. Fix that. Also document `timeslice` method in `trainControl` and add a bunch of extra regexps to .gitignore.