### PR TITLE
Speedup predict.dummyVars

### DIFF
--- a/pkg/caret/R/dummyVar.R
+++ b/pkg/caret/R/dummyVar.R
@@ -235,16 +235,18 @@ predict.dummyVars <- function(object, newdata, na.action = na.pass, ...)
       }
     }
   }
+  cnames <- colnames(x)
   if(!is.null(object$sep) & !object$levelsOnly) {
     for(i in object$facVars[order(-nchar(object$facVars))]) {
       ## the default output form model.matrix is NAMElevel with no separator.
       for(j in object$lvls[[i]]) {
         from_text <- paste0(i, j)
         to_text <- paste(i, j, sep = object$sep)
-        colnames(x) <- gsub(from_text, to_text, colnames(x), fixed = TRUE)
+        cnames <- gsub(from_text, to_text, cnames, fixed = TRUE)
       }
     }
   }
+  colnames(x) <- cnames
   x[, colnames(x) != "(Intercept)", drop = FALSE]
 }
 


### PR DESCRIPTION
`predict.dummyVars` was very slow with large datasets with many factors due to the `colnames(x) <- ` assignments within nested loops. Here's an illustrative example:

```R
#create a local version of predict.dummyVars that is fixed to be the same as in this PR
predict_dummyVars <- caret:::predict.dummyVars
fix(predict_dummyVars)

n <- 400000
p <- 100
x <- data.frame(rep(list(x=rep(c('a','b'), n/2)), p/4)) # nominal
x <- cbind(x, data.frame(rep(list(x=rep(c('c','d','e','f'), n/4)), p/4)))
x <- cbind(x, data.frame(rep(list(x=rep(1, n)), p/2)))  # some numeric
colnames(x) <- paste0('x', 1:p)
dim(x)

dumm <- dummyVars("~ .", data = x, fullRank = T)

# before
ptm <- proc.time()
x1 <- predict(dumm, x)
print(proc.time() - ptm)

# after
ptm <- proc.time()
x2 <- predict_dummyVars(dumm, x)
print(proc.time() - ptm)

all.equal(x1,x2)
```
that results in:
```R
> # before
   user  system elapsed 
  33.60   44.07   77.86 
> # after
   user  system elapsed 
   2.05    0.78    2.81 
> all.equal(x1,x2)
[1] TRUE
```
