### PR TITLE
fix typo, add link

### DIFF
--- a/pkg/caret/R/varImp.R
+++ b/pkg/caret/R/varImp.R
@@ -4,7 +4,7 @@
 #' \code{train} and method specific methods
 #' 
 #' For models that do not have corresponding \code{varImp} methods, see
-#' \code{filerVarImp}.
+#' \code{\link{filterVarImp}}.
 #' 
 #' Otherwise:
 #' 


### PR DESCRIPTION
typo in function name `filterVarImp`