### PR TITLE
Change default objective to 'reg:squarederror' for xgboost models 

### DIFF
--- a/models/files/xgbDART.R
+++ b/models/files/xgbDART.R
@@ -150,7 +150,7 @@ modelInfo <- list(label = "eXtreme Gradient Boosting",
                                                      colsample_bytree = param$colsample_bytree),
                                                 data = x,
                                                 nrounds = param$nrounds,
-                                                objective = "reg:linear",
+                                                objective = "reg:squarederror",
                                                 booster= "dart",
                                                 ...)
                     }

--- a/models/files/xgbLinear.R
+++ b/models/files/xgbLinear.R
@@ -72,7 +72,7 @@ modelInfo <- list(label = "eXtreme Gradient Boosting",
                                                      alpha = param$alpha), 
                                                 data = x,
                                                 nrounds = param$nrounds,
-                                                objective = "reg:linear",
+                                                objective = "reg:squarederror",
                                                 ...)
                     }
                     out

--- a/models/files/xgbTree.R
+++ b/models/files/xgbTree.R
@@ -116,7 +116,7 @@ modelInfo <- list(label = "eXtreme Gradient Boosting",
                                                      subsample = param$subsample),
                                                  data = x,
                                                  nrounds = param$nrounds,
-                                                 objective = "reg:linear",
+                                                 objective = "reg:squarederror",
                                                  ...)
                     }
                     out


### PR DESCRIPTION
To supress reg:linear deprecation warning.

The other option is to just exclude this parameter, since since it's the default anyway for xgboost.train.
 
That would have the benefit of not printing "parameters were provided multiple times" warning should the user try to use a different objective, but it makes the caret usage inconsistent between regression and classification.