### PR TITLE
Fix classification in optimism bootstrap

### DIFF
--- a/pkg/caret/R/workflows.R
+++ b/pkg/caret/R/workflows.R
@@ -220,7 +220,7 @@ nominalTrainWorkflow <- function(x, y, wts, info, method, ppOpts, ctrl, lev, tes
           colnames(probValues) <- lev
           if(!is.null(submod))
           {
-            probValues <- rep(probValues, nrow(info$submodels[[parm]]) + 1L)
+            probValues <- rep(list(probValues), nrow(info$submodels[[parm]]) + 1L)
           }
         }
         if(testing) print(head(probValues))
@@ -230,9 +230,9 @@ nominalTrainWorkflow <- function(x, y, wts, info, method, ppOpts, ctrl, lev, tes
         probValuesExtra <- as.data.frame(matrix(NA, nrow = nrow(x), ncol = length(lev)))
         colnames(probValuesExtra) <- lev
         if(!is.null(submod)) {
-          probValuesExtra <- rep(probValuesExtra, nrow(info$submodels[[parm]]) + 1L)
-          probValuesExtra <- rep(list(probValuesExtra), 2L)
+          probValuesExtra <- rep(list(probValuesExtra), nrow(info$submodels[[parm]]) + 1L)
         }
+        probValuesExtra <- rep(list(probValuesExtra), 2L)
       }
       
       ##################################


### PR DESCRIPTION
Hello again. Sorry for all the pull requests, I could've sworn I tested more cases locally and they all worked, but apparently I was half asleep at the time. 

The fix in my previous commit broke classification with optimism bootstrap when `classProbs = FALSE`. I've fixed it and I tested both classification and regression. It seems to be working on my end. Let me know if it works for you too.