### PR TITLE
return full list of variables in xgb*$varImp

### DIFF
--- a/models/files/xgbLinear.R
+++ b/models/files/xgbLinear.R
@@ -94,6 +94,12 @@ modelInfo <- list(label = "eXtreme Gradient Boosting",
                     rownames(imp) <- as.character(imp[,1])
                     imp <- imp[,2,drop = FALSE]
                     colnames(imp) <- "Overall"
+
+                    missing <- object$xNames[!(object$xNames %in% rownames(imp))]
+                    missing_imp <- data.frame(Overall=rep(0, times=length(missing)))
+                    rownames(missing_imp) <- missing
+                    imp <- rbind(imp, missing_imp)
+
                     imp   
                   },
                   levels = function(x) x$obsLevels,

--- a/models/files/xgbTree.R
+++ b/models/files/xgbTree.R
@@ -184,6 +184,12 @@ modelInfo <- list(label = "eXtreme Gradient Boosting",
                     rownames(imp) <- as.character(imp[,1])
                     imp <- imp[,2,drop = FALSE]
                     colnames(imp) <- "Overall"
+
+                    missing <- object$xNames[!(object$xNames %in% rownames(imp))]
+                    missing_imp <- data.frame(Overall=rep(0, times=length(missing)))
+                    rownames(missing_imp) <- missing
+                    imp <- rbind(imp, missing_imp)
+
                     imp
                   },
                   levels = function(x) x$obsLevels,


### PR DESCRIPTION
xgb.importance returns only features which are used at least once in the classifier. While usually not a problem, missing features in the importance data frame lead to an error in rfe when using caretFuncs with xgbTree as classifier. This patch adds the missing features to the importance output.