### PR TITLE
Remove deprecated context() calls from tests

### DIFF
--- a/tests/testthat/test_BoxCox.R
+++ b/tests/testthat/test_BoxCox.R
@@ -1,5 +1,3 @@
-context('Box Cox transformations')
-
 ###################################################################
 ## Generate data and do BC using the source function to get
 ## expected results

--- a/tests/testthat/test_Dummies.R
+++ b/tests/testthat/test_Dummies.R
@@ -1,5 +1,3 @@
-context('Dummy Variables')
-
 ## Test cases by Josh Brady (doublej2) from issue #344
 
 check_dummies <- function(x, expected = NULL) {

--- a/tests/testthat/test_classDist.R
+++ b/tests/testthat/test_classDist.R
@@ -1,5 +1,3 @@
-context('classDist')
-
 test_that("errors working", {
   trainSet = 1:3
 

--- a/tests/testthat/test_confusionMatrix.R
+++ b/tests/testthat/test_confusionMatrix.R
@@ -1,4 +1,3 @@
-context('Test confusionMatrix')
 set.seed(442)
 
 

--- a/tests/testthat/test_data_spliting.R
+++ b/tests/testthat/test_data_spliting.R
@@ -1,5 +1,3 @@
-context("Data Spliting")
-
 test_that("createTimeSlices works as expected", {
   s1 <- createTimeSlices(1:8, 5, horizon = 1)
   s2 <- createTimeSlices(1:8, 5, horizon = 1, skip = 3)

--- a/tests/testthat/test_gafs.R
+++ b/tests/testthat/test_gafs.R
@@ -1,5 +1,3 @@
-context('gafs')
-
 test_that("gafsControl errors working", {
   expect_error(gafsControl(method = "larry"), "method should be one of")
 

--- a/tests/testthat/test_ggplot.R
+++ b/tests/testthat/test_ggplot.R
@@ -1,4 +1,3 @@
-context("Test ggplot")
 skip_if_not_installed("kernlab")
 
 test_that("ggplot.train correctly orders factors", {

--- a/tests/testthat/test_glmnet_varImp.R
+++ b/tests/testthat/test_glmnet_varImp.R
@@ -1,6 +1,5 @@
 library(caret)
 
-context('Testing varImp')
 
 test_that('glmnet varImp returns non-negative values', {
   skip_on_cran()

--- a/tests/testthat/test_minimal.R
+++ b/tests/testthat/test_minimal.R
@@ -1,4 +1,3 @@
-context('Minimal Tests')
 # fmt: skip
 stats <- caret:::basic2x2Stats(factor(0:1), factor(0:1), pos='1', neg='0')
 expect_equal(stats[['Sensitivity']], 1)

--- a/tests/testthat/test_misc.R
+++ b/tests/testthat/test_misc.R
@@ -1,6 +1,3 @@
-context('misc functions')
-
-
 test_that("R2 and RMSE are calculating correctly", {
   pred <- runif(25)
   obs <- runif(25)

--- a/tests/testthat/test_mnLogLoss.R
+++ b/tests/testthat/test_mnLogLoss.R
@@ -1,5 +1,3 @@
-context('mnLogLoss')
-
 classes <- LETTERS[1:3]
 
 test_dat1 <- data.frame(

--- a/tests/testthat/test_models_bagEarth.R
+++ b/tests/testthat/test_models_bagEarth.R
@@ -2,7 +2,6 @@
 # such as the bagEarth() not returning the right kind of object, that one of
 # the functions (bagEarth, format, predict) crash during normal usage, or that
 # bagEarth cannot model a simplistic kind of linear equation.
-context("earth")
 test_that('bagEarth simple regression', {
   skip_on_cran()
   data <- data.frame(X = 1:100)

--- a/tests/testthat/test_multiclassSummary.R
+++ b/tests/testthat/test_multiclassSummary.R
@@ -1,5 +1,3 @@
-context('multiClassSummary')
-
 test_that("multiClassSummary presenting warnings from train", {
   skip_if_not_installed("MLmetrics")
   skip_if_not_installed("ModelMetrics", "1.2.2.2")

--- a/tests/testthat/test_nearZeroVar.R
+++ b/tests/testthat/test_nearZeroVar.R
@@ -1,5 +1,3 @@
-context("Test nearZeroVar")
-
 test_that("nearZeroVar works properly with foreach", {
   ## shouldn't trigger error
   r <- nearZeroVar(iris, foreach = T)

--- a/tests/testthat/test_preProcess.R
+++ b/tests/testthat/test_preProcess.R
@@ -1,5 +1,3 @@
-context('Test preProcess')
-
 # Helper function
 check.medianImpute <- function(x) {
   # Reference column medians for checks

--- a/tests/testthat/test_preProcess_internals.R
+++ b/tests/testthat/test_preProcess_internals.R
@@ -1,5 +1,3 @@
-context('Test preProcess internals')
-
 test_that("handles situation when there's a single column per transformation", {
   # For the data below, the list of transformations used internally by
   # "preProcess" contains a single related attribute

--- a/tests/testthat/test_preProcess_methods.R
+++ b/tests/testthat/test_preProcess_methods.R
@@ -1,5 +1,3 @@
-context('preProcess/methods')
-
 ###################################################################
 ## test centering and scaling
 

--- a/tests/testthat/test_ptypes.R
+++ b/tests/testthat/test_ptypes.R
@@ -1,5 +1,3 @@
-context('ptypes')
-
 data("Sacramento", package = "caret")
 
 mtcars_0 <- mtcars[0, -1]

--- a/tests/testthat/test_recipe_fs.R
+++ b/tests/testthat/test_recipe_fs.R
@@ -2,7 +2,6 @@ library(testthat)
 library(caret)
 library(recipes)
 
-context('selection with recipes')
 
 # ------------------------------------------------------------------------------
 

--- a/tests/testthat/test_recipe_upsample.R
+++ b/tests/testthat/test_recipe_upsample.R
@@ -1,5 +1,3 @@
-context('upsampling with recipes')
-
 test_that("model test", {
   skip_if_not_installed("themis")
   withr::local_seed(2542)

--- a/tests/testthat/test_safs.R
+++ b/tests/testthat/test_safs.R
@@ -1,5 +1,3 @@
-context('safs')
-
 test_that("safsControl errors working", {
   expect_error(safsControl(method = "larry"), "method should be one of")
 

--- a/tests/testthat/test_sampling_options.R
+++ b/tests/testthat/test_sampling_options.R
@@ -1,7 +1,6 @@
 library(caret)
 library(testthat)
 
-context("sampling options")
 load(system.file("models", "sampling.RData", package = "caret"))
 
 test_that('check appropriate sampling calls by name', {

--- a/tests/testthat/test_sparse_Matrix.R
+++ b/tests/testthat/test_sparse_Matrix.R
@@ -1,5 +1,3 @@
-context("Testing sparse Matrix")
-
 test_that("caret can return sparse Matrix object", {
   skip_on_cran()
   skip_if_not_installed('glmnet')

--- a/tests/testthat/test_spatialSign.R
+++ b/tests/testthat/test_spatialSign.R
@@ -1,5 +1,3 @@
-context('spatialSign')
-
 test_that("errors working", {
   # vector
   expect_error(spatialSign(iris$Species), "not defined")

--- a/tests/testthat/test_twoClassSummary.R
+++ b/tests/testthat/test_twoClassSummary.R
@@ -1,6 +1,3 @@
-context('twoClassSummary testing')
-
-
 test_that("twoClassSummary is calculating correctly", {
   set.seed(1)
   tr_dat <- twoClassSim(100)

--- a/tests/testthat/test_updates.R
+++ b/tests/testthat/test_updates.R
@@ -4,8 +4,6 @@ library(testthat)
 
 # ------------------------------------------------------------------------------
 
-context('updating objects')
-
 diff_coef <- function(x, y) {
   x_nm <- names(x$fit$finalModel$coefficients)
   y_nm <- names(y$fit$finalModel$coefficients)

--- a/tests/testthat/test_varImp.R
+++ b/tests/testthat/test_varImp.R
@@ -1,5 +1,3 @@
-context('varImp')
-
 test_that("high level tests", {
   data(iris)
   TrainData <- iris[, 1:4]

--- a/tests/testthat/trim.R
+++ b/tests/testthat/trim.R
@@ -1,5 +1,3 @@
-context('Test model object trimming')
-
 library(rpart)
 library(ipred)
 


### PR DESCRIPTION
Part of "Overhaul existing tests" (#1418, step 5).

## What
Remove the deprecated `context()` call from all 28 test/helper files in `tests/testthat/`.
## Why
- `context()` is deprecated in testthat edition 3 (enabled in #1442) and emits a deprecation warning on every call — a large share of the warning noise in `devtools::test()`.
- The test file name already documents the context, so `context()` is redundant.
## Notes
- Behavior-only labels removed; no test logic, seeds, or data changed.
- Re-tidied leading/blank lines with `air format`.
- Net: 28 files, 51 deletions, 0 insertions. All files parse; spot-checked `test_misc.R` passes under edition 3.