### PR TITLE
A quick fix of issue #390 partially solved in commit b4f8a87ce516b6f5d9d8a11cfb940a3b696ec5ca (see my recent comments on #390)

### DIFF
--- a/pkg/caret/DESCRIPTION
+++ b/pkg/caret/DESCRIPTION
@@ -15,6 +15,7 @@ Depends:
 URL: https://github.com/topepo/caret/
 BugReports: https://github.com/topepo/caret/issues
 Imports:
+    stringi,
     foreach,
     methods,
     plyr,

--- a/pkg/caret/DESCRIPTION
+++ b/pkg/caret/DESCRIPTION
@@ -15,7 +15,6 @@ Depends:
 URL: https://github.com/topepo/caret/
 BugReports: https://github.com/topepo/caret/issues
 Imports:
-    stringi,
     foreach,
     methods,
     plyr,

--- a/pkg/caret/R/dummyVar.R
+++ b/pkg/caret/R/dummyVar.R
@@ -23,7 +23,7 @@
 #'            1      0      0      0      1      0      0}
 #'
 #' In some situations, there may be a need for dummy variables for all the
-#' levels of the factor. For the same example: 
+#' levels of the factor. For the same example:
 #' \preformatted{ dayMon dayTue dayWed dayThu dayFri daySat daySun
 #'       1      0      0      0      0      0      0
 #'       1      0      0      0      0      0      0
@@ -73,7 +73,7 @@
 #' logical}
 #'
 #' The \code{predict} function produces a data frame.
-#' 
+#'
 #' \code{class2ind} returns a matrix (or a vector if \code{drop2nd = TRUE}).
 #'
 #' \code{contr.ltfr} generates a design matrix.
@@ -122,7 +122,7 @@
 #' predict(noNames, when)
 #'
 #' head(class2ind(iris$Species))
-#' 
+#'
 #' two_levels <- factor(rep(letters[1:2], each = 5))
 #' class2ind(two_levels)
 #' class2ind(two_levels, drop2nd = TRUE)
@@ -140,7 +140,7 @@ dummyVars.default <- function (formula, data, sep = ".", levelsOnly = FALSE, ful
 {
   formula <- as.formula(formula)
   if(!is.data.frame(data)) data <- as.data.frame(data)
-  
+
   vars <- all.vars(formula)
   if(any(vars == "."))
   {
@@ -179,7 +179,7 @@ dummyVars.default <- function (formula, data, sep = ".", levelsOnly = FALSE, ful
               fullRank = fullRank)
   class(out) <- "dummyVars"
   out
-  
+
 }
 
 #' @rdname dummyVars
@@ -224,14 +224,14 @@ predict.dummyVars <- function(object, newdata, na.action = na.pass, ...)
     on.exit(options(contrasts = oldContr))
   }
   m <- model.frame(Terms, newdata, na.action = na.action, xlev = object$lvls)
-  
+
   x <- model.matrix(Terms, m)
-  
+
   if(object$levelsOnly) {
     for(i in object$facVars) {
       for(j in object$lvls[[i]]) {
         from_text <- paste0(i, j)
-        colnames(x) <- gsub(from_text, j, colnames(x), fixed = TRUE)
+        colnames(x)[which(colnames(x) == from_text)] <- stringi::stri_replace_last(str = colnames(x)[which(colnames(x) == from_text)], replacement = j, regex = from_text)
       }
     }
   }
@@ -242,7 +242,9 @@ predict.dummyVars <- function(object, newdata, na.action = na.pass, ...)
       for(j in object$lvls[[i]]) {
         from_text <- paste0(i, j)
         to_text <- paste(i, j, sep = object$sep)
-        cnames <- gsub(from_text, to_text, cnames, fixed = TRUE)
+#        cnames <- gsub(from_text, to_text, cnames, fixed = TRUE)
+#        cnames <- stringi::stri_replace_last(str = cnames, replacement = to_text, regex = from_text)
+        cnames[which(cnames == from_text)] <- stringi::stri_replace_last(str = cnames[which(cnames == from_text)], replacement = to_text, regex = from_text)
       }
     }
   }
@@ -291,7 +293,7 @@ contr.dummy <- function(n, ...)
 #' @rdname dummyVars
 #' @importFrom stats model.matrix
 #' @export
