### PR TITLE
To solve the problem: when using xgbTree, the memory would not be released

### DIFF
--- a/pkg/caret/R/adaptive.R
+++ b/pkg/caret/R/adaptive.R
@@ -239,6 +239,8 @@ adaptiveWorkflow <- function(x, y, wts, info, method, ppOpts, ctrl, lev,
               thisResample$Resample <- names(resampleIndex)[iter]
               if(ctrl$verboseIter) progress(printed[parm,,drop = FALSE],
                                             names(resampleIndex), iter, FALSE)
+              mod <- NULL
+              gc()
               list(resamples = thisResample, pred = tmpPred)
             } ## end initial loop over resamples and models
 

--- a/pkg/caret/R/workflows.R
+++ b/pkg/caret/R/workflows.R
@@ -257,6 +257,8 @@ nominalTrainWorkflow <- function(x, y, wts, info, method, ppOpts, ctrl, lev, tes
                                     names(resampleIndex), iter, FALSE)
 
       if(testing) print(thisResample)
+      mod <- NULL
+      gc()
       list(resamples = thisResample, pred = tmpPred, resamplesExtra = thisResampleExtra)
     }
 
@@ -461,6 +463,8 @@ looTrainWorkflow <- function(x, y, wts, info, method, ppOpts, ctrl, lev, testing
       }
       if(ctrl$verboseIter) progress(printed[parm,,drop = FALSE],
                                     names(ctrl$index), iter, FALSE)
+      mod <- NULL
+      gc()
       predicted
     }
 


### PR DESCRIPTION
This is xgbost's  problem, see issue [3045](https://github.com/dmlc/xgboost/issues/3045).
To solve it, just simply set mod to NULL and call gc() in the proper place of R/adaptive.R and R/workflows.R.