### PR TITLE
Make sure `gam' method can generate grid of length 1.

### DIFF
--- a/models/files/gam.R
+++ b/models/files/gam.R
@@ -7,7 +7,7 @@ modelInfo <- list(label = "Generalized Additive Model using Splines",
                                           label = c('Feature Selection', 'Method')),
                   grid = function(x, y, len = NULL, search = "grid") {
                     if(search == "grid") {
-                      out <- expand.grid(select = c(TRUE, FALSE), method = "GCV.Cp")
+                      out <- expand.grid(select = c(TRUE, FALSE)[1:min(2,len)], method = "GCV.Cp")
                     } else {
                       out <- data.frame(select = sample(c(TRUE, FALSE), size = len, replace = TRUE),
                                         method = sample(c("GCV.Cp", "ML"), size = len, replace = TRUE))


### PR DESCRIPTION
Currently, the `gam' method gives an error if passed with trainControl(method = "none"). You can see the error here:

rm( list = ls())
n <- 1e3
x <- cbind(x = rnorm(n))
y <- c(x + rnorm(n))
train(x, y, method = "gam", trControl = trainControl(method = "none"))
# Error: Only one model should be specified in tuneGrid with no resampling

Note that the default behavior of `trainControl(method = "none")` is to create a grid of length 1.

However, here the minimal grid it was creating always had length 2, as it was passing both TRUE and FALSE to the parameter `select,' which does not make sense if we want a grid of length 1.

The proposed change makes sure expand.grid will always have length 1, if len = 1.