### PR TITLE
Sub-Sampling changes

### DIFF
--- a/models/sampling_methods.R
+++ b/models/sampling_methods.R
@@ -4,8 +4,8 @@ sampling_methods <- list(
   up = function(x, y)
     upSample(x, y, list = TRUE),
   smote = function(x, y) {
-    checkInstall("DMwR")
-    library(DMwR)
+    checkInstall("themis")
+    library(themis)
     dat <-
       if (is.data.frame(x)) {
         if (inherits(x, "tbl_df"))
@@ -16,7 +16,7 @@ sampling_methods <- list(
     else
       as.data.frame(x)
     dat$.y <- y
-    dat <- SMOTE(.y ~ ., data = dat)
+    dat <- themis::smote(dat, var = ".y")
     list(x = dat[,!grepl(".y", colnames(dat), fixed = TRUE), drop = FALSE],
          y = dat$.y)
   },

--- a/pkg/caret/DESCRIPTION
+++ b/pkg/caret/DESCRIPTION
@@ -1,81 +1,116 @@
 Package: caret
-Version: 6.0-88
 Title: Classification and Regression Training
-Authors@R: c(
-  person("Max", "Kuhn", role = c("aut", "cre"), email = "mxkuhn@gmail.com"),
-  person("Jed", "Wing", role = "ctb"),
-	person("Steve", "Weston", role = "ctb"),
-	person("Andre", "Williams", role = "ctb"),
-	person("Chris", "Keefer", role = "ctb"),
-	person("Allan", "Engelhardt", role = "ctb"),
-	person("Tony", "Cooper", role = "ctb"),
-	person("Zachary", "Mayer", role = "ctb"),
-	person("Brenton", "Kenkel", role = "ctb"),
-	person("R Core Team", role = "ctb"),
-	person("Michael", "Benesty", role = "ctb"),
-	person("Reynald", "Lescarbeau", role = "ctb"),
-	person("Andrew", "Ziem", role = "ctb"),
-	person("Luca", "Scrucca", role = "ctb"),
-	person("Yuan", "Tang", role = "ctb"),
-	person("Can", "Candan", role = "ctb"),
-	person("Tyler", "Hunt", role = "ctb")
-    )
+Version: 6.0-88
+Authors@R: 
+    c(person(given = "Max",
+             family = "Kuhn",
+             role = c("aut", "cre"),
+             email = "mxkuhn@gmail.com"),
+      person(given = "Jed",
+             family = "Wing",
+             role = "ctb"),
+      person(given = "Steve",
+             family = "Weston",
+             role = "ctb"),
+      person(given = "Andre",
+             family = "Williams",
+             role = "ctb"),
+      person(given = "Chris",
+             family = "Keefer",
+             role = "ctb"),
+      person(given = "Allan",
+             family = "Engelhardt",
+             role = "ctb"),
+      person(given = "Tony",
+             family = "Cooper",
+             role = "ctb"),
+      person(given = "Zachary",
+             family = "Mayer",
+             role = "ctb"),
+      person(given = "Brenton",
+             family = "Kenkel",
+             role = "ctb"),
+      person(given = "R Core Team",
+             role = "ctb"),
+      person(given = "Michael",
+             family = "Benesty",
+             role = "ctb"),
+      person(given = "Reynald",
+             family = "Lescarbeau",
+             role = "ctb"),
+      person(given = "Andrew",
+             family = "Ziem",
+             role = "ctb"),
+      person(given = "Luca",
+             family = "Scrucca",
+             role = "ctb"),
+      person(given = "Yuan",
+             family = "Tang",
+             role = "ctb"),
+      person(given = "Can",
+             family = "Candan",
+             role = "ctb"),
+      person(given = "Tyler",
+             family = "Hunt",
+             role = "ctb"))
 Description: Misc functions for training and plotting classification and
     regression models.
-Depends:
-    R (>= 3.2.0),
-    lattice (>= 0.20),
-    ggplot2
+License: GPL (>= 2)
 URL: https://github.com/topepo/caret/
 BugReports: https://github.com/topepo/caret/issues
+Depends:
+    ggplot2,
+    lattice (>= 0.20),
+    R (>= 3.2.0)
 Imports:
     foreach,
+    grDevices,
     methods,
-    plyr,
     ModelMetrics (>= 1.2.2.2),
     nlme,
+    plyr,
+    pROC,
+    recipes (>= 0.1.10),
     reshape2,
     stats,
     stats4,
     utils,
-    grDevices,
-    recipes (>= 0.1.10),
-    withr (>= 2.0.0),
-    pROC,
+    withr (>= 2.0.0)
 Suggests:
     BradleyTerry2,
+    covr,
+    Cubist,
+    dplyr,
     e1071,
     earth (>= 2.2-3),
+    ellipse,
     fastICA,
     gam (>= 1.15),
     ipred,
     kernlab,
-    knitr,
     klaR,
+    knitr,
     MASS,
-    ellipse,
     Matrix,
     mda,
     mgcv,
     mlbench,
     MLmetrics,
     nnet,
+    pamr,
     party (>= 0.9-99992),
     pls,
     proxy,
     randomForest,
     RANN,
     rmarkdown,
+    rpart,
     spls,
     subselect,
-    pamr,
     superpc,
-    Cubist,
     testthat (>= 0.9.1),
-    rpart,
-    dplyr,
-    covr
-License: GPL (>= 2)
-RoxygenNote: 7.1.1.9001
-VignetteBuilder: knitr
+    themis (>= 0.1.3)
+VignetteBuilder: 
+    knitr
 Encoding: UTF-8
+RoxygenNote: 7.1.2

--- a/pkg/caret/R/misc.R
+++ b/pkg/caret/R/misc.R
@@ -447,7 +447,7 @@ parse_sampling <- function(x, check_install = TRUE) {
                 func = sampling_methods[x][[1]],
                 first = TRUE)
     }
-    pkgs <- switch(x$name, rose = "ROSE", smote = "DMwR", "")
+    pkgs <- switch(x$name, rose = "ROSE", smote = "themis", "")
     if(pkgs != "" & check_install)
       checkInstall(pkgs)
   } else {

--- a/pkg/caret/R/trainControl.R
+++ b/pkg/caret/R/trainControl.R
@@ -92,7 +92,7 @@
 #' sampling that is conducted after resampling (usually to resolve class
 #' imbalances). Values are \code{"none"}, \code{"down"}, \code{"up"},
 #' \code{"smote"}, or \code{"rose"}. The latter two values require the
-#' \pkg{DMwR} and \pkg{ROSE} packages, respectively. This argument can also be
+#' \pkg{themis} and \pkg{ROSE} packages, respectively. This argument can also be
 #' a list to facilitate custom sampling and these details can be found on the
 #' \pkg{caret} package website for sampling (link below).
 #' @param index a list with elements for each resampling iteration. Each list

--- a/pkg/caret/inst/NEWS.Rd
+++ b/pkg/caret/inst/NEWS.Rd
@@ -3,6 +3,15 @@
 \newcommand{\cpkg}{\href{https://CRAN.R-project.org/package=#1}{\pkg{#1}}}
 \newcommand{\issue}{\href{https://github.com/topepo/caret/issues/#1}{(issue #1)}}
 
+
+\section{Changes in version 6.0-89}{
+  \itemize{
+   \item SMOTE subsampling is now computed via the \cpkg{themis} package \issue{1226}.
+
+  }
+}
+
+
 \section{Changes in version 6.0-88}{
   \itemize{
    \item Fixed cases where the "corr" filter was not run in \code{preProcess()}.

--- a/pkg/caret/man/createDataPartition.Rd
+++ b/pkg/caret/man/createDataPartition.Rd
@@ -58,7 +58,7 @@ training set sample}
 \item{skip}{integer, how many (if any) resamples to skip to thin the total
 amount}
 
-\item{group}{a vector of groups whose length matches the number of rows in 
+\item{group}{a vector of groups whose length matches the number of rows in
 the overall data set.}
 }
 \value{
@@ -102,7 +102,7 @@ techniques that move the training and test sets in time.
 \code{createTimeSlices} can create the indices for this type of splitting.
 
 For Group k-fold cross-validation, the data are split such that no group
-is contained in both the modeling and holdout sets. One or more group 
+is contained in both the modeling and holdout sets. One or more group
 could be left out, depending on the value of \code{k}.
 }
 \examples{

--- a/pkg/caret/man/recall.Rd
+++ b/pkg/caret/man/recall.Rd
@@ -97,7 +97,7 @@ See the references for discussions of the statistics.
 lvs <- c("Relevant", "Irrelevant")
 tbl_2_1_pred <- factor(rep(lvs, times = c(42, 58)), levels = lvs)
 tbl_2_1_truth <- factor(c(rep(lvs, times = c(30, 12)),
-                          rep(lvs, times = c(30, 28))),               
+                          rep(lvs, times = c(30, 28))),
                         levels = lvs)
 tbl_2_1 <- table(tbl_2_1_pred, tbl_2_1_truth)
 
@@ -109,7 +109,7 @@ recall(data = tbl_2_1_pred, reference = tbl_2_1_truth, relevant = "Relevant")
 
 tbl_2_2_pred <- factor(rep(lvs, times = c(76, 24)), levels = lvs)
 tbl_2_2_truth <- factor(c(rep(lvs, times = c(56, 20)),
-                          rep(lvs, times = c(12, 12))),               
+                          rep(lvs, times = c(12, 12))),
                         levels = lvs)
 tbl_2_2 <- table(tbl_2_2_pred, tbl_2_2_truth)
 

--- a/pkg/caret/man/sensitivity.Rd
+++ b/pkg/caret/man/sensitivity.Rd
@@ -129,7 +129,7 @@ truth <- factor(rep(lvs, times = c(86, 258)),
 pred <- factor(
                c(
                  rep(lvs, times = c(54, 32)),
-                 rep(lvs, times = c(27, 231))),               
+                 rep(lvs, times = c(27, 231))),
                levels = rev(lvs))
 
 xtab <- table(pred, truth)

--- a/pkg/caret/man/trainControl.Rd
+++ b/pkg/caret/man/trainControl.Rd
@@ -77,7 +77,7 @@ classification models (along with predicted values) in each resample?}
 
 \item{summaryFunction}{a function to compute performance metrics across
 resamples. The arguments to the function should be the same as those in
-\code{\link{defaultSummary}}. Note that if \code{method = "oob"} is used, 
+\code{\link{defaultSummary}}. Note that if \code{method = "oob"} is used,
 this option is ignored and a warning is issued.}
 
 \item{selectionFunction}{the function used to select the optimal tuning
@@ -92,7 +92,7 @@ The type of pre-processing (e.g. center, scaling etc) is passed in via the
 sampling that is conducted after resampling (usually to resolve class
 imbalances). Values are \code{"none"}, \code{"down"}, \code{"up"},
 \code{"smote"}, or \code{"rose"}. The latter two values require the
-\pkg{DMwR} and \pkg{ROSE} packages, respectively. This argument can also be
+\pkg{themis} and \pkg{ROSE} packages, respectively. This argument can also be
 a list to facilitate custom sampling and these details can be found on the
 \pkg{caret} package website for sampling (link below).}
 
@@ -190,11 +190,11 @@ The supported bootstrap methods are:
   \item \code{"boot632"}: the 0.632 bootstrap estimator (Efron, 1983).
   \item \code{"optimism_boot"}: the optimism bootstrap estimator.
     (Efron and Tibshirani, 1994).
-  \item \code{"boot_all"}: all of the above (for efficiency, 
+  \item \code{"boot_all"}: all of the above (for efficiency,
     but "boot" will be used for calculations).
 }
 
-The \code{"boot632"} method should not to be confused with the 0.632+ 
+The \code{"boot632"} method should not to be confused with the 0.632+
 estimator proposed later by the same author.
 
 Note that if \code{index} or \code{indexOut} are specified, the label shown by \code{train} may not be accurate since these arguments supersede the \code{method} argument.

--- a/pkg/caret/tests/testthat/test_recipe_upsample.R
+++ b/pkg/caret/tests/testthat/test_recipe_upsample.R
@@ -1,7 +1,7 @@
 
 library(testthat)
 library(caret)
-library(recipes)
+library(themis)
 
 context('upsampling with recipes')
 
@@ -14,7 +14,7 @@ dat <- twoClassSim(200, intercept = 6)
 
 rec <-
   recipe(Class ~ TwoFactor1 + TwoFactor2 + Linear01, data = dat) %>%
-  step_upsample(Class, seed = 534)
+  themis::step_upsample(Class, seed = 534)
 
 
 test_that("model test", {


### PR DESCRIPTION
Two changes: 

 * `themis::smote()` is now used since `DMwR` is archived/orphaned. 
 * In the new version of `recipes`, `step_upsample()` has been deprecated and removed.  