### PR TITLE
Avoid leaving option() changed when model.matrix fails

### DIFF
--- a/pkg/caret/R/dummyVar.R
+++ b/pkg/caret/R/dummyVar.R
@@ -221,11 +221,11 @@ predict.dummyVars <- function(object, newdata, na.action = na.pass, ...)
     newContr <- oldContr
     newContr["unordered"] <- "contr.ltfr"
     options(contrasts = newContr)
+    on.exit(options(contrasts = oldContr))
   }
   m <- model.frame(Terms, newdata, na.action = na.action, xlev = object$lvls)
   
   x <- model.matrix(Terms, m)
-  if(!object$fullRank) options(contrasts = oldContr)
   
   if(object$levelsOnly) {
     for(i in object$facVars) {


### PR DESCRIPTION
In some situations `x <- model.matrix(Terms, m)` fails and `options()$constrasts` leaves changed to `"contr.ltfr"`. Calling `options(contrasts = oldContr)` via `on.exit()` solves this problem.

A reproducible example is shown below. The same thing happens when a user loads `dummyVars` object from .RData file and calls `predict` function before loading the package.

```r
options()["contrasts"] # Normally the first element is "contr.treatment"
unloadNamespace("caret") # Unload the package

dummies <- caret::dummyVars(Sepal.Length ~ ., data = iris)
head(predict(dummies, newdata = iris)) # It fails because the package is not loaded

options()["contrasts"] # The first element has been changed to "contr.ltfr"

model <- lm(Sepal.Length ~ ., data = iris) # It also fails because the "contrasts" option has been changed
```