-#' @param drop2nd A logical: if the factor has two levels, should a single binary vector be returned?  
+#' @param drop2nd A logical: if the factor has two levels, should a single binary vector be returned?
 class2ind <- function(x, drop2nd = FALSE) {
   if(!is.factor(x)) stop("'x' should be a factor")
   y <- model.matrix(~ x - 1)

--- a/pkg/caret/R/dummyVar.R
+++ b/pkg/caret/R/dummyVar.R
@@ -242,8 +242,6 @@ predict.dummyVars <- function(object, newdata, na.action = na.pass, ...)
       for(j in object$lvls[[i]]) {
         from_text <- paste0(i, j)
         to_text <- paste(i, j, sep = object$sep)
-#        cnames <- gsub(from_text, to_text, cnames, fixed = TRUE)
-#        cnames <- stringi::stri_replace_last(str = cnames, replacement = to_text, regex = from_text)
         cnames[which(cnames == from_text)] <- stringi::stri_replace_last(str = cnames[which(cnames == from_text)], replacement = to_text, regex = from_text)
       }
     }

--- a/pkg/caret/tests/testthat/test_Dummies.R
+++ b/pkg/caret/tests/testthat/test_Dummies.R
@@ -5,22 +5,22 @@ context('Dummy Variables')
 check_dummies <- function(x, expected = NULL) {
   dfTrain <- data.frame(xf = c('a','b','c'))
   dfTest <- data.frame(xf = c('a','b'))
-  
+
   dummyObj1 <- dummyVars(~., dfTrain)
-  
+
   expected_train <- diag(3)
   colnames(expected_train) <- paste0("xf.", letters[1:3])
   rownames(expected_train) <- paste(1:3)
   expected_test <- expected_train[1:2,]
-  
-  expect_equal(predict(dummyObj1, newdata = dfTrain), 
+
+  expect_equal(predict(dummyObj1, newdata = dfTrain),
                expected_train)
-  expect_equal(predict(dummyObj1, newdata = dfTest), 
-               expected_test)  
-  
+  expect_equal(predict(dummyObj1, newdata = dfTest),
+               expected_test)
+
   ###################################################################
   ## tests related to issue #390
-  
+
   ## from ?dummyVars
   when <- data.frame(time = c("afternoon", "night", "afternoon",
                               "morning", "morning", "morning",
@@ -28,13 +28,13 @@ check_dummies <- function(x, expected = NULL) {
                      day = c("Mon", "Mon", "Mon",
                              "Wed", "Wed", "Fri",
                              "Sat", "Sat", "Fri"))
-  
+
   levels(when$time) <- list(morning="morning",
                             afternoon="afternoon",
                             night="night")
   levels(when$day) <- list(Mon="Mon", Tue="Tue", Wed="Wed", Thu="Thu",
                            Fri="Fri", Sat="Sat", Sun="Sun")
-  
+
   mainEffects <- dummyVars(~ day + time, data = when)
   interactionModel <- dummyVars(~ day + time + day:time,
                                 data = when,
@@ -42,76 +42,87 @@ check_dummies <- function(x, expected = NULL) {
   noNames <- dummyVars(~ day + time + day:time,
                        data = when,
                        levelsOnly = TRUE)
-  
-  
-  exp_main_nomissing <- structure(c(1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
-                                    0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
-                                    0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 
-                                    0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 
-                                    1, 0, 1, 0, 0, 0, 0, 0, 0, 0), 
-                                  .Dim = 9:10, 
+
+
+  exp_main_nomissing <- structure(c(1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                    0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                    0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0,
+                                    0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1,
+                                    1, 0, 1, 0, 0, 0, 0, 0, 0, 0),
+                                  .Dim = 9:10,
                                   .Dimnames = list(
-                                    c("1", "2", "3", "4", "5", "6", "7", "8", "9"), 
-                                    c("day.Mon",  "day.Tue", "day.Wed", "day.Thu", "day.Fri", 
+                                    c("1", "2", "3", "4", "5", "6", "7", "8", "9"),
+                                    c("day.Mon",  "day.Tue", "day.Wed", "day.Thu", "day.Fri",
                                       "day.Sat", "day.Sun", "time.morning", "time.afternoon", "time.night")))
   res_main_nomissing <- predict(mainEffects, when)
   expect_equal(res_main_nomissing,  exp_main_nomissing)
-  
+
   when2 <- when
   when2[1, 1] <- NA
-  
-  exp_main_missing <- structure(c(1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
-                                  0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
-                                  0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 
-                                  0, 0, 0, 0, NA, 0, 0, 1, 1, 1, 1, 0, 0, NA, 0, 1, 0, 0, 0, 0, 
-                                  1, 1, NA, 1, 0, 0, 0, 0, 0, 0, 0), 
-                                .Dim = 9:10, 
+
+  exp_main_missing <- structure(c(1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                  0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                  0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0,
+                                  0, 0, 0, 0, NA, 0, 0, 1, 1, 1, 1, 0, 0, NA, 0, 1, 0, 0, 0, 0,
+                                  1, 1, NA, 1, 0, 0, 0, 0, 0, 0, 0),
+                                .Dim = 9:10,
                                 .Dimnames = list(
-                                  c("1", "2", "3", "4", "5", "6", "7", "8", "9"), 
-                                  c("day.Mon", "day.Tue", "day.Wed", "day.Thu", 
-                                    "day.Fri", "day.Sat", "day.Sun", "time.morning", 
+                                  c("1", "2", "3", "4", "5", "6", "7", "8", "9"),
+                                  c("day.Mon", "day.Tue", "day.Wed", "day.Thu",
+                                    "day.Fri", "day.Sat", "day.Sun", "time.morning",
                                     "time.afternoon", "time.night")))
-  
+
   res_main_missing <- predict(mainEffects, when2)
   expect_equal(res_main_missing,  exp_main_missing)
-  
-  exp_main_omit <- structure(c(1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
-                               0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 
-                               0, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 
-                               1, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0), 
-                             .Dim = c(8L, 10L), 
-                             .Dimnames = list(c("2", "3", "4", "5",  "6", "7", "8", "9"), 
-                                              c("day.Mon", "day.Tue", "day.Wed", "day.Thu", 
-                                                "day.Fri", "day.Sat", "day.Sun", "time.morning", 
+
+  exp_main_omit <- structure(c(1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                               0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
+                               0, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+                               1, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0),
+                             .Dim = c(8L, 10L),
+                             .Dimnames = list(c("2", "3", "4", "5",  "6", "7", "8", "9"),
+                                              c("day.Mon", "day.Tue", "day.Wed", "day.Thu",
+                                                "day.Fri", "day.Sat", "day.Sun", "time.morning",
                                                 "time.afternoon",  "time.night")))
-  res_main_omit <- predict(mainEffects, when2, na.action = na.omit)  
-  expect_equal(res_main_omit,  exp_main_omit)  
-  
+  res_main_omit <- predict(mainEffects, when2, na.action = na.omit)
+  expect_equal(res_main_omit,  exp_main_omit)
+
   ###################################################################
   ## tests related to issue #390
-  
+
   test_data <- data.frame('id' = seq(1,30,1),
                           'fooFactor' = factor(c(rep(1,10), rep(2,10), rep(3,10))),
                           'fooFactorBar' = factor(c(rep(4,10), rep(5,10), rep(6,10))),
                           'fooBarFactor' = factor(c(rep(7,10), rep(8,10), rep(9,10))))
-  
-  foosbars <- dummies <- dummyVars(formula = id ~., 
+
+  foosbars <- dummies <- dummyVars(formula = id ~.,
                                    data = test_data,
                                    sep = '-')
-  
+
   exp_names <- c(paste("fooFactor", 1:3, sep = "-"),
                  paste("fooFactorBar", 4:6, sep = "-"),
                  paste("fooBarFactor", 7:9, sep = "-"))
   res_names <- colnames(predict(foosbars, test_data))
-  expect_equal(exp_names,  res_names)  
- 
-  foosbarsbars <- dummies <- dummyVars(formula = id ~., 
+  expect_equal(exp_names,  res_names)
+
+  foosbarsbars <- dummies <- dummyVars(formula = id ~.,
                                    data = test_data,
                                    sep = '-',
-                                   levelsOnly = TRUE) 
-  
+                                   levelsOnly = TRUE)
+
   exp_names_lvls <- paste(1:9)
   res_names_lvls <- colnames(predict(foosbarsbars, test_data))
-  expect_equal(exp_names_lvls,  res_names_lvls)   
-  
+  expect_equal(exp_names_lvls,  res_names_lvls)
+
 }
+
+
+test_that("Good names for dummies with reocurring patterns", {
+  data = data.frame(matrix(rep(as.factor(sample.int(15, size = 100, replace = TRUE, prob = rep(1/15,15))), 15), ncol = 15))
+  essai_dummyVars = caret::dummyVars(stats::as.formula(paste0("~ ", colnames(data), collapse = "+")), data)
+
+  exp_names_lvls <- apply(expand.grid(paste0("X",1:15), paste0(".",1:15)), 1, paste, collapse="")
+  res_names_lvls <- colnames(predict(essai_dummyVars, data))
+  expect_true(all(exp_names_lvls %in% res_names_lvls))
+})
+


### PR DESCRIPTION
See issue #390 for a MWE.

dummyVars behaves badly when confronted with `colnames` "X1", "X10" which have reocurring patterns in their factor levels, e.g. "1", ... "10" for which `colnames` of the one-hot encoded resulting matrix are "X1.1.1".

This fix adds `stringi` to the Imports list, which is probably overkill, and uses a `which` statement which might result in a performance bottleneck.