### PR TITLE
Add regression tests for confusionMatrix

### DIFF
--- a/pkg/caret/tests/testthat/test_confusionMatrix.R
+++ b/pkg/caret/tests/testthat/test_confusionMatrix.R
@@ -1,9 +1,7 @@
 context('Test confusionMatrix')
-set.seed(442)
-
 
 test_that("Confusion matrix works", {
-  library(caret)
+  set.seed(442)
   train <- twoClassSim(n = 1000, intercept = -8, linearVars = 3,
                        noiseVars = 10, corrVars = 4, corrValue = 0.6)
 
@@ -46,4 +44,125 @@ test_that("Confusion matrix works", {
   mat1 <- as.matrix(cm1$table)
   cm11 <- confusionMatrix(mat1)
   expect_equal(cm1, cm11)
+})
+
+test_that("confusionMatrix.train works with repeatedcv and different norms", {
+  set.seed(442)
+  train_data <- twoClassSim(n = 100, intercept = -8, linearVars = 3,
+                            noiseVars = 10, corrVars = 4, corrValue = 0.6)
+
+  ctrl <- trainControl(method = "repeatedcv", number = 2, repeats = 1,
+                       classProbs = TRUE, savePredictions = TRUE) # savePredictions needed for older caret versions
+
+  knnFit <- train(Class ~ ., data = train_data,
+                     method = "knn",
+                     preProc = c("center", "scale"),
+                     tuneLength = 2,
+                     trControl = ctrl)
+
+  # Test with default norm ("overall")
+  cm_overall <- confusionMatrix(knnFit)
+  expect_s3_class(cm_overall, "confusionMatrix.train")
+  expect_equal(dim(cm_overall$table), c(2, 2))
+  expect_equal(cm_overall$norm, "overall")
+
+  # Test with norm = "average"
+  cm_average <- confusionMatrix(knnFit, norm = "average")
+  expect_s3_class(cm_average, "confusionMatrix.train")
+  expect_equal(dim(cm_average$table), c(2, 2))
+  expect_equal(cm_average$norm, "average")
+
+  # Test with norm = "none"
+  cm_none <- confusionMatrix(knnFit, norm = "none")
+  expect_s3_class(cm_none, "confusionMatrix.train")
+  expect_equal(dim(cm_none$table), c(2, 2))
+  expect_equal(cm_none$norm, "none")
+
+  # Test print method
+  expect_output(print(cm_overall), "Cross-Validated.*percentual average cell counts")
+})
+
+test_that("confusionMatrix.train works with lgocv", {
+  set.seed(442)
+  train_data <- twoClassSim(n = 100, intercept = -8, linearVars = 3,
+                            noiseVars = 10, corrVars = 4, corrValue = 0.6)
+
+  ctrl <- trainControl(method = "lgocv", p = 0.7, number = 3,
+                       classProbs = TRUE, savePredictions = TRUE)
+
+  knnFit <- train(Class ~ ., data = train_data,
+                  method = "knn",
+                  preProc = c("center", "scale"),
+                  tuneLength = 2,
+                  trControl = ctrl)
+
+  cm_lgocv <- confusionMatrix(knnFit)
+  expect_s3_class(cm_lgocv, "confusionMatrix.train")
+  expect_equal(dim(cm_lgocv$table), c(2, 2))
+  expect_equal(cm_lgocv$norm, "overall")
+
+  # Test print method
+  expect_output(print(cm_lgocv), "Repeated Train/Test Splits Estimated")
+})
+
+test_that("confusionMatrix.rfe works with cv and different norms", {
+  skip_if_not_installed("randomForest")
+
+  set.seed(442)
+  # Using iris for simplicity with rfe
+  TrainData <- iris[,1:4]
+  TrainClasses <- iris[,5]
+
+  rfe_ctrl <- rfeControl(method = "cv", number = 2)
+
+  expect_output({
+    rfe_fit <- rfe(TrainData, TrainClasses,
+                   sizes = c(2, 3), # Test with 2 and 3 variables
+                   rfeControl = rfe_ctrl,
+                   metric = "Accuracy",
+                   functions = ldaFuncs)
+  }, "only.*unique complexity parameters in default grid.*Truncating the grid")
+
+  # Test with default norm ("overall")
+  cm_overall <- confusionMatrix(rfe_fit)
+  expect_s3_class(cm_overall, "confusionMatrix.rfe")
+  expect_equal(dim(cm_overall$table), c(3, 3)) # 3 classes in iris
+  expect_equal(cm_overall$norm, "overall")
+
+  # Test with norm = "average"
+  cm_average <- confusionMatrix(rfe_fit, norm = "average")
+  expect_s3_class(cm_average, "confusionMatrix.rfe")
+  expect_equal(dim(cm_average$table), c(3, 3))
+  expect_equal(cm_average$norm, "average")
+
+  # Test with norm = "none"
+  cm_none <- confusionMatrix(rfe_fit, norm = "none")
+  expect_s3_class(cm_none, "confusionMatrix.rfe")
+  expect_equal(dim(cm_none$table), c(3, 3))
+  expect_equal(cm_none$norm, "none")
+
+  # Test print method
+  expect_output(print(cm_overall), "Cross-Validated.*percentual average cell counts")
+})
+
+test_that("confusionMatrix.sbf works with cv and different norms", {
+  set.seed(442)
+  # Using iris for simplicity with sbf
+  TrainData <- iris[,1:4]
+  TrainClasses <- iris[,5]
+
+  sbf_ctrl <- sbfControl(method = "cv", number = 2,
+                         saveDetails = TRUE)
+
+  sbf_fit <- sbf(TrainData, TrainClasses,
+                 sbfControl = sbf_ctrl)
+
+  # Test with default norm ("overall")
+  cm_overall <- confusionMatrix(sbf_fit)
+  expect_s3_class(cm_overall, "confusionMatrix.sbf")
+  expect_equal(dim(cm_overall$table), c(3, 3)) # 3 classes in iris
+  expect_equal(cm_overall$norm, "overall")
+
+  # Test print method
+  expect_output(print(cm_overall), "Cross-Validated.*percentual average cell counts")
 })


### PR DESCRIPTION
Another set of new tests for ensuring code works before/after dropping ddply.

Again, these were mostly generated by Gemini, with required edits by me to be passing on `master`.