### PR TITLE
Amendments and additional test for PR #624 (issue #620)

### DIFF
--- a/pkg/caret/R/ggplot.R
+++ b/pkg/caret/R/ggplot.R
@@ -122,8 +122,8 @@ ggplot.train <- function(data = NULL, mapping = NULL, metric = data$metric[1], p
       strip_lab <- as.character(subset(data$modelInfo$parameters, parameter %in% strip_vars)$label)
       for(i in seq_along(strip_vars))
         dat[, strip_vars[i]] <- factor(
-          paste(strip_lab[i], dat[, strip_vars[i]], sep = ": "),
-          levels = paste(strip_lab[i], sort(unique(dat[, strip_vars[i]])), sep = ": ")
+          paste(strip_lab[i], format(dat[, strip_vars[i]]), sep = ": "),
+          levels = paste(strip_lab[i], format(sort(unique(dat[, strip_vars[i]]))), sep = ": ")
         )
     }
     ## TODO: use factor(format(x)) to make a solid block of colors?

--- a/pkg/caret/tests/testthat/test_ggplot.R
+++ b/pkg/caret/tests/testthat/test_ggplot.R
@@ -1,12 +1,16 @@
 context("Test ggplot")
 
 test_that("ggplot.train correctly orders factors", {
+  library(caret)
+  library(kernlab)
   data(mtcars)
-  m <- train(mpg ~ cyl + disp,
-             data = mtcars,
-             method="svmRadial",
-             tuneGrid = expand.grid(C=1:2, sigma=c(0.0001, 0.01, 1)))
-  g <- ggplot(m, plotType="level")
+  m <- train(
+    mpg ~ cyl + disp,
+    data = mtcars,
+    method = "svmRadial",
+    tuneGrid = expand.grid(C = 1:2, sigma = c(0.0001, 0.01, 1))
+  )
+  g <- ggplot(m, plotType = "level")
 
   # Test plot data
   obj_sigma <- as.numeric(levels(g$data$sigma))
@@ -20,4 +24,38 @@ test_that("ggplot.train correctly orders factors", {
   obj_y <- as.numeric(build$layout$panel_ranges[[1]]$y.labels)
   expect_equal(obj_x, sort(obj_x))
   expect_equal(obj_y, sort(obj_y))
+})
+
+test_that("ggplot.train correctly orders facets' labels", {
+  library(caret)
+  library(kernlab)
+  data(mtcars)
+  m <- suppressWarnings(train(
+    mpg ~ cyl + disp,
+    data = mtcars,
+    method = "svmPoly",
+    tuneGrid = expand.grid(
+      degree = c(0.0001, 0.01, 1),
+      scale = c(0.0001, 0.01, 1),
+      C = c(0.0001, 0.01, 1)
+    )
+  ))
+  g <- ggplot(m, plotType = "level", nameInStrip = TRUE)
+
+  # Test plot data
+  obj_C <- as.numeric(gsub(
+    'Cost: ',
+    '',
+    levels(g$data$C)
+  ))
+  expect_equal(obj_C, sort(obj_C))
+
+  # Test axes' labels on a built plot
+  build <- ggplot2::ggplot_build(g)
+  obj_labels <- as.numeric(gsub(
+    'Cost: ',
+    '',
+    levels(build$layout$panel_layout$C)
+  ))
+  expect_equal(obj_labels, sort(obj_labels))
 })


### PR DESCRIPTION
Amendments and additional test for PR #624 (issue #620).

`format()` is added to facets' labels (which I am not sure is needed, as it is more a matter of taste and consistency), without it test labels were as follows:
1. `"Subsample Ratio of Columns: 1e-04"`;
2. `"Subsample Ratio of Columns: 0.01"`;
3. `"Subsample Ratio of Columns: 1"`;

which is now changed to:
1. `"Subsample Ratio of Columns: 1e-04"`;
2. `"Subsample Ratio of Columns: 1e-02"`;
3. `"Subsample Ratio of Columns: 1e+00"`.

Also additional test for ordering of facets' labels is added and packages `kernlab` and `xgboost` are explicitly loaded as the "missing package" error message when using `library()` is much clearer compared to the whole call stack print without it:

Error message with `library()`:
```
Failed -------------------------------------------------------------------------
1. Error: ggplot.train correctly orders factors (@test_ggplot.R#5) -------------
there is no package called 'kernlab'
1: library(kernlab) at [removed]\caret\pkg\caret/tests/testthat/test_ggplot.R:5
2: stop(txt, domain = NA)
```

and without:
```
Test ggplot: 1 package is needed for this model and is not installed. (kernlab). Would you like to try to install it now?1..

Failed -------------------------------------------------------------------------
1. Error: ggplot.train correctly orders factors (@test_ggplot.R#7) -------------

1: train(mpg ~ cyl + disp, data = mtcars, method = "svmRadial", tuneGrid = expand.grid(C = 1:2, 
       sigma = c(1e-04, 0.01, 1))) at [removed]\caret\pkg\caret/tests/testthat/test_ggplot.R:7
2: train.formula(mpg ~ cyl + disp, data = mtcars, method = "svmRadial", tuneGrid = expand.grid(C = 1:2, 
       sigma = c(1e-04, 0.01, 1))) at [removed]\caret\pkg\caret/R/train.default.R:217
3: train(x, y, weights = w, ...) at [removed]\caret\pkg\caret/R/train.default.R:912
4: train.default(x, y, weights = w, ...) at [removed]\caret\pkg\caret/R/train.default.R:217
5: checkInstall(models$library) at [removed]\caret\pkg\caret/R/train.default.R:251
6: stop() at [removed]\caret\pkg\caret/R/modelLookup.R:110
```