### PR TITLE
Optimize createTimeSlices and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ RegressionTests/.RData
 
 caret.Rproj
 
+auto/
+
 release_process/talk/caret.vrb
 
 release_process/talk/caret.nav

--- a/pkg/caret/R/train.default.R
+++ b/pkg/caret/R/train.default.R
@@ -406,7 +406,8 @@ train.default <- function(x, y,
       trControl$indexOut <- createTimeSlices(seq(along = y),
                                              initialWindow = trControl$initialWindow,
                                              horizon = trControl$horizon,
-                                             fixedWindow = trControl$fixedWindow)$test
+                                             fixedWindow = trControl$fixedWindow,
+                                             skip = trControl$skip)$test
     }
   }
 

--- a/pkg/caret/man/createDataPartition.Rd
+++ b/pkg/caret/man/createDataPartition.Rd
@@ -34,30 +34,29 @@ matrix with the number of rows equal to \code{floor(p * length(y))} and
 \item{k}{an integer for the number of folds.}
 
 \item{returnTrain}{a logical. When true, the values returned are the sample
-positions corresponding to the data used during training. This argument only
-works in conjunction with \code{list = TRUE}}
+positions corresponding to the data used during training. This argument
+only works in conjunction with \code{list = TRUE}}
 
 \item{initialWindow}{The initial number of consecutive values in each
 training set sample}
 
-\item{horizon}{The number of consecutive values in test set sample}
+\item{horizon}{the number of consecutive values in test set sample}
 
-\item{fixedWindow}{A logical: if \code{FALSE}, the training set always start
-at the first sample.}
+\item{fixedWindow}{logical, if \code{FALSE}, all training samples start at 1}
 
-\item{skip}{An integer specifying how many (if any) resamples to skip to
-thin the total amount.}
+\item{skip}{integer, how many (if any) resamples to skip to thin the total
+amount}
 }
 \value{
 A list or matrix of row position integers corresponding to the
-training data
+  training data. For \code{createTimeSlices} subsamples are named by the end
+  index of each training subsample.
 }
 \description{
 A series of test/training partitions are created using
 \code{createDataPartition} while \code{createResample} creates one or more
 bootstrap samples. \code{createFolds} splits the data into \code{k} groups
-while \code{createTimeSlices} creates cross-validation sample information to
-be used with time series data.
+while \code{createTimeSlices} creates cross-validation split for series data.
 }
 \details{
 For bootstrap samples, simple random sampling is used.

--- a/pkg/caret/tests/testthat/test_data_spliting.R
+++ b/pkg/caret/tests/testthat/test_data_spliting.R
@@ -1,0 +1,21 @@
+context("Data Spliting")
+
+test_that("createTimeSlices works as expected", {
+    
+    s1 <- createTimeSlices(1:8, 5, horizon = 1)
+    s2 <- createTimeSlices(1:8, 5, horizon = 1, skip = 3)
+    s3 <- createTimeSlices(1:10, 5, horizon = 1, fixedWindow = FALSE, skip = 3)
+    s4 <- createTimeSlices(1:10, 5, horizon = 2, skip = 2)
+
+    expect_equal(s1, list(train = list(Training5 = 1:5, Training6 = 2:6, Training7 = 3:7),
+                          test = list(Testing5 = 6L, Testing6 = 7L, Testing7 = 8L)))
+
+    expect_equal(s2, list(train = structure(list(Training5 = 1:5)), 
+                          test = structure(list(Testing5 = 6L))))
+
+    expect_equal(s3, list(train = list(Training5 = 1:5, Training9 = 1:9),
+                          test = list(Testing5 = 6L, Testing9 = 10L)))
+
+    expect_equal(s4, list(train = list(Training5 = 1:5, Training8 = 4:8),
+                          test = list(Testing5 = 6:7, Testing8 = 9:10)))
+})


### PR DESCRIPTION
Current implementation of createTimeSlices is rather unfortunate. It creates full slicing with increment 1, and only after subsets with `skip=n`. Even on moderate data sets of 100k and `skip=1000` this blows the memory to 10GB while the final object is about 5MB. Fix this and add tests. 

The new algorithm generates exactly same slices as before. The only difference is the naming. Now subsamples are named with the end index of the train subsample (which is also the starting - 1 index of the test subsample). These are meaningful and always distinct. Previous naming wasn't particularly meaningful.      