### PR TITLE
Maximize and report weighted metrics when regression weights are provided

### DIFF
--- a/pkg/caret/R/aaa.R
+++ b/pkg/caret/R/aaa.R
@@ -229,5 +229,6 @@ best <- function(x, metric, maximize)
 defaultSummary <- function(data, lev = NULL, model = NULL)
 {
   if(is.character(data$obs)) data$obs <- factor(data$obs, levels = lev)
-  postResample(data[,"pred"], data[,"obs"])
+  postResample(data[, "pred"], data[, "obs"],
+               if(any(names(data) == "weights")) data[, "weights"] else NULL)
 }

--- a/pkg/caret/R/misc.R
+++ b/pkg/caret/R/misc.R
@@ -171,19 +171,56 @@ bagEarthStats <- function(x) getModelInfo("bagEarth", regex = FALSE)[[1]]$oob(x)
 
 #' @importFrom stats complete.cases cor
 #' @export
-R2 <- function(pred, obs, formula = "corr", na.rm = FALSE)
+R2 <- function(pred, obs, formula = "corr", na.rm = FALSE, weights = NULL)
 {
   n <- sum(complete.cases(pred))
-  switch(formula,
-         corr = cor(obs, pred, use = ifelse(na.rm, "complete.obs", "everything"))^2,
-         traditional = 1 - (sum((obs-pred)^2, na.rm = na.rm)/((n-1)*var(obs, na.rm = na.rm))))
+  if(is.null(weights)) {
+    switch(formula,
+           corr = cor(obs, pred, use = ifelse(na.rm, "complete.obs", "everything"))^2,
+           traditional = 1 - (sum((obs-pred)^2, na.rm = na.rm)/((n-1)*var(obs, na.rm = na.rm))))
+  } else {
+    if(length(weights) != length(pred)) stop("`weights` must have the same length as `pred`")
+    if(na.rm) {
+      good <- complete.cases(pred, obs, weights)
+      pred <- pred[good]
+      obs <- obs[good]
+      weights <- weights[good]
+    } else {
+      if(any(!complete.cases(pred, obs, weights))) return(NA_real_)
+    }
+    sum_w <- sum(weights)
+    if(sum_w <= 0) return(NA_real_)
+    w_obs <- weighted.mean(obs, weights)
+    switch(formula,
+           corr = {
+             w_pred <- weighted.mean(pred, weights)
+             var_obs <- sum(weights * (obs - w_obs)^2)/sum_w
+             var_pred <- sum(weights * (pred - w_pred)^2)/sum_w
+             if(var_obs <= 0 || var_pred <= 0) NA_real_ else {
+               cov_w <- sum(weights * (obs - w_obs) * (pred - w_pred))/sum_w
+               (cov_w/sqrt(var_obs * var_pred))^2
+             }
+           },
+           traditional = {
+             sst <- sum(weights * (obs - w_obs)^2)
+             if(sst <= 0) NA_real_ else 1 - (sum(weights * (obs - pred)^2)/sst)
+           })
+  }
 }
 
 #' @export
-RMSE <- function(pred, obs, na.rm = FALSE) sqrt(mean((pred - obs)^2, na.rm = na.rm))
+RMSE <- function(pred, obs, na.rm = FALSE, weights = NULL) {
+  if(is.null(weights)) return(sqrt(mean((pred - obs)^2, na.rm = na.rm)))
+  if(length(weights) != length(pred)) stop("`weights` must have the same length as `pred`")
+  sqrt(weighted.mean((pred - obs)^2, weights, na.rm = na.rm))
+}
 
 #' @export
-MAE <- function(pred, obs, na.rm = FALSE) mean(abs(pred - obs), na.rm = na.rm)
+MAE <- function(pred, obs, na.rm = FALSE, weights = NULL) {
+  if(is.null(weights)) return(mean(abs(pred - obs), na.rm = na.rm))
+  if(length(weights) != length(pred)) stop("`weights` must have the same length as `pred`")
+  weighted.mean(abs(pred - obs), weights, na.rm = na.rm)
+}
 
 #' @importFrom utils capture.output
 partRuleSummary <- function(x)

