### PR TITLE
Prefix predict for every kernlab use

### DIFF
--- a/models/files/gaussprLinear.R
+++ b/models/files/gaussprLinear.R
@@ -12,12 +12,12 @@ modelInfo <- list(label = "Gaussian Process",
 				     kpar = list(), ...)
                     },
                   predict = function(modelFit, newdata, submodels = NULL) {            
-                    out <- predict(modelFit, as.matrix(newdata))
+                    out <- kernlab::predict(modelFit, as.matrix(newdata))
                     if(is.matrix(out)) out <- out[,1]
                     out
                   },
                   prob = function(modelFit, newdata, submodels = NULL) {
-                    predict(modelFit, as.matrix(newdata), type = "probabilities")
+                    kernlab::predict(modelFit, as.matrix(newdata), type = "probabilities")
                   },
                   predictors = function(x, ...) {
                     if(hasTerms(x) & !is.null(x@terms))

--- a/models/files/gaussprPoly.R
+++ b/models/files/gaussprPoly.R
@@ -22,12 +22,12 @@ modelInfo <- list(label = "Gaussian Process with Polynomial Kernel",
                                                        offset = 1), ...)         
                     },
                   predict = function(modelFit, newdata, submodels = NULL) {  
-                    out <- predict(modelFit, as.matrix(newdata))
+                    out <- kernlab::predict(modelFit, as.matrix(newdata))
                     if(is.matrix(out)) out <- out[,1]
                     out
                   },
                   prob = function(modelFit, newdata, submodels = NULL) {
-                    predict(modelFit, as.matrix(newdata), type = "probabilities")
+                    kernlab::predict(modelFit, as.matrix(newdata), type = "probabilities")
                   },
                   predictors = function(x, ...) {
                     if(hasTerms(x) & !is.null(x@terms))

--- a/models/files/lssvmPoly.R
+++ b/models/files/lssvmPoly.R
@@ -25,7 +25,7 @@ modelInfo <- list(label = "Least Squares Support Vector Machine with Polynomial 
                                                             offset = 1), ...)         
                   },
                   predict = function(modelFit, newdata, submodels = NULL) {  
-                    out <- predict(modelFit, as.matrix(newdata))
+                    out <- kernlab::predict(modelFit, as.matrix(newdata))
                     if(is.matrix(out)) out <- out[,1]
                     out
                   },

--- a/models/files/lssvmRadial.R
+++ b/models/files/lssvmRadial.R
@@ -24,7 +24,7 @@ modelInfo <- list(label = "Least Squares Support Vector Machine with Radial Basi
                                    kpar = list(sigma = param$sigma), ...)         
                   },
                   predict = function(modelFit, newdata, submodels = NULL) {  
-                    out <- predict(modelFit, as.matrix(newdata))
+                    out <- kernlab::predict(modelFit, as.matrix(newdata))
                     if(is.matrix(out)) out <- out[,1]
                     out
                   },

--- a/models/files/rvmLinear.R
+++ b/models/files/rvmLinear.R
@@ -12,7 +12,7 @@ modelInfo <- list(label = "Relevance Vector Machines with Linear Kernel",
                                   ...)
                   },
                   predict = function(modelFit, newdata, submodels = NULL) 
-                    predict(modelFit, newdata),
+                    kernlab::predict(modelFit, newdata),
                   prob = NULL,
                   predictors = function(x, ...) {
                     if(hasTerms(x) & !is.null(x@terms))

--- a/models/files/rvmPoly.R
+++ b/models/files/rvmPoly.R
@@ -24,7 +24,7 @@ modelInfo <- list(label = "Relevance Vector Machines with Polynomial Kernel",
                                   ...)
                   },
                   predict = function(modelFit, newdata, submodels = NULL) 
-                    predict(modelFit, newdata),
+                    kernlab::predict(modelFit, newdata),
                   prob = NULL,
                   predictors = function(x, ...) {
                     if(hasTerms(x) & !is.null(x@terms))

--- a/models/files/rvmRadial.R
+++ b/models/files/rvmRadial.R
@@ -22,7 +22,7 @@ modelInfo <- list(label = "Relevance Vector Machines with Radial Basis Function 
                                   ...)
                   },
                   predict = function(modelFit, newdata, submodels = NULL)
