### PR TITLE
add a ptype element

### DIFF
--- a/pkg/caret/DESCRIPTION
+++ b/pkg/caret/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: caret
 Title: Classification and Regression Training
-Version: 6.0-89
+Version: 6.0-89.9000
 Authors@R: 
     c(person(given = "Max",
              family = "Kuhn",

--- a/pkg/caret/R/misc.R
+++ b/pkg/caret/R/misc.R
@@ -832,4 +832,10 @@ parallel_check <- function(pkg, models) {
   flush.console()
 }
 
+# ------------------------------------------------------------------------------
 
+terms_ptype <- function(x, data) {
+  cols <- attr(x, "variables")[-2]
+  cols <- all.vars(cols)
+  data[0, cols, drop = FALSE]
+}

--- a/pkg/caret/R/train.default.R
+++ b/pkg/caret/R/train.default.R
@@ -308,6 +308,12 @@ train.default <- function(x, y,
                           tuneLength = ifelse(trControl$method == "none", 1, 3)) {
   startTime <- proc.time()
 
+  if (is.vector(x)) {
+    ptype <- NULL
+  } else {
+    ptype <- x[0,,drop = FALSE]
+  }
+
   ## get a seed before packages are loaded or recipes are processed
   rs_seed <- sample.int(.Machine$integer.max, 1L)
 
@@ -900,6 +906,7 @@ train.default <- function(x, y,
                         finalModel = finalModel,
                         preProcess = pp,
                         trainingData = outData,
+                        ptype = ptype,
                         resample = byResample,
                         resampledCM = resampledCM,
                         perfNames = perfNames,
@@ -939,6 +946,7 @@ train.formula <- function (form, data, ..., weights, subset, na.action = na.fail
   m <- eval.parent(m)
   if(nrow(m) < 1) stop("Every row has at least one missing value were found", call. = FALSE)
   Terms <- attr(m, "terms")
+  ptype <- terms_ptype(Terms, data)
   x <- model.matrix(Terms, m, contrasts)
   cons <- attr(x, "contrast")
   int_flag <- grepl("(Intercept)", colnames(x))
@@ -953,6 +961,7 @@ train.formula <- function (form, data, ..., weights, subset, na.action = na.fail
   res$na.action <- attr(m, "na.action")
   res$contrasts <- cons
   res$xlevels <- .getXlevels(Terms, m)
+  res$ptype <- ptype
   if(!is.null(res$trainingData)) {
     ## We re-save the original data from the formula interface
     ## since it has not been converted to dummy variables.

--- a/pkg/caret/inst/NEWS.Rd
+++ b/pkg/caret/inst/NEWS.Rd
@@ -3,6 +3,11 @@
 \newcommand{\cpkg}{\href{https://CRAN.R-project.org/package=#1}{\pkg{#1}}}
 \newcommand{\issue}{\href{https://github.com/topepo/caret/issues/#1}{(issue #1)}}
 
+\section{Changes in devel version}{
+  \itemize{
+   \item A \code{ptype} element was added to \code{train} objects that records the trianing set predictor columns and their types using a zero-row slice.
+   }
+}
 
 \section{Changes in version 6.0-89}{
   \itemize{

--- a/pkg/caret/inst/NEWS.Rd
+++ b/pkg/caret/inst/NEWS.Rd
@@ -3,7 +3,7 @@
 \newcommand{\cpkg}{\href{https://CRAN.R-project.org/package=#1}{\pkg{#1}}}
 \newcommand{\issue}{\href{https://github.com/topepo/caret/issues/#1}{(issue #1)}}
 
-\section{Changes in devel version}{
+\section{Changes in version 6.0-90}{
   \itemize{
    \item A \code{ptype} element was added to \code{train} objects that records the trianing set predictor columns and their types using a zero-row slice.
    }

--- a/pkg/caret/tests/testthat/test_ptypes.R
+++ b/pkg/caret/tests/testthat/test_ptypes.R
@@ -1,0 +1,35 @@
+context('ptypes')
+
+data("Sacramento", package = "caret")
+
+mtcars_0 <- mtcars[0, -1]
+sac_0 <- Sacramento[0, -7]
+wt_0 <- mtcars[0, 6, drop = FALSE]
+
+# ------------------------------------------------------------------------------
+
+none <- trainControl(method = "none")
+
+f_plain <- train(mpg ~ ., data = mtcars, method = "lm", trControl = none)
+f_oned <- train(mpg ~ wt, data = mtcars, method = "lm", trControl = none)
+f_inter <- train(mpg ~ (.)^2, data = mtcars, method = "lm", trControl = none)
+f_dmmy <- train(price ~ ., data = Sacramento, method = "lm", trControl = none)
+
+xy_plain <- train(x = mtcars[, -1], y = mtcars$mpg, method = "lm", trControl = none)
+xy_oned <- train(x = mtcars[, "wt", drop = FALSE], y = mtcars$mpg, method = "lm", trControl = none)
+xy_dmmy <- train(x = Sacramento[, -7], y = Sacramento$price, method = "lm", trControl = none)
+
+# ------------------------------------------------------------------------------
+
+test_that("ptypes for formulas", {
+  expect_equal(f_plain$ptype, mtcars_0)
+  expect_equal(f_oned$ptype, wt_0)
+  expect_equal(f_inter$ptype, mtcars_0)
+  expect_equal(f_dmmy$ptype, sac_0)
+})
+
+test_that("ptypes for formulas", {
+  expect_equal(xy_plain$ptype, mtcars_0)
+  expect_equal(xy_oned$ptype, wt_0)
+  expect_equal(xy_dmmy$ptype, sac_0)
+})


### PR DESCRIPTION
This saves a zero-row slice of the predictors such as 

``` r
mtcars[0, -1]
#>  [1] cyl  disp hp   drat wt   qsec vs   am   gear carb
#> <0 rows> (or 0-length row.names)
str(mtcars[0, -1])
#> 'data.frame':    0 obs. of  10 variables:
#>  $ cyl : num 
#>  $ disp: num 
#>  $ hp  : num 
#>  $ drat: num 
#>  $ wt  : num 
#>  $ qsec: num 
#>  $ vs  : num 
#>  $ am  : num 
#>  $ gear: num 
#>  $ carb: num
```

<sup>Created on 2021-09-30 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>