### PR TITLE
Fix misquotation of meta tag of GitHub repository

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
   
   
   <meta property="og:description" content="Documentation for the <code>caret</code> package" />
-  <meta name="github-repo" content="<a href="https://github.com/topepo/caret" class="uri">https://github.com/topepo/caret</a>" />
+  <meta name="github-repo" content="<a href='https://github.com/topepo/caret' class='uri'>https://github.com/topepo/caret</a>" />
 
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:title" content="The caret Package" />


### PR DESCRIPTION
The live site has a stray link in the top left corner of the page. This fixes the quotation of the link that should have single quotes rather than double quotes.

**Screenshot**:

Before:

![image](https://user-images.githubusercontent.com/2754821/37478394-57f66daa-2837-11e8-8910-5fe61c8ffb46.png)

After:

![image](https://user-images.githubusercontent.com/2754821/37478486-97954ed6-2837-11e8-8d4a-ffb6a66b211e.png)
