### PR TITLE
Update nnet.R

### DIFF
--- a/models/files/nnet.R
+++ b/models/files/nnet.R
@@ -18,17 +18,20 @@ modelInfo <- list(label = "Neural Network",
                   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
                     dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
                     dat$.outcome <- y
+                    linout <- ifelse(is.factor(y), FALSE, TRUE)                    
                     if(!is.null(wts)) {
                       out <- nnet::nnet(.outcome ~ .,
                                         data = dat,
                                         weights = wts,
                                         size = param$size,
                                         decay = param$decay,
+                                        linout = linout,
                                         ...)
                     } else out <- nnet::nnet(.outcome ~ .,
                                              data = dat,
                                              size = param$size,
                                              decay = param$decay,
+                                             linout = linout,
                                              ...)
                     out
                   },


### PR DESCRIPTION
Regressions were not performed correctly, as the output must be linear for regressions. See nnet::nnet(..., linout = T / F): switch for linear output units. Default logistic output units.