--- a/pkg/caret/R/postResample.R
+++ b/pkg/caret/R/postResample.R
@@ -81,6 +81,7 @@
 #'  getTrainPerf mnLogLoss R2 RMSE multiClassSummary MAE
 #' @param pred A vector of numeric data (could be a factor)
 #' @param obs A vector of numeric data (could be a factor)
+#' @param weights Optional case weights for regression summaries.
 #' @param data a data frame with columns \code{obs} and
 #'  \code{pred} for the observed and predicted outcomes. For metrics
 #'  that rely on class probabilities, such as
@@ -116,12 +117,14 @@
 #' mnLogLoss(dat, lev = classes)
 #'
 #' @export postResample
-postResample <- function(pred, obs)
+postResample <- function(pred, obs, weights = NULL)
 {
 
   isNA <- is.na(pred)
   pred <- pred[!isNA]
   obs <- obs[!isNA]
+  if(!is.null(weights))
+    weights <- weights[!isNA]
 
   if (!is.factor(obs) && is.numeric(obs))
     {
@@ -129,17 +132,14 @@ postResample <- function(pred, obs)
         {
           out <- rep(NA, 3)
         } else {
-          if(length(unique(pred)) < 2 || length(unique(obs)) < 2)
-            {
-              resamplCor <- NA
-            } else {
-              resamplCor <- try(cor(pred, obs, use = "pairwise.complete.obs"), silent = TRUE)
-              if (inherits(resamplCor, "try-error")) resamplCor <- NA
-            }
-          mse <- mean((pred - obs)^2)
-          mae <- mean(abs(pred - obs))
+          rmse <- try(RMSE(pred, obs, weights = weights), silent = TRUE)
+          if (inherits(rmse, "try-error")) rmse <- NA
+          rsq <- try(R2(pred, obs, formula = "corr", weights = weights), silent = TRUE)
+          if (inherits(rsq, "try-error")) rsq <- NA
+          mae <- try(MAE(pred, obs, weights = weights), silent = TRUE)
+          if (inherits(mae, "try-error")) mae <- NA
 
-          out <- c(sqrt(mse), resamplCor^2, mae)
+          out <- c(rmse, rsq, mae)
         }
       names(out) <- c("RMSE", "Rsquared", "MAE")
     } else {

--- a/pkg/caret/tests/testthat/test_misc.R
+++ b/pkg/caret/tests/testthat/test_misc.R
@@ -12,6 +12,49 @@ test_that("R2 and RMSE are calculating correctly", {
 
 })
 
+test_that("weighted regression summaries are honored", {
+
+  pred <- c(0, 1, 2, 3)
+  obs <- c(0, 1, 3, 2)
+  wts <- c(1, 1, 20, 20)
+
+  w_mean_obs <- weighted.mean(obs, wts)
+  w_mean_pred <- weighted.mean(pred, wts)
+  w_cov <- sum(wts * (obs - w_mean_obs) * (pred - w_mean_pred))/sum(wts)
+  w_var_obs <- sum(wts * (obs - w_mean_obs)^2)/sum(wts)
+  w_var_pred <- sum(wts * (pred - w_mean_pred)^2)/sum(wts)
+  w_rsq <- (w_cov/sqrt(w_var_obs * w_var_pred))^2
+
+  w_rmse <- sqrt(weighted.mean((pred - obs)^2, wts))
+  w_mae <- weighted.mean(abs(pred - obs), wts)
+
+  out <- postResample(pred, obs, weights = wts)
+  expect_equal(unname(out["RMSE"]), w_rmse)
+  expect_equal(unname(out["Rsquared"]), w_rsq)
+  expect_equal(unname(out["MAE"]), w_mae)
+
+  data_out <- defaultSummary(data.frame(obs = obs, pred = pred, weights = wts))
+  expect_equal(unname(data_out["Rsquared"]), w_rsq)
+})
+
+test_that("postResample argument matching remains backward compatible", {
+
+  pred <- c(0, 1, 2, 3)
+  obs <- c(0, 1, 3, 2)
+  wts <- c(1, 1, 20, 20)
+
+  base <- postResample(pred, obs)
+  expect_equal(postResample(pred = pred, obs = obs), base)
+  expect_equal(postResample(obs = obs, pred = pred), base)
+
+  weighted_named <- postResample(pred, obs, weights = wts)
+  weighted_positional <- postResample(pred, obs, wts)
+  weighted_partial <- postResample(pred, obs, w = wts)
+
+  expect_equal(weighted_positional, weighted_named)
+  expect_equal(weighted_partial, weighted_named)
+})
+
 
 test_that("auc calculation is > .5 when Xs provide prediction", {
   skip_if_not_installed("MLmetrics")


### PR DESCRIPTION
Even when models are trained using regression weights, i.e. weights are passed to the function that does the actual training, the metrics computed, maximized/minimized, and reported are unweighted. This breaks optimality guarantees if I am not mistaken, e.g. for MSE you are taking the expectation over a population that your unweighted sample is not representative of. 

`postResample()` used inline unweighted metric calculations and did not route through metric helpers, which were not weight-aware anyway.

`defaultSummary()` also did not consistently pass weights through to regression summaries.

## Steps to reproduce

```r
library(caret)
set.seed(54321)
n <- 120
x <- runif(n, -2, 2)
y <- 2 + 3*x + rnorm(n, sd=.4)
out <- sample(n, 20)
y[out] <- y[out] + rnorm(20, sd=8)     # large-noise points
w <- rep(1, n); w[out] <- 0.02         # downweight those points
df <- data.frame(x=x, y=y, w=w)

ctrl <- trainControl(method="cv", number=5, savePredictions="final")
fit <- train(x=df["x"], y=df$y, method="lm", weights=df$w, trControl=ctrl)
fit_lm <- lm(y ~ x, data=df, weights=w)

folds <- split(fit$pred, fit$pred$Resample)
rmse_u <- mean(vapply(folds, function(d) sqrt(mean((d$pred-d$obs)^2)), numeric(1)))
rmse_w <- mean(vapply(folds, function(d) sqrt(weighted.mean((d$pred-d$obs)^2, d$weights)), numeric(1)))
mae_u  <- mean(vapply(folds, function(d) mean(abs(d$pred-d$obs)), numeric(1)))
mae_w  <- mean(vapply(folds, function(d) weighted.mean(abs(d$pred-d$obs), d$weights), numeric(1)))

cat(sprintf("caret train RMSE: %.6f\n", fit$results$RMSE))
cat(sprintf("caret train MAE : %.6f\n", fit$results$MAE))
cat(sprintf("manual unweighted RMSE: %.6f\n", rmse_u))
cat(sprintf("manual weighted   RMSE: %.6f\n", rmse_w))
cat(sprintf("manual unweighted MAE : %.6f\n", mae_u))
cat(sprintf("manual weighted   MAE : %.6f\n", mae_w))
cat(sprintf("coef caret: %.6f %.6f\n", coef(fit$finalModel)[1], coef(fit$finalModel)[2]))
cat(sprintf("coef lm   : %.6f %.6f\n", coef(fit_lm)[1], coef(fit_lm)[2]))
```

## Behaviur

Script outputs
```
caret train RMSE: 3.145790
caret train MAE : 1.351392
manual unweighted RMSE: 3.145790
manual weighted   RMSE: 0.632988
manual unweighted MAE : 1.351392
manual weighted   MAE : 0.328145
coef caret: 1.967979 3.006252
coef lm   : 1.967979 3.006252
```

## Expected behavior

`caret` metric outputs should match weighted, not unweighted, manual ones.

## Fix

- Added optional weights argument to `postResample()`, `R2()`, `RMSE()`, `MAE()`
- Updated defaultSummary() to pass a weights column (when present) into postResample().
- Updated roxygen docs

## Tests

- Added test_that("weighted regression summaries are honored", ...) in pkg/caret/tests/testthat/test_misc.R.
- Added test_that("postResample argument matching remains backward compatible", ...) in pkg/caret/tests/testthat/test_misc.R.

## Disclaimer

This PR was prepared with assistance from Codex, but I have experience with R so I can conduct more thorough testing if you want. 