### PR TITLE
Fix !all.equal usage to check isTRUE() instead

### DIFF
--- a/pkg/caret/R/confusionMatrix.R
+++ b/pkg/caret/R/confusionMatrix.R
@@ -208,7 +208,7 @@ confusionMatrix.table <- function(data, positive = NULL,
   if(!(mode %in% c("sens_spec", "prec_recall", "everything")))
     stop("`mode` should be either 'sens_spec', 'prec_recall', or 'everything'")
   if(length(dim(data)) != 2) stop("the table must have two dimensions")
-  if(!all.equal(nrow(data), ncol(data))) stop("the table must nrow = ncol")
+  if(!isTRUE(all.equal(nrow(data), ncol(data)))) stop("the table must nrow = ncol")
   if(!isTRUE(all.equal(rownames(data), colnames(data)))) stop("the table must the same classes in the same order")
   if(!is.character(positive) & !is.null(positive)) stop("positive argument must be character")
 

--- a/pkg/caret/R/negPredValue.R
+++ b/pkg/caret/R/negPredValue.R
@@ -29,8 +29,8 @@ function(data, reference, negative = levels(reference)[2], prevalence = NULL, ..
   function(data, negative = rownames(data)[-1], prevalence = NULL, ...)
 {
   ## "truth" in columns, predictions in rows
-  if(!all.equal(nrow(data), ncol(data))) stop("the table must have nrow = ncol")
-  if(!all.equal(rownames(data), colnames(data))) stop("the table must the same groups in the same order")
+  if(!isTRUE(all.equal(nrow(data), ncol(data)))) stop("the table must have nrow = ncol")
+  if(!isTRUE(all.equal(rownames(data), colnames(data)))) stop("the table must the same groups in the same order")
 
   if(nrow(data) > 2)
     {

--- a/pkg/caret/R/posPredValue.R
+++ b/pkg/caret/R/posPredValue.R
@@ -30,8 +30,8 @@ posPredValue <-
   function(data, positive = rownames(data)[1], prevalence = NULL, ...)
 {
   ## "truth" in columns, predictions in rows
-  if(!all.equal(nrow(data), ncol(data))) stop("the table must have nrow = ncol")
-  if(!all.equal(rownames(data), colnames(data))) stop("the table must the same groups in the same order")
+  if(!isTRUE(all.equal(nrow(data), ncol(data)))) stop("the table must have nrow = ncol")
+  if(!isTRUE(all.equal(rownames(data), colnames(data)))) stop("the table must the same groups in the same order")
 
   if(nrow(data) > 2)
     {

--- a/pkg/caret/R/prec_rec.R
+++ b/pkg/caret/R/prec_rec.R
@@ -91,8 +91,8 @@ recall <- function(data, ...) UseMethod("recall")
 #' @rdname recall
 #' @export
 "recall.table" <- function(data, relevant = rownames(data)[1], ...){
-  if(!all.equal(nrow(data), ncol(data))) stop("the table must have nrow = ncol")
-  if(!all.equal(rownames(data), colnames(data))) stop("the table must the same groups in the same order")
+  if(!isTRUE(all.equal(nrow(data), ncol(data)))) stop("the table must have nrow = ncol")
+  if(!isTRUE(all.equal(rownames(data), colnames(data)))) stop("the table must the same groups in the same order")
 
   if(nrow(data) > 2) {
     tmp <- data
@@ -163,9 +163,9 @@ precision.default <- function(data, reference, relevant = levels(reference)[1],
 #' @rdname recall
 #' @export
 precision.table <- function (data, relevant = rownames(data)[1], ...) {
-  if (!all.equal(nrow(data), ncol(data)))
+  if (!isTRUE(all.equal(nrow(data), ncol(data))))
     stop("the table must have nrow = ncol")
-  if (!all.equal(rownames(data), colnames(data)))
+  if (!isTRUE(all.equal(rownames(data), colnames(data))))
     stop("the table must the same groups in the same order")
   if (nrow(data) > 2) {
     tmp <- data

--- a/pkg/caret/R/sensitivity.R
+++ b/pkg/caret/R/sensitivity.R
@@ -168,8 +168,8 @@ sensitivity <-
   function(data, positive = rownames(data)[1], ...)
 {
   ## "truth" in columns, predictions in rows
-  if(!all.equal(nrow(data), ncol(data))) stop("the table must have nrow = ncol")
-  if(!all.equal(rownames(data), colnames(data))) stop("the table must the same groups in the same order")
+  if(!isTRUE(all.equal(nrow(data), ncol(data)))) stop("the table must have nrow = ncol")
+  if(!isTRUE(all.equal(rownames(data), colnames(data)))) stop("the table must the same groups in the same order")
 
   if(nrow(data) > 2)
     {

--- a/pkg/caret/R/specificity.R
+++ b/pkg/caret/R/specificity.R
@@ -38,8 +38,8 @@ function(data, reference, negative = levels(reference)[-1], na.rm = TRUE, ...)
   function(data, negative = rownames(data)[-1], ...)
 {
   ## "truth" in columns, predictions in rows
-  if(!all.equal(nrow(data), ncol(data))) stop("the table must have nrow = ncol")
-  if(!all.equal(rownames(data), colnames(data))) stop("the table must the same groups in the same order")
+  if(!isTRUE(all.equal(nrow(data), ncol(data)))) stop("the table must have nrow = ncol")
+  if(!isTRUE(all.equal(rownames(data), colnames(data)))) stop("the table must the same groups in the same order")
 
   if(nrow(data) > 2)
     {


### PR DESCRIPTION
As surfaced by the new `lintr::all_equal_linter()`.

`all.equal()` returns either `TRUE` or a character vector -- checking `!` will fail in the latter case.