### PR TITLE
Fix `varImp()` for `rf` regression model

### DIFF
--- a/models/files/rf.R
+++ b/models/files/rf.R
@@ -32,8 +32,13 @@ modelInfo <- list(label = "Random Forest",
                   },
                   varImp = function(object, ...){
                     varImp <- randomForest::importance(object, ...)
-                    if(object$type == "regression")
-                      varImp <- data.frame(Overall = varImp[,"%IncMSE"])
+                    if(object$type == "regression") {
+                      if("%IncMSE" %in% colnames(varImp)) {
+                        varImp <- data.frame(Overall = varImp[,"%IncMSE"])
+                      } else {
+                        varImp <- data.frame(Overall = varImp[,1])
+                      }
+                    }
                     else {
                       retainNames <- levels(object$y)
                       if(all(retainNames %in% colnames(varImp))) {


### PR DESCRIPTION
This is an alternative approach to issue #872: when `rf` regression model is trained with `importance = FALSE` and `%IncMSE` column is missing in the output we can use an alternative importance score similarly to classification case.

I didn't update `pkg/caret/inst/models/models.RData` intentionally since this binary file can't be properly reviewed and, therefore, IMHO it should be only updated by repository owner or other trusted committer.