### PR TITLE
accelerated groupKFold

### DIFF
--- a/pkg/caret/R/createDataPartition.R
+++ b/pkg/caret/R/createDataPartition.R
@@ -271,16 +271,18 @@ createTimeSlices <- function(y, initialWindow, horizon = 1, fixedWindow = TRUE, 
 #' @rdname createDataPartition
 #' @export
 groupKFold <- function(group, k = length(unique(group))) {
-  if(k > length(unique(group)))
-    stop(paste("`k` should be less than", length(unique(group))))
-  dat <- data.frame(index = seq(along = group), group = group)
-  groups <- data.frame(group = unique(dat$group))
-  group_folds <- createFolds(groups$group, returnTrain = TRUE, k = k)
-  group_folds <- lapply(group_folds, function(x, y) y[x,,drop = FALSE], y = groups)
-  dat_folds <- lapply(group_folds, function(x, y) merge(x, y), y = dat)
-  lapply(dat_folds, function(x) sort(x$index))
+  g_unique <- unique(group)
+  m <- length(g_unique)
+  if (k > m) {
+    stop("`k` should be less than ", m)
+  }
+  g_folds <- sample(k, size = m, replace = TRUE)
+  # Distribute obs to hold-out
+  out <- split(seq_along(group), g_folds[match(group, g_unique)])
+  names(out) <- paste0("Fold", gsub(" ", "0", format(seq_along(out))))
+  # Switch from hold-out to fold
+  lapply(out, function(z) seq_along(group)[-z])
 }
-
 
 make_resamples <- function(ctrl_obj, outcome) {
   n <- length(outcome)


### PR DESCRIPTION
Implements https://github.com/topepo/caret/issues/1102#issue-527542475

In- and output interface remain unchanged, but the results are not backward compatible as the splits are done differently.