### PR TITLE
Update postResample.R

### DIFF
--- a/pkg/caret/R/postResample.R
+++ b/pkg/caret/R/postResample.R
@@ -122,7 +122,7 @@ postResample <- function(pred, obs)
   pred <- pred[!isNA]
   obs <- obs[!isNA]
 
-  if(!is.factor(obs) & is.numeric(obs))
+  if (!is.factor(obs) && is.numeric(obs))
     {
       if(length(obs) + length(pred) == 0)
         {


### PR DESCRIPTION
https://stackoverflow.com/questions/6558921/r-boolean-operators-and
'&' in if expression can be a problem
```
> if (c(T,T) & c(T)) 1
[1] 1
Warning message:
In if (c(T, T) & c(T)) 1 :
  the condition has length > 1 and only the first element will be used
```
because it is designed to output vectors instead of scalars (vectors with one element). 
And one comment on the code style 
https://image.prntscr.com/image/lhe4VEMiS1_uGnSz77jDeg.png
I'm not sure you will find any of my recommendations useful that's why I did not mark all of them in caret. 
If you want you can use this approach for refactoring:
https://image.prntscr.com/image/_pmpSdj6Q9OSBOgInh0FUg.png