### PR TITLE
Fix issue #637: incorrect two-class mnLogLoss

### DIFF
--- a/pkg/caret/R/postResample.R
+++ b/pkg/caret/R/postResample.R
@@ -173,7 +173,7 @@ mnLogLoss <- function(data, lev = NULL, model = NULL){
 
   inds <- match(dataComplete$obs, colnames(probs))
   if(nlevels(dataComplete$obs) == 2){
-    logLoss <- ModelMetrics::logLoss(dataComplete$obs, probs)
+    logLoss <- ModelMetrics::logLoss(dataComplete$obs == lev[2], probs[, lev[2]])
   } else {
     logLoss <- ModelMetrics::mlogLoss(dataComplete$obs, probs)
   }

--- a/pkg/caret/tests/testthat/test_mnLogLoss.R
+++ b/pkg/caret/tests/testthat/test_mnLogLoss.R
@@ -25,4 +25,28 @@ test_that("Multiclass logloss returns expected values", {
 
 })
 
+# Issue #637
 
+classes.b <- c("A", "B")
+
+test_dat1.b <- data.frame(obs  = c("A", "A", "A", "B", "B"),
+                          pred = c("A", "A", "A", "B", "B"),
+                          A = c(1, .80, .51, .1, .2),
+                          B = c(0, .20, .49, .9, .8))
+
+test_that("Twoclass logloss returns expected values", {
+  result1 <- mnLogLoss(test_dat1.b, classes.b)
+
+  test_dat2.b <- test_dat1.b
+  test_dat2.b$A[1] <- NA
+  result2 <- mnLogLoss(test_dat2.b, classes.b)
+
+  test_dat3.b <- test_dat1.b
+  test_dat3.b <- test_dat3.b[, rev(1:4)]
+  result3 <- mnLogLoss(test_dat3.b, classes.b)
+
+  expect_equal(result1, c(logLoss = 0.244998), tolerance = .000001)
+  expect_equal(result2, c(logLoss = 0.306248), tolerance = .000001)
+  expect_equal(result3, c(logLoss = 0.244998), tolerance = .000001)
+
+})


### PR DESCRIPTION
Fix mnLogLoss to work properly for two-class input.

Add unit test for this particular case.

Supersedes PR #696 