### PR TITLE
Change reference to undefined variable 'mod' in thresholder

### DIFF
--- a/pkg/caret/R/thresholder.R
+++ b/pkg/caret/R/thresholder.R
@@ -59,7 +59,7 @@ thresholder <- function(x, threshold, final = TRUE) {
   if(!inherits(x, "train"))
     stop("`x` should be an object of class 'train'", 
          call. = FALSE)
-  if (!mod$control$classProbs)
+  if (!x$control$classProbs)
     stop("`classProbs` must be TRUE in `trainControl`",
          call. = FALSE)
   if (is.null(threshold))


### PR DESCRIPTION
`R CMD check` throws the following note:

```
* checking R code for possible problems ... NOTE
thresholder: no visible binding for global variable ‘mod’
Undefined global functions or variables:
  mod
```

Looking at the function signature, it appears that `thresholder` should be referencing input argument `x`, not `mod`.