### PR TITLE
Remove packages in DESCRIPTION from `r_packages`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,28 +13,8 @@ r:
 r_packages: 
   - covr
   - data.table
-  - ellipse
   - ggplot2
-  - klaR
-  - MASS
-  - mda
-  - mgcv
-  - mlbench
-  - MLmetrics
-  - ModelMetrics
-  - nnet
-  - pamr
-  - party
-  - pls
-  - proxy
-  - randomForest
-  - RANN
   - rARPACK
-  - reshape2
-  - spls
-  - subselect
-  - superpc
-  - testthat
   - xgboost
 
 before_install:


### PR DESCRIPTION
Packages listed in `r_packages` are installed unconditionally, e.g. the package cache has no effect. Therefore when possible you should not put packages in `r_packages` that are already listed in the DESCRIPTION file.