### PR TITLE
Fix `tuneGrid` problems with method = 'none'

### DIFF
--- a/pkg/caret/tests/testthat/test_minimal.R
+++ b/pkg/caret/tests/testthat/test_minimal.R
@@ -4,3 +4,27 @@ expect_equal(stats[['Sensitivity']], 1)
 expect_equal(stats[['Specificity']], 1)
 expect_equal(stats[['Pos Pred Value']], 1)
 expect_equal(stats[['Neg Pred Value']], 1)
+
+test_that("resampling method 'none' doesn't conflict with default tuneLength", {
+    
+    data(BloodBrain)
+    
+    expect_error(train(bbbDescr, logBBB,
+                       method = "earth",
+                       trControl = trainControl(method = "none")),
+                 NA)
+
+    expect_error(train(bbbDescr, logBBB,
+                       method = "earth",
+                       tuneLength = 1, 
+                       trControl = trainControl(method = "none")),
+                 NA)
+
+    expect_error(train(mpg ~ cyl + disp, data = mtcars,
+                       method = "gam",
+                       tuneLength = 1, 
+                       trControl = trainControl(method = "none")),
+                 NA)
+
+})
+


### PR DESCRIPTION
There are two problems with method = "none"

First is that the default tuneLength=3 throws an error with most of the models:

```R
> train(bbbDescr, logBBB,
+       method = "earth",
+       trControl = trainControl(method = "none"))
Error in train.default(bbbDescr, logBBB, method = "earth", trControl = trainControl(method = "none")) (from train.default.R!64711Jn#236) : 
  Only one model should be specified in tuneGrid with no resampling
```

This could be fixed by explicitely supplying tuneLength arg

```R
> train(bbbDescr, logBBB,
+       method = "earth",
+       tuneLength = 1, 
+       trControl = trainControl(method = "none"))
Multivariate Adaptive Regression Spline 

208 samples
134 predictors

No pre-processing
Resampling: None 
```
but this is an unfortunate design. I fixed this by conditional default argument.

Second issue is that for some models grid function ignores `len` parameter. Fixing this by explicitely taking first row of the generated grid.

```R
> train(mpg ~ cyl + disp, data = mtcars,
+       method = "gam",
+       tuneLength = 1, 
+       trControl = trainControl(method = "none"))
Error in train.default(x, y, weights = w, ...) (from train.default.R!64711Jn#236) : 
  Only one model should be specified in tuneGrid with no resampling
> 
```