### PR TITLE
Add createMultiFolds() to help page

### DIFF
--- a/pkg/caret/R/createDataPartition.R
+++ b/pkg/caret/R/createDataPartition.R
@@ -222,7 +222,7 @@ createDataPartition <- function (y, times = 1, p = 0.5, list = TRUE, groups = mi
     out
   }
 
-
+#' @rdname createDataPartition
 #' @export
 createMultiFolds <- function(y, k = 10, times = 5) {
   if(class(y)[1] == "Surv") y <- y[,"time"]


### PR DESCRIPTION
At present, createMultiFolds() is partly documented under ?createDataPartition (under Details mostly). But it does not show up under the Usage section.

So I propose to add 

#' @rdname createDataPartition

for this function so that it will show up there.

If this is intentional, please ignore.