### PR TITLE
More statistics for function thresholder

### DIFF
--- a/pkg/caret/R/thresholder.R
+++ b/pkg/caret/R/thresholder.R
@@ -109,7 +109,7 @@ thresholder <- function(x, threshold, final = TRUE, statistics = "all") {
   if (!any(statistics %in% c("all", stat_names)) ||
       ("all" %in% statistics && length(statistics) > 1))
     stop("`statistics` should be either 'all', or one or more of '",
-         paste0(names(res), collapse="', '"), "'.")
+         paste0(stat_names, collapse="', '"), "'.")
 
   if (length(statistics) == 1 && statistics == "all")
     statistics <- stat_names

--- a/pkg/caret/R/thresholder.R
+++ b/pkg/caret/R/thresholder.R
@@ -111,7 +111,7 @@ thresholder <- function(x, threshold, final = TRUE, statistics = "all") {
     stop("`statistics` should be either 'all', or one or more of '",
          paste0(names(res), collapse="', '"), "'.")
 
-  if (statistics == "all")
+  if (length(statistics) == 1 && statistics == "all")
     statistics <- stat_names
   
   disc <- c("pred", "rowIndex", x$levels[-1])

--- a/pkg/caret/R/thresholder.R
+++ b/pkg/caret/R/thresholder.R
@@ -15,14 +15,38 @@
 #' @param final A logical: should only the final tuning parameters
 #'   chosen by \code{\link{train}} be used when 
 #'   \code{savePredictions = 'all'}?
+#' @param statistics A character vector indicating which statistics to
+#'   calculate. See details below for possible choices; the default value
+#'   \code{"all"} computes all of these.
 #' @return A data frame with columns for each of the tuning parameters
 #'  from the model along with an additional column called
 #'  \code{prob_threshold} for the probability threshold. There are
 #'  also columns for summary statistics averaged over resamples with
-#'  column names \code{Sensitivity}, \code{Specificity}, \code{J},
-#'  \code{Dist}. The last two correspond to Youden's J statistic 
-#'  and the distance to the best possible cutoff (i.e. perfect
-#'  sensitivity and specificity). 
+#'  column names corresponding to the input argument \code{statistics}. 
+#' @details The argument \code{statistics} designates the statistics to compute
+#'  for each probability threshold. One or more of the following statistics can
+#'  be selected:
+#'  \itemize{
+#'  \item Sensitivity
+#'  \item Specificity
+#'  \item Pos Pred Value
+#'  \item Neg Pred Value
+#'  \item Precision
+#'  \item Recall
+#'  \item F1
+#'  \item Prevalence
+#'  \item Detection Rate
+#'  \item Detection Prevalence
+#'  \item Balanced Accuracy
+#'  \item Accuracy
+#'  \item Kappa
+#'  \item J
+#'  \item Dist
+#' }
+#' For a description of these statistics (except the last two), see the
+#' documentation of \code{\link{confusionMatrix}}. The last two statistics
+#' are Youden's J statistic and the distance to the best possible cutoff (i.e.
+#' perfect sensitivity and specificity.
 #' @export
 #' @importFrom plyr ddply
 #' @examples 
@@ -55,7 +79,7 @@
 #'   geom_point() + 
 #'   geom_point(aes(y = Specificity), col = "red")
 #' }
-thresholder <- function(x, threshold, final = TRUE) {
+thresholder <- function(x, threshold, final = TRUE, statistics = "all") {
   if(!inherits(x, "train"))
     stop("`x` should be an object of class 'train'", 
          call. = FALSE)
@@ -78,6 +102,18 @@ thresholder <- function(x, threshold, final = TRUE) {
   if (length(levels(x$pred$obs)) > 2)
     stop("For two class problems only", call. = TRUE)
   
+  stat_names <- c("Sensitivity", "Specificity", "Pos Pred Value",
+                  "Neg Pred Value", "Precision", "Recall", "F1", "Prevalence",
+                  "Detection Rate", "Detection Prevalence", "Balanced Accuracy",
+                  "Accuracy", "Kappa", "J", "Dist")
+  if (!any(statistics %in% c("all", stat_names)) ||
+      ("all" %in% statistics && length(statistics) > 1))
+    stop("`statistics` should be either 'all', or one or more of '",
+         paste0(names(res), collapse="', '"), "'.")
+
+  if (statistics == "all")
+    statistics <- stat_names
+  
   disc <- c("pred", "rowIndex", x$levels[-1])
   
   ## Expand the predicted values with the candidate values of
@@ -95,11 +131,11 @@ thresholder <- function(x, threshold, final = TRUE) {
   pred_dat <- ddply(pred_dat, .variables = param, recode)
   
   ## Compute statistics per threshold and tuning parameters
-  pred_stats <- ddply(pred_dat, .variables = param,  stats)
+  pred_stats <- ddply(pred_dat, .variables = param, stats)
   
   ## Summarize over resamples
   pred_resamp <- ddply(pred_stats, .variables = param[-1],
-                       summ_stats)
+                       summ_stats, statistics)
   pred_resamp
 }
 
@@ -126,16 +162,20 @@ recode <- function(dat) {
 stats <- function(dat) {
   tab <- caret::confusionMatrix(dat$pred, dat$obs,
                                 positive = levels(dat$obs)[1])
-  res <- tab$byClass[c("Sensitivity", "Specificity")]
+  res <- c(tab$byClass, tab$overall[c("Accuracy", "Kappa")])
   res <- c(res,
            res["Sensitivity"] + res["Specificity"] - 1,
            sqrt((res["Sensitivity"] - 1) ^ 2 + (res["Specificity"] - 1) ^ 2))
-  names(res)[3:4] <- c("J", "Dist")
+  names(res)[-seq_len(length(res) - 2)] <- c("J", "Dist")
   res
 }
 
-stat_names <- c("Sensitivity", "Specificity", "J", "Dist")
-
-summ_stats <- function(x, cols = stat_names)
-  colMeans(x[, cols, drop = FALSE])
-
+summ_stats <- function(x, cols) {
+  na_cols <- apply(x, 2, function(x) any(is.na(x)))
+  if (any(na_cols))
+    warning("The following columns have missing values (NA), which have been ",
+            "removed: '", paste0(names(na_cols)[na_cols], collapse = "', '"),
+            "'.")
+  print(x)
+  colMeans(x[, cols, drop = FALSE], na.rm = TRUE)
+}

--- a/pkg/caret/R/thresholder.R
+++ b/pkg/caret/R/thresholder.R
@@ -172,10 +172,11 @@ stats <- function(dat) {
 
 summ_stats <- function(x, cols) {
   na_cols <- apply(x, 2, function(x) any(is.na(x)))
-  if (any(na_cols))
+  na_col_names <- colnames(x)[na_cols]
+  relevant_col_names <- intersect(na_col_names, cols)
+  if (length(relevant_col_names) > 0)
     warning("The following columns have missing values (NA), which have been ",
-            "removed: '", paste0(names(na_cols)[na_cols], collapse = "', '"),
+            "removed: '", paste0(relevant_col_names, collapse = "', '"),
             "'.")
-  print(x)
   colMeans(x[, cols, drop = FALSE], na.rm = TRUE)
 }

--- a/pkg/caret/R/thresholder.R
+++ b/pkg/caret/R/thresholder.R
@@ -177,6 +177,6 @@ summ_stats <- function(x, cols) {
   if (length(relevant_col_names) > 0)
     warning("The following columns have missing values (NA), which have been ",
             "removed: '", paste0(relevant_col_names, collapse = "', '"),
-            "'.")
+            "'.\n")
   colMeans(x[, cols, drop = FALSE], na.rm = TRUE)
 }

--- a/pkg/caret/man/thresholder.Rd
+++ b/pkg/caret/man/thresholder.Rd
@@ -4,7 +4,7 @@
 \alias{thresholder}
 \title{Generate Data to Choose a Probability Threshold}
 \usage{
-thresholder(x, threshold, final = TRUE)
+thresholder(x, threshold, final = TRUE, statistics = "all")
 }
 \arguments{
 \item{x}{A \code{\link{train}} object where the values of
@@ -20,21 +20,48 @@ is classified as that level.}
 \item{final}{A logical: should only the final tuning parameters
 chosen by \code{\link{train}} be used when 
 \code{savePredictions = 'all'}?}
+
+\item{statistics}{A character vector indicating which statistics to
+calculate. See details below for possible choices; the default value
+\code{"all"} computes all of these.}
 }
 \value{
 A data frame with columns for each of the tuning parameters
  from the model along with an additional column called
  \code{prob_threshold} for the probability threshold. There are
  also columns for summary statistics averaged over resamples with
- column names \code{Sensitivity}, \code{Specificity}, \code{J},
- \code{Dist}. The last two correspond to Youden's J statistic 
- and the distance to the best possible cutoff (i.e. perfect
- sensitivity and specificity).
+ column names corresponding to the input argument \code{statistics}.
 }
 \description{
 This function uses the resampling results from a \code{\link{train}}
  object to generate performance statistics over a set of probability
  thresholds for two-class problems.
+}
+\details{
+The argument \code{statistics} designates the statistics to compute
+ for each probability threshold. One or more of the following statistics can
+ be selected:
+ \itemize{
+ \item Sensitivity
+ \item Specificity
+ \item Pos Pred Value
+ \item Neg Pred Value
+ \item Precision
+ \item Recall
+ \item F1
+ \item Prevalence
+ \item Detection Rate
+ \item Detection Prevalence
+ \item Balanced Accuracy
+ \item Accuracy
+ \item Kappa
+ \item J
+ \item Dist
+}
+For a description of these statistics (except the last two), see the
+documentation of \code{\link{confusionMatrix}}. The last two statistics
+are Youden's J statistic and the distance to the best possible cutoff (i.e.
+perfect sensitivity and specificity.
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
The function `thresholder` currently computes Sensitivity, Specificity, Youden's J and the distance to the best possible cutoff. However, these may not be the metrics that the user wishes to compare models by. 

Internally, `thresholder` uses `caret::confusionMatrix` which calculates a bunch of other statistics, but throws away all but those above. This pull request enables the user to choose which statistics to compute for each probability cutoff, the options being the same as those calculated in `caret::confusionMatrix`. The default option calculates all statistics from `caret::confusionMatrix`.