### PR TITLE
Minor fixes to mxnet* model files.

### DIFF
--- a/models/files/mxnet.R
+++ b/models/files/mxnet.R
@@ -45,8 +45,8 @@ modelInfo <- list(label = "Neural Network",
                                            eval.metric = mx.metric.rmse, 
                                            array.layout = "rowmajor",
                                            activation = rep( as.character(param$activation), length(num_units)),
+                                           # Use He/MSRA when available in R 
                                            initializer = mx.init.Xavier(factor_type = "avg", magnitude = 3, rnd_type = 'uniform'),
-                                           verbose= FALSE,
                                            ...)
                     } else {
                       y <- as.numeric(y) - 1
@@ -61,7 +61,6 @@ modelInfo <- list(label = "Neural Network",
                                            array.layout = "rowmajor",
                                            activation = rep( as.character(param$activation), length(num_units)),
                                            initializer = mx.init.Xavier(factor_type = "avg", magnitude = 3, rnd_type = 'uniform'), 
-                                           verbose= FALSE,
                                            ...)
                     }
                     if(last)

--- a/models/files/mxnet.R
+++ b/models/files/mxnet.R
@@ -46,6 +46,7 @@ modelInfo <- list(label = "Neural Network",
                                            array.layout = "rowmajor",
                                            activation = rep( as.character(param$activation), length(num_units)),
                                            initializer = mx.init.Xavier(factor_type = "avg", magnitude = 3, rnd_type = 'uniform'),
+                                           verbose= FALSE,
                                            ...)
                     } else {
                       y <- as.numeric(y) - 1
@@ -60,6 +61,7 @@ modelInfo <- list(label = "Neural Network",
                                            array.layout = "rowmajor",
                                            activation = rep( as.character(param$activation), length(num_units)),
                                            initializer = mx.init.Xavier(factor_type = "avg", magnitude = 3, rnd_type = 'uniform'), 
+                                           verbose= FALSE,
                                            ...)
                     }
                     if(last)

--- a/models/files/mxnetAdam.R
+++ b/models/files/mxnetAdam.R
@@ -32,7 +32,7 @@ modelInfo <- list(label = "Neural Network",
                     if(!is.matrix(x)) x <- as.matrix(x)
                     if(is.numeric(y)) {
                       mxnet::mx.set.seed(21)  
-                      out <- mxnet::mx.mlp(data = x, label = y, out_node = 1, out_activation = "rmse", verbose= FALSE,
+                      out <- mxnet::mx.mlp(data = x, label = y, out_node = 1, out_activation = "rmse", 
                                            optimizer = 'adam', eval.metric = mx.metric.rmse, array.layout = "rowmajor", 
                                            learning.rate = param$learningrate,  
                                            beta1 = param$beta1, 
@@ -40,12 +40,13 @@ modelInfo <- list(label = "Neural Network",
                                            dropout = param$dropout,
                                            hidden_node = num_units,
                                            activation = rep( as.character(param$activation), length(num_units)),
+                                           # Consider using He/MSRA paper when available in R
                                            initializer = mx.init.Xavier(factor_type = "avg", magnitude = 3, rnd_type = 'uniform'),
                                            ...)
                     } else {
                       y <- as.numeric(y) - 1 
                       mxnet::mx.set.seed(21)
-                      out <- mxnet::mx.mlp(data = x, label = y, out_node = length(unique(y)), out_activation = "softmax",  verbose= FALSE,
+                      out <- mxnet::mx.mlp(data = x, label = y, out_node = length(unique(y)), out_activation = "softmax", 
                                           optimizer = 'adam', eval.metric = mx.metric.accuracy, array.layout = "rowmajor", 
                                           learning.rate = param$learningrate, 
                                           beta1 = param$beta1, 

--- a/models/files/mxnetAdam.R
+++ b/models/files/mxnetAdam.R
@@ -31,7 +31,7 @@ modelInfo <- list(label = "Neural Network",
                     num_units <- num_units[num_units > 0]
                     if(!is.matrix(x)) x <- as.matrix(x)
                     if(is.numeric(y)) {
-                      mx.set.seed(21)  
+                      mxnet::mx.set.seed(21)  
                       out <- mxnet::mx.mlp(data = x, label = y, out_node = 1, out_activation = "rmse", verbose= FALSE,
                                            optimizer = 'adam', eval.metric = mx.metric.rmse, array.layout = "rowmajor", 
                                            learning.rate = param$learningrate,  
@@ -44,7 +44,7 @@ modelInfo <- list(label = "Neural Network",
                                            ...)
                     } else {
                       y <- as.numeric(y) - 1 
-                      mx.set.seed(21)
+                      mxnet::mx.set.seed(21)
                       out <- mxnet::mx.mlp(data = x, label = y, out_node = length(unique(y)), out_activation = "softmax",  verbose= FALSE,
                                           optimizer = 'adam', eval.metric = mx.metric.accuracy, array.layout = "rowmajor", 
                                           learning.rate = param$learningrate, 


### PR DESCRIPTION
Very minor adjustments to `mxnet*` related code. 

Harding-coding verbose as `FALSE` will probably increase convenience. 
Similarly adding `packagename::functionname()` syntax for `mx.set.seed`; I forgot at the time.