### PR TITLE
Add missing exports required for some foreach backend

### DIFF
--- a/pkg/caret/R/workflows.R
+++ b/pkg/caret/R/workflows.R
@@ -75,12 +75,10 @@ nominalTrainWorkflow <- function(x, y, wts, info, method, ppOpts, ctrl, lev, tes
   keep_pred <- isTRUE(ctrl$savePredictions) || ctrl$savePredictions %in% c("all", "final")
   pkgs <- c("methods", "caret")
   if(!is.null(method$library)) pkgs <- c(pkgs, method$library)
-  export <- c("optimism_xy", "ctrl", "requireNamespaceQuietStop",
-              "x", "y", "wts", "info", "method", "ppOpts", "ctrl", "lev",
-              "testing","pkgs", "resampleIndex")
+  export <- c()
 
-  result <- foreach(iter = seq(along = resampleIndex), .combine = "c", .verbose = FALSE, .export = export) %:%
-    foreach(parm = 1L:nrow(info$loop), .combine = "c", .verbose = FALSE, .export = export)  %op%
+  result <- foreach(iter = seq(along = resampleIndex), .combine = "c", .verbose = FALSE, .export = export, .packages = "caret") %:%
+    foreach(parm = 1L:nrow(info$loop), .combine = "c", .verbose = FALSE, .export = export , .packages = "caret")  %op%
     {
       if(!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds))) set.seed(ctrl$seeds[[iter]][parm])
 

--- a/pkg/caret/R/workflows.R
+++ b/pkg/caret/R/workflows.R
@@ -75,7 +75,9 @@ nominalTrainWorkflow <- function(x, y, wts, info, method, ppOpts, ctrl, lev, tes
   keep_pred <- isTRUE(ctrl$savePredictions) || ctrl$savePredictions %in% c("all", "final")
   pkgs <- c("methods", "caret")
   if(!is.null(method$library)) pkgs <- c(pkgs, method$library)
-  export <- c("optimism_xy")
+  export <- c("optimism_xy", "ctrl", "requireNamespaceQuietStop",
+              "x", "y", "wts", "info", "method", "ppOpts", "ctrl", "lev",
+              "testing","pkgs", "resampleIndex")
 
   result <- foreach(iter = seq(along = resampleIndex), .combine = "c", .verbose = FALSE, .export = export) %:%
     foreach(parm = 1L:nrow(info$loop), .combine = "c", .verbose = FALSE, .export = export)  %op%


### PR DESCRIPTION
I've stumbled upon a bug for some foreach backend (doFuture with multisession for instance...). There are some missing exports in  workflows.R. It seems that completing the list as proposed below fix this issue.