### PR TITLE
remove unnecessary space

### DIFF
--- a/pkg/caret/R/print.train.R
+++ b/pkg/caret/R/print.train.R
@@ -257,7 +257,7 @@ stringFunc <- function (x)  {
             met <- paste(met,
                          switch(x$control$selectionFunction,
                                 best = paste(
-                                  " the",
+                                  "the",
                                   ifelse(x$maximize, "largest", "smallest"),
                                   "value.\n"),
                                 oneSE = " the one SE rule.\n",


### PR DESCRIPTION
tiny suggestion, but because there is a surrounding `paste`, this space is unnecessary. Currently, the output is formatted as follows:

`pearson was used to select the optimal model using  the largest value.`

![image](https://user-images.githubusercontent.com/2942215/30867450-d6104378-a290-11e7-8cb4-9815abcbddaf.png)
(not sure it shows clearly as text above)
