### PR TITLE
Train a glmnet model with a sparseMatrix

### DIFF
--- a/models/files/glmnet.R
+++ b/models/files/glmnet.R
@@ -52,20 +52,19 @@ modelInfo <- list(label = "glmnet",
                     ## pass in any model weights
                     if(!is.null(wts)) theDots$weights <- wts
 
-                    if(!(class(x)[1] %in% c("matrix", "sparseMatrix")))
+                    if(!is.matrix(x) && !inherits(x, "sparseMatrix"))
                       x <- Matrix::as.matrix(x)
 
                     modelArgs <- c(list(x = x,
                                         y = y,
                                         alpha = param$alpha),
                                    theDots)
-
                     out <- do.call(glmnet::glmnet, modelArgs)
                     if(!is.na(param$lambda[1])) out$lambdaOpt <- param$lambda[1]
                     out
                   },
                   predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata)) newdata <- Matrix::as.matrix(newdata)
+                    if(!is.matrix(newdata) && !inherits(newdata, "sparseMatrix")) newdata <- Matrix::as.matrix(newdata)
                     if(length(modelFit$obsLevels) < 2) {
                       out <- predict(modelFit, newdata, s = modelFit$lambdaOpt)
                     } else {


### PR DESCRIPTION
This fixes caret's glmnet model object so that sparse matrix objects are not converted to regular matrix anymore. I was experiencing extremely long CV and training times with caret in comparison to vanilla `glmnet::cv.glmnet` with sparse matrix data coming from text2vec.

This problem was mentioned in #474. Caret's code for training and testing a glmnet model currently checks if the input data is a sparse matrix using the `class` function. This is incorrect as sparse matrices from Matrix can be of different classes. For example, my object returned by text2vec is of class `dgCMatrix`. The fix relying on the `inherits` function instead of `class` should work with any sparse matrix returned by the Matrix package.

(Note that I didn't include in the commit the updated binary pkg/caret/inst/models/models.RData generated by models/parseModels.R)