### PR TITLE
add space below kappa in print.confusionMatrix

### DIFF
--- a/pkg/caret/R/confusionMatrix.R
+++ b/pkg/caret/R/confusionMatrix.R
@@ -659,6 +659,7 @@ print.confusionMatrix <- function(x, mode = x$mode, digits = max(3, getOption("d
                      paste(overall[c("AccuracyNull", "AccuracyPValue")]),
                      "",
                      paste(overall["Kappa"]),
+                     "",
                      paste(overall["McnemarPValue"]))
 
     overallNames <- c("Accuracy", "95% CI",
@@ -666,6 +667,7 @@ print.confusionMatrix <- function(x, mode = x$mode, digits = max(3, getOption("d
                       "P-Value [Acc > NIR]",
                       "",
                       "Kappa",
+                      "",
                       "Mcnemar's Test P-Value")
 
     if(dim(x$table)[1] > 2){


### PR DESCRIPTION
As noted in https://github.com/tidymodels/broom/issues/523, the McNamara's test p-value is unrelated to kappa. I've added a space in `print.confusionMatrix` to separate the two for clarity, given that they are separate from accuracy