### PR TITLE
Typo in the documentation for 'scat' data

### DIFF
--- a/pkg/caret/R/caret-package.R
+++ b/pkg/caret/R/caret-package.R
@@ -230,7 +230,7 @@ NULL
 
 #' Morphometric Data on Scat
 #'
-#' Reid (2105) collected data on animal feses in coastal California. The data
+#' Reid (2015) collected data on animal feses in coastal California. The data
 #' consist of DNA verified species designations as well as fields related to
 #' the time and place of the collection and the scat itself. The data frame
 #' \code{scat_orig} contains while \code{scat} contains data on the three main


### PR DESCRIPTION
I found a typo after reading Twitter poem. :)