### PR TITLE
Correction in mlpKerasDecay for regression

### DIFF
--- a/models/files/mlpKerasDecay.R
+++ b/models/files/mlpKerasDecay.R
@@ -78,7 +78,7 @@ modelInfo <- list(label = "Multilayer Perceptron Network with Weight Decay",
                           units = 1, 
                           activation = 'linear',
                           kernel_regularizer = keras::regularizer_l2(param$lambda)
-                        ) %>% compile(
+                        ) %>% keras::compile(
                           loss = "mean_squared_error",
                           optimizer = keras::optimizer_rmsprop(
                             lr = param$lr,


### PR DESCRIPTION
In line 81, the compile function is called without the prefix keras::
If you try to build a regression model, the following error is returned :
compile function not found

Note :
I tried on my local with the correction and it works now.