### PR TITLE
Fix "var_seq(..., len=1)" - regression/classification defaults were swapped

### DIFF
--- a/pkg/caret/R/misc.R
+++ b/pkg/caret/R/misc.R
@@ -396,7 +396,7 @@ get_resample_perf.gafs <- function(x) {
 #' @export var_seq
 var_seq <- function(p, classification = FALSE, len = 3) {
   if(len == 1) {
-    tuneSeq <- if(classification) max(floor(p/3), 1) else floor(sqrt(p))
+    tuneSeq <- if(!classification) max(floor(p/3), 1) else floor(sqrt(p))
   } else {
     if(p <= len)
     {


### PR DESCRIPTION
From the `var_seq` documentation:
> If `len = 1`, the defaults from the `randomForest` package are used.

From the `randomForest` documentation:
> Note that the default values are different for classification (sqrt(p) where p is number of variables in 'x') and regression (p/3)

The right values were used, but for the wrong case.