### PR TITLE
github-repo is supposed to be the slug

### DIFF
--- a/bookdown/index.Rmd
+++ b/bookdown/index.Rmd
@@ -9,7 +9,7 @@ output:
       toc:
         collapse: section
 documentclass: book
-github-repo: https://github.com/topepo/caret
+github-repo: topepo/caret
 description: "Documentation for the `caret` package"
 split_by: chapter
 ---


### PR DESCRIPTION
instead of a full URL; see https://bookdown.org/home/about.html