-                    predict(modelFit, newdata),
+                    kernlab::predict(modelFit, newdata),
                   prob = NULL,
                   predictors = function(x, ...) {
                     if(hasTerms(x) & !is.null(x@terms))

--- a/models/files/svmBoundrangeString.R
+++ b/models/files/svmBoundrangeString.R
@@ -40,9 +40,9 @@ modelInfo <- list(label = "Support Vector Machines with Boundrange String Kernel
                     {
                       hasPM <- !is.null(unlist(obj@prob.model))
                       if(hasPM) {
-                        pred <- kernlab::lev(obj)[apply(predict(obj, x, type = "probabilities"),
+                        pred <- kernlab::lev(obj)[apply(kernlab::predict(obj, x, type = "probabilities"),
                                                1, which.max)]
-                      } else pred <- predict(obj, x)
+                      } else pred <- kernlab::predict(obj, x)
                       pred
                     }
                     out <- try(svmPred(modelFit, newdata[,1]), silent = TRUE)
@@ -64,7 +64,7 @@ modelInfo <- list(label = "Support Vector Machines with Boundrange String Kernel
                     out
                   },
                   prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- try(predict(modelFit, newdata[,1], type="probabilities"),
+                    out <- try(kernlab::predict(modelFit, newdata[,1], type="probabilities"),
                                silent = TRUE)
                     if(class(out)[1] != "try-error")
                     {

--- a/models/files/svmExpoString.R
+++ b/models/files/svmExpoString.R
@@ -40,9 +40,9 @@ modelInfo <- list(label = "Support Vector Machines with Exponential String Kerne
                     {
                       hasPM <- !is.null(unlist(obj@prob.model))
                       if(hasPM) {
-                        pred <- lev(obj)[apply(predict(obj, x, type = "probabilities"), 
+                        pred <- lev(obj)[apply(kernlab::predict(obj, x, type = "probabilities"), 
                                                1, which.max)]
-                      } else pred <- predict(obj, x)
+                      } else pred <- kernlab::predict(obj, x)
                       pred
                     }
                     out <- try(svmPred(modelFit, newdata[,1]), silent = TRUE)
@@ -64,7 +64,7 @@ modelInfo <- list(label = "Support Vector Machines with Exponential String Kerne
                     out
                   },
                   prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- try(predict(modelFit, newdata[,1], type="probabilities"),
+                    out <- try(kernlab::predict(modelFit, newdata[,1], type="probabilities"),
                                silent = TRUE)
                     if(class(out)[1] != "try-error")
                     {

--- a/models/files/svmPoly.R
+++ b/models/files/svmPoly.R
@@ -39,9 +39,9 @@ modelInfo <- list(label = "Support Vector Machines with Polynomial Kernel",
                     svmPred <- function(obj, x) {
                       hasPM <- !is.null(unlist(obj@prob.model))
                       if(hasPM) {
-                        pred <- kernlab::lev(obj)[apply(predict(obj, x, type = "probabilities"), 
+                        pred <- kernlab::lev(obj)[apply(kernlab::predict(obj, x, type = "probabilities"), 
                                                1, which.max)]
-                      } else pred <- predict(obj, x)
+                      } else pred <- kernlab::predict(obj, x)
                       pred
                     }
                     out <- try(svmPred(modelFit, newdata), silent = TRUE)
@@ -61,7 +61,7 @@ modelInfo <- list(label = "Support Vector Machines with Polynomial Kernel",
                     out
                   },
                   prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- try(predict(modelFit, newdata, type="probabilities"),
+                    out <- try(kernlab::predict(modelFit, newdata, type="probabilities"),
                                silent = TRUE)
                     if(class(out)[1] != "try-error") {
                       ## There are times when the SVM probability model will

--- a/models/files/svmRadial.R
+++ b/models/files/svmRadial.R
@@ -37,9 +37,9 @@ modelInfo <- list(label = "Support Vector Machines with Radial Basis Function Ke
                     svmPred <- function(obj, x) {
                       hasPM <- !is.null(unlist(obj@prob.model))
                       if(hasPM) {
-                        pred <- kernlab::lev(obj)[apply(predict(obj, x, type = "probabilities"), 
+                        pred <- kernlab::lev(obj)[apply(kernlab::predict(obj, x, type = "probabilities"), 
                                                1, which.max)]
-                      } else pred <- predict(obj, x)
+                      } else pred <- kernlab::predict(obj, x)
                       pred
                     }
                     out <- try(svmPred(modelFit, newdata), silent = TRUE)
@@ -59,7 +59,7 @@ modelInfo <- list(label = "Support Vector Machines with Radial Basis Function Ke
                     out
                   },
                   prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- try(predict(modelFit, newdata, type="probabilities"),
+                    out <- try(predict(kernlab::modelFit, newdata, type="probabilities"),
                                silent = TRUE)
                     if(class(out)[1] != "try-error") {
                       ## There are times when the SVM probability model will

--- a/models/files/svmRadialCost.R
+++ b/models/files/svmRadialCost.R
@@ -32,9 +32,9 @@ modelInfo <- list(label = "Support Vector Machines with Radial Basis Function Ke
                     svmPred <- function(obj, x) {
                       hasPM <- !is.null(unlist(obj@prob.model))
                       if(hasPM) {
-                        pred <- kernlab::lev(obj)[apply(predict(obj, x, type = "probabilities"), 
+                        pred <- kernlab::lev(obj)[apply(kernlab::predict(obj, x, type = "probabilities"), 
                                                1, which.max)]
-                      } else pred <- predict(obj, x)
+                      } else pred <- kernlab::predict(obj, x)
                       pred
                     }
                     out <- try(svmPred(modelFit, newdata), silent = TRUE)
@@ -55,7 +55,7 @@ modelInfo <- list(label = "Support Vector Machines with Radial Basis Function Ke
                     out
                   },
                   prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- try(predict(modelFit, newdata, type="probabilities"),
+                    out <- try(kernlab::predict(modelFit, newdata, type="probabilities"),
                                silent = TRUE)
                     if(class(out)[1] != "try-error")
                     {

--- a/models/files/svmRadialSigma.R
+++ b/models/files/svmRadialSigma.R
@@ -37,9 +37,9 @@ modelInfo <- list(label = "Support Vector Machines with Radial Basis Function Ke
                     svmPred <- function(obj, x) {
                       hasPM <- !is.null(unlist(obj@prob.model))
                       if(hasPM) {
-                        pred <- kernlab::lev(obj)[apply(predict(obj, x, type = "probabilities"), 
+                        pred <- kernlab::lev(obj)[apply(kernlab::predict(obj, x, type = "probabilities"), 
                                                1, which.max)]
-                      } else pred <- predict(obj, x)
+                      } else pred <- kernlab::predict(obj, x)
                       pred
                     }
                     out <- try(svmPred(modelFit, newdata), silent = TRUE)
@@ -59,7 +59,7 @@ modelInfo <- list(label = "Support Vector Machines with Radial Basis Function Ke
                     out
                   },
                   prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- try(predict(modelFit, newdata, type="probabilities"),
+                    out <- try(kernlab::predict(modelFit, newdata, type="probabilities"),
                                silent = TRUE)
                     if(class(out)[1] != "try-error") {
                       ## There are times when the SVM probability model will

--- a/models/files/svmRadialWeights.R
+++ b/models/files/svmRadialWeights.R
@@ -43,12 +43,12 @@ modelInfo <- list(label = "Support Vector Machines with Class Weights",
                     out            
                   },
                   predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata)
+                    out <- kernlab::predict(modelFit, newdata)
                     if(is.matrix(out)) out <- out[,1]
                     out
                   },
                   prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- try(predict(modelFit, newdata, type="probabilities"),
+                    out <- try(kernlab::predict(modelFit, newdata, type="probabilities"),
                                silent = TRUE)
                     if(class(out)[1] != "try-error") {
                       ## There are times when the SVM probability model will

--- a/models/files/svmSpectrumString.R
+++ b/models/files/svmSpectrumString.R
@@ -37,9 +37,9 @@ modelInfo <- list(label = "Support Vector Machines with Spectrum String Kernel",
                     svmPred <- function(obj, x) {
                       hasPM <- !is.null(unlist(obj@prob.model))
                       if(hasPM) {
-                        pred <- kernlab::lev(obj)[apply(predict(obj, x, type = "probabilities"), 
+                        pred <- kernlab::lev(obj)[apply(kernlab::predict(obj, x, type = "probabilities"), 
                                                1, which.max)]
-                      } else pred <- predict(obj, x)
+                      } else pred <- kernlab::predict(obj, x)
                       pred
                     }
                     out <- try(svmPred(modelFit, newdata[,1]), silent = TRUE)
@@ -59,7 +59,7 @@ modelInfo <- list(label = "Support Vector Machines with Spectrum String Kernel",
                     out
                   },
                   prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- try(predict(modelFit, newdata[,1], type="probabilities"),
+                    out <- try(kernlab::predict(modelFit, newdata[,1], type="probabilities"),
                                silent = TRUE)
                     if(class(out)[1] != "try-error") {
                       ## There are times when the SVM probability model will


### PR DESCRIPTION
Dear Max,

it seems that the predict function has to be explicitly prefixed when using kernlab otherwise NAs are prediicted...

Erwan