### PR TITLE
Fixed bug in nnet wrapper (including avNNet, pcaNNet)

### DIFF
--- a/models/files/avNNet.R
+++ b/models/files/avNNet.R
@@ -19,7 +19,8 @@ modelInfo <- list(label = "Model Averaged Neural Network",
                   },
                   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
                     dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
+                    dat$.outcome <- y                    
+                    lt <- ifelse(is.factor(y),FALSE,TRUE)
                     if(!is.null(wts)) {
                       out <- caret::avNNet(.outcome ~ .,
                                     data = dat,
@@ -27,12 +28,14 @@ modelInfo <- list(label = "Model Averaged Neural Network",
                                     size = param$size,
                                     decay = param$decay,
                                     bag = param$bag,
+                                    linout = lt,
                                     ...)
                     } else out <- caret::avNNet(.outcome ~ .,
                                          data = dat,
                                          size = param$size,
                                          decay = param$decay,
                                          bag = param$bag,
+                                         linout = lt,                                                
                                          ...)
                     out
                   },

--- a/models/files/nnet.R
+++ b/models/files/nnet.R
@@ -18,17 +18,20 @@ modelInfo <- list(label = "Neural Network",
                   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
                     dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
                     dat$.outcome <- y
+                    lt <- ifelse(is.factor(y),FALSE,TRUE)
                     if(!is.null(wts)) {
                       out <- nnet::nnet(.outcome ~ .,
                                         data = dat,
                                         weights = wts,
                                         size = param$size,
                                         decay = param$decay,
+                                        linout = lt,
                                         ...)
                     } else out <- nnet::nnet(.outcome ~ .,
                                              data = dat,
                                              size = param$size,
                                              decay = param$decay,
+                                             linout = lt,
                                              ...)
                     out
                   },

--- a/models/files/pcaNNet.R
+++ b/models/files/pcaNNet.R
@@ -18,6 +18,7 @@ modelInfo <- list(label = "Neural Networks with Feature Extraction",
                   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
                     dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
                     dat$.outcome <- y
+                    lt <- ifelse(is.factor(y),FALSE,TRUE)                    
                     if(!is.null(wts))
                     {
                       out <- caret::pcaNNet(.outcome ~ .,
@@ -25,11 +26,13 @@ modelInfo <- list(label = "Neural Networks with Feature Extraction",
                                           weights = wts,
                                           size = param$size,
                                           decay = param$decay,
+                                          linout = lt,
                                           ...)
                     } else out <- caret::pcaNNet(.outcome ~ .,
                                                 data = dat,
                                                 size = param$size,
                                                 decay = param$decay,
+                                                linout = lt,
                                                 ...)
                     out
                   },


### PR DESCRIPTION
Correct the linout parameter for nnet, avNNet, pcaNNet. This is required for regression. If not set, regression performance metrics will be wrong. 
linout = FALSE # for classification
linout = TRUE # for regression