### PR TITLE
Fix decay value in nnet random grid parameter

### DIFF
--- a/models/files/nnet.R
+++ b/models/files/nnet.R
@@ -11,7 +11,7 @@ modelInfo <- list(label = "Neural Network",
                                          decay = c(0, 10 ^ seq(-1, -4, length = len - 1)))
                     } else {
                       out <- data.frame(size = sample(1:20, size = len, replace = TRUE),
-                                        decay = 10^runif(len, min = -5, 1))
+                                        decay = 10^runif(len, min = -5, -1))
                     }
                     out
                   },


### PR DESCRIPTION
This PR will fix the random grid for `nnet` to generate `decay` value up to 0.1 (`10^-1`) maximum.

Previously, the random grid will generate value between 0.00001 to 10 (`10^1`).

Feel free to close/ignore this PR if the value of 10 as maximum is intended.