### PR TITLE
Drop dlply() usage

### DIFF
--- a/pkg/caret/R/createDataPartition.R
+++ b/pkg/caret/R/createDataPartition.R
@@ -144,8 +144,8 @@ createDataPartition <- function (y, times = 1, p = 0.5, list = TRUE, groups = mi
   }
 
   for (j in 1:times) {
-    tmp <- dlply(data.frame(y = y, index = seq(along.with = y)),
-                 .(y), subsample, p = p)
+    tmp <- lapply(split(data.frame(y = y, index = seq_along(y)), seq_along(y)),
+                  subsample, p = p)
     tmp <- sort(as.vector(unlist(tmp)))
     out[[j]] <- tmp
   }

--- a/pkg/caret/R/createDataPartition.R
+++ b/pkg/caret/R/createDataPartition.R
@@ -106,6 +106,7 @@
 #' folds <- groupKFold(groups)
 #' lapply(folds, function(x, y) table(y[x]), y = groups)
 #' @export createDataPartition
+#' @importFrom utils tail
 createDataPartition <- function (y, times = 1, p = 0.5, list = TRUE, groups = min(5, length(y))){
   if(inherits(y, "Surv")) y <- y[,"time"]
   out <- vector(mode = "list", times)
@@ -130,6 +131,15 @@ createDataPartition <- function (y, times = 1, p = 0.5, list = TRUE, groups = mi
       warning(paste("Some classes have a single record (",
                     paste(names(xtab)[xtab  == 1], sep = "", collapse = ", "),
                     ") and these will be selected for the sample"))
+    }
+    # force missing level to come last
+    if (anyNA(y)) {
+      na_sentinel <- paste0(tail(names(xtab), 1L), "___")
+      if (is.factor(y)) {
+        # trying to write a level that's not "registered" won't work.
+        levels(y) <- c(levels(y), na_sentinel)
+      }
+      y[is.na(y)] <- na_sentinel
     }
   }
 

--- a/pkg/caret/R/createDataPartition.R
+++ b/pkg/caret/R/createDataPartition.R
@@ -144,7 +144,7 @@ createDataPartition <- function (y, times = 1, p = 0.5, list = TRUE, groups = mi
   }
 
   for (j in 1:times) {
-    tmp <- lapply(split(data.frame(y = y, index = seq_along(y)), data$y),
+    tmp <- lapply(split(data.frame(y = y, index = seq_along(y)), y),
                   subsample, p = p)
     tmp <- sort(as.vector(unlist(tmp)))
     out[[j]] <- tmp

--- a/pkg/caret/R/createDataPartition.R
+++ b/pkg/caret/R/createDataPartition.R
@@ -144,7 +144,7 @@ createDataPartition <- function (y, times = 1, p = 0.5, list = TRUE, groups = mi
   }
 
   for (j in 1:times) {
-    tmp <- lapply(split(data.frame(y = y, index = seq_along(y)), seq_along(y)),
+    tmp <- lapply(split(data.frame(y = y, index = seq_along(y)), data$y),
                   subsample, p = p)
     tmp <- sort(as.vector(unlist(tmp)))
     out[[j]] <- tmp

--- a/pkg/caret/R/nearZeroVar.R
+++ b/pkg/caret/R/nearZeroVar.R
@@ -151,7 +151,6 @@ nzv <- function (x, freqCut = 95/5, uniqueCut = 10, saveMetrics = FALSE, names =
 
 zeroVar <- function(x)
 {
-  x <- x[,colnames(x) != ".outcome", drop = FALSE]
   which(apply(x, 2, function(x) length(unique(x)) < 2))
 }
 
@@ -159,8 +158,15 @@ zeroVar <- function(x)
 #' @export
 checkConditionalX <- function(x, y)
 {
-  x$.outcome <- y
-  unique(unlist(dlply(x, .(.outcome), zeroVar)))
+  # force NA to be sorted last & kept by split()
+  if (anyNA(y)) {
+    y <- factor(y)
+    old_levels <- levels(y)
+    new_level <- paste0(tail(old_levels, 1L), "___")
+    levels(y) <- c(old_levels, new_level)
+    y[is.na(y)] <- new_level
+  }
+  unique(unlist(lapply(split(x, y), zeroVar)))
 }
 
 #' @rdname nearZeroVar


### PR DESCRIPTION
One step towards removing the long-superseded {plyr} from the package.