### PR TITLE
Fix bug in zv & corr preProcess

### DIFF
--- a/pkg/caret/R/preProcess.R
+++ b/pkg/caret/R/preProcess.R
@@ -270,7 +270,7 @@ preProcess.default <- function(x, method = c("center", "scale"),
   
   ## check for highly correlated predictors
   if(any(names(method) == "corr")){
-    cmat <- try(cor(x[, !(colnames(x) %in% method$ignore | colnames(x) %in% method$remove), drop = FALSE], 
+    cmat <- try(cor(x[, !(colnames(x) %in% c(method$ignore, method$remove)), drop = FALSE], 
                     use = "pairwise.complete.obs"), 
                 silent = TRUE)
     if(class(cmat)[1] != "try-error") {

--- a/pkg/caret/R/preProcess.R
+++ b/pkg/caret/R/preProcess.R
@@ -270,7 +270,7 @@ preProcess.default <- function(x, method = c("center", "scale"),
   
   ## check for highly correlated predictors
   if(any(names(method) == "corr")){
-    cmat <- try(cor(x[, !(colnames(x) %in% method$ignore), drop = FALSE], 
+    cmat <- try(cor(x[, !(colnames(x) %in% method$ignore | colnames(x) %in% method$remove), drop = FALSE], 
                     use = "pairwise.complete.obs"), 
                 silent = TRUE)
     if(class(cmat)[1] != "try-error") {


### PR DESCRIPTION
In preProcess with methods "zv" and "corr", if there is zero variance variable to remove, it must be taken into account for correlation computation, otherwise correlation fails to compute.