### PR TITLE
make more BibTeX-friendly (fixes #1034)

### DIFF
--- a/pkg/caret/DESCRIPTION
+++ b/pkg/caret/DESCRIPTION
@@ -1,6 +1,25 @@
 Package: caret
 Version: 6.0-84
 Title: Classification and Regression Training
+Authors@R: c(
+    person("Max", "Kuhn", role = c("aut", "cre")),
+    person("Jed", "Wing", role = "ctb"),
+	person("Steve", "Weston", role = "ctb"),
+	person("Andre", "Williams", role = "ctb"),
+	person("Chris", "Keefer", role = "ctb"),
+	person("Allan", "Engelhardt", role = "ctb"),
+	person("Tony", "Cooper", role = "ctb"),
+	person("Zachary", "Mayer", role = "ctb"),
+	person("Brenton", "Kenkel", role = "ctb"),
+	person("R Core Team", role = "ctb"),
+	person("Michael", "Benesty", role = "ctb"),
+	person("Reynald", "Lescarbeau", role = "ctb"),
+	person("Andrew", "Ziem", role = "ctb"),
+	person("Luca", "Scrucca", role = "ctb"),
+	person("Yuan", "Tang", role = "ctb"),
+	person("Can", "Candan", role = "ctb"),
+	person("Tyler", "Hunt", role = "ctb")
+    )
 Author: Max Kuhn. Contributions from Jed Wing, Steve Weston, Andre
     Williams, Chris Keefer, Allan Engelhardt, Tony Cooper, Zachary Mayer,
     Brenton Kenkel, the R Core Team, Michael Benesty, Reynald Lescarbeau,

--- a/pkg/caret/R/preProcess.R
+++ b/pkg/caret/R/preProcess.R
@@ -32,7 +32,7 @@ getRangeBounds <- function(pp) {
 #'
 #' The Box-Cox (\code{method = "BoxCox"}), Yeo-Johnson (\code{method =
 #' "YeoJohnson"}), and exponential transformations (\code{method =
-#' "expoTrans"})have been "repurposed" here: they are being used to transform
+#' "expoTrans"}) have been "repurposed" here: they are being used to transform
 #' the predictor variables. The Box-Cox transformation was developed for
 #' transforming the response variable while another method, the Box-Tidwell
 #' transformation, was created to estimate transformations of predictor data.
@@ -40,7 +40,7 @@ getRangeBounds <- function(pp) {
 #' is equally effective for estimating power transformations. The Yeo-Johnson
 #' transformation is similar to the Box-Cox model but can accommodate
 #' predictors with zero and/or negative values (while the predictors values for
-#' the Box-Cox transformation must be strictly positive.) The exponential
+#' the Box-Cox transformation must be strictly positive). The exponential
 #' transformation of Manly (1976) can also be used for positive or negative
 #' data.
 #'

--- a/pkg/caret/man/avNNet.Rd
+++ b/pkg/caret/man/avNNet.Rd
@@ -11,11 +11,11 @@
 avNNet(x, ...)
 
 \method{avNNet}{formula}(formula, data, weights, ..., repeats = 5,
-  bag = FALSE, allowParallel = TRUE, seeds = sample.int(1e+05,
+  bag = FALSE, allowParallel = TRUE, seeds = sample.int(100000,
   repeats), subset, na.action, contrasts = NULL)
 
 \method{avNNet}{default}(x, y, repeats = 5, bag = FALSE,
-  allowParallel = TRUE, seeds = sample.int(1e+05, repeats), ...)
+  allowParallel = TRUE, seeds = sample.int(100000, repeats), ...)
 
 \method{print}{avNNet}(x, ...)
 

--- a/pkg/caret/man/preProcess.Rd
+++ b/pkg/caret/man/preProcess.Rd
@@ -99,7 +99,7 @@ nothing is recomputed when using the \code{predict} function.
 
 The Box-Cox (\code{method = "BoxCox"}), Yeo-Johnson (\code{method =
 "YeoJohnson"}), and exponential transformations (\code{method =
-"expoTrans"})have been "repurposed" here: they are being used to transform
+"expoTrans"}) have been "repurposed" here: they are being used to transform
 the predictor variables. The Box-Cox transformation was developed for
 transforming the response variable while another method, the Box-Tidwell
 transformation, was created to estimate transformations of predictor data.
@@ -107,7 +107,7 @@ However, the Box-Cox method is simpler, more computationally efficient and
 is equally effective for estimating power transformations. The Yeo-Johnson
 transformation is similar to the Box-Cox model but can accommodate
 predictors with zero and/or negative values (while the predictors values for
-the Box-Cox transformation must be strictly positive.) The exponential
+the Box-Cox transformation must be strictly positive). The exponential
 transformation of Manly (1976) can also be used for positive or negative
 data.
 


### PR DESCRIPTION
Uses Authors@R parameter so `citation("caret")` produces better result.

See example DESCRIPTION file from `dplyr`.