### PR TITLE
Update nnet.R - Correct the linout parameter

### DIFF
--- a/models/files/nnet.R
+++ b/models/files/nnet.R
@@ -18,17 +18,20 @@ modelInfo <- list(label = "Neural Network",
                   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
                     dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
                     dat$.outcome <- y
+                    lt <- ifelse(is.factor(y),FALSE,TRUE)
                     if(!is.null(wts)) {
                       out <- nnet::nnet(.outcome ~ .,
                                         data = dat,
                                         weights = wts,
                                         size = param$size,
                                         decay = param$decay,
+                                        linout = lt,
                                         ...)
                     } else out <- nnet::nnet(.outcome ~ .,
                                              data = dat,
                                              size = param$size,
                                              decay = param$decay,
+                                             linout = lt,
                                              ...)
                     out
                   },


### PR DESCRIPTION
Correct the linout parameter for nnet. This is required for regression. If not set, regression performance metrics will be wrong.