### PR TITLE
post resample error handling

### DIFF
--- a/pkg/caret/R/postResample.R
+++ b/pkg/caret/R/postResample.R
@@ -144,9 +144,6 @@ postResample <- function(pred, obs)
       names(out) <- c("RMSE", "Rsquared", "MAE")
     } else {
     
-      if ( is.logical( obs ) ){
-        stop( "logical type output variables are not presently supported.  Try converting your output variable to a factor." )
-      }
       if(length(obs) + length(pred) == 0)
         {
           out <- rep(NA, 2)

--- a/pkg/caret/R/postResample.R
+++ b/pkg/caret/R/postResample.R
@@ -145,7 +145,7 @@ postResample <- function(pred, obs)
     } else {
     
       if ( is.logical( obs ) ){
-        stop( "logical type output variables are not presently supported.  Try converting your output variable to a factor". )
+        stop( "logical type output variables are not presently supported.  Try converting your output variable to a factor." )
       }
       if(length(obs) + length(pred) == 0)
         {

--- a/pkg/caret/R/postResample.R
+++ b/pkg/caret/R/postResample.R
@@ -143,6 +143,10 @@ postResample <- function(pred, obs)
         }
       names(out) <- c("RMSE", "Rsquared", "MAE")
     } else {
+    
+      if ( is.logical( obs ) ){
+        stop( "logical type output variables are not presently supported.  Try converting your output variable to a factor". )
+      }
       if(length(obs) + length(pred) == 0)
         {
           out <- rep(NA, 2)

--- a/pkg/caret/R/postResample.R
+++ b/pkg/caret/R/postResample.R
@@ -143,7 +143,6 @@ postResample <- function(pred, obs)
         }
       names(out) <- c("RMSE", "Rsquared", "MAE")
     } else {
-    
       if(length(obs) + length(pred) == 0)
         {
           out <- rep(NA, 2)

--- a/pkg/caret/R/train.default.R
+++ b/pkg/caret/R/train.default.R
@@ -315,7 +315,12 @@ train.default <- function(x, y,
     stop("Please use column names for `x`", call. = FALSE)
   
   if(is.character(y)) y <- as.factor(y)
-
+  
+  if( !is.numeric(y) & !is.factor(y) ){
+    #This error will often trigger if the y value is logical.  
+    stop( "Please make sure `y` is a factor or numeric value." , call. = FALSE )
+  }
+  
   if(is.list(method)) {
     minNames <- c("library", "type", "parameters", "grid",
                   "fit", "predict", "prob")


### PR DESCRIPTION
If your output variable is of type 'logical', then train throws a pretty cryptic error.   

    Error in tab[1:m, 1:m] : subscript out of bounds


To solve it, I had to google it, and I found this [blog post](http://davidhughjones.blogspot.com/2015/04/r-tip-caret-error.html), indicating several other people have had the same problem over the years. 



This patch simply checks to see if your output variable is logical and then throws a clearer error message.

FWIW: It seems like it is probably possible to fix the underlying problem and support logicals, but I don't understand all the implications that would have in the codebase, so I went with a more conservative patch.