### PR TITLE
Tests: modern expectations + consistent skip_on_cran()

### DIFF
--- a/tests/testthat/test_BoxCox.R
+++ b/tests/testthat/test_BoxCox.R
@@ -29,8 +29,11 @@ check_BoxCox <- function(x, expected = NULL) {
   expect_equal(obs_lambdas1, expected)
 }
 
-check_BoxCox(dat, expected = exp_lambdas)
-check_BoxCox(
-  as.data.frame(dat, stringsAsFactors = TRUE),
-  expected = exp_lambdas
-)
+test_that("BoxCox lambdas match MASS::boxcox", {
+  skip_on_cran()
+  check_BoxCox(dat, expected = exp_lambdas)
+  check_BoxCox(
+    as.data.frame(dat, stringsAsFactors = TRUE),
+    expected = exp_lambdas
+  )
+})

--- a/tests/testthat/test_Dummies.R
+++ b/tests/testthat/test_Dummies.R
@@ -138,6 +138,7 @@ check_dummies <- function(x, expected = NULL) {
 
 
 test_that("Good names for dummies with reocurring patterns", {
+  skip_on_cran()
   set.seed(176)
   # 200 all but guarantees (99.999% chance) 1:15 all represented, #1350
   data = data.frame(

--- a/tests/testthat/test_classDist.R
+++ b/tests/testthat/test_classDist.R
@@ -1,4 +1,5 @@
 test_that("errors working", {
+  skip_on_cran()
   trainSet = 1:3
 
   expect_snapshot(
@@ -11,6 +12,7 @@ test_that("errors working", {
 })
 
 test_that("Object matches expectations - factor y", {
+  skip_on_cran()
   trainSet <- sample(1:150, 100)
   x = iris[trainSet, 1:4]
   y = iris$Species[trainSet]
@@ -45,6 +47,7 @@ test_that("Object matches expectations - factor y", {
 
 
 test_that("Object matches expectations - numeric y", {
+  skip_on_cran()
   trainSet <- sample(1:150, 100)
   x = iris[trainSet, 1:4]
   y = as.numeric(iris$Species[trainSet])
@@ -74,6 +77,7 @@ test_that("Object matches expectations - numeric y", {
 
 
 test_that("predictions", {
+  skip_on_cran()
   trainSet <- sample(1:150, 100)
   x = iris[trainSet, 1:4]
   y = iris$Species[trainSet]

--- a/tests/testthat/test_confusionMatrix.R
+++ b/tests/testthat/test_confusionMatrix.R
@@ -2,6 +2,7 @@ set.seed(442)
 
 
 test_that("Confusion matrix works", {
+  skip_on_cran()
   library(caret)
   train <- twoClassSim(
     n = 1000,
@@ -38,10 +39,10 @@ test_that("Confusion matrix works", {
   cm2 <- suppressWarnings(confusionMatrix(dat2, ref2))
   cm3 <- suppressWarnings(confusionMatrix(dat3, ref2))
   cm4 <- suppressWarnings(confusionMatrix(dat4, ref2))
-  expect_true(inherits(cm1, "confusionMatrix"))
-  expect_true(inherits(cm2, "confusionMatrix"))
-  expect_true(inherits(cm3, "confusionMatrix"))
-  expect_true(inherits(cm4, "confusionMatrix"))
+  expect_s3_class(cm1, "confusionMatrix")
+  expect_s3_class(cm2, "confusionMatrix")
+  expect_s3_class(cm3, "confusionMatrix")
+  expect_s3_class(cm4, "confusionMatrix")
   expect_snapshot_warning(confusionMatrix(dat2, ref2))
   expect_snapshot_warning(confusionMatrix(dat3, ref2))
   expect_snapshot(confusionMatrix(dat5, ref2), error = TRUE)

--- a/tests/testthat/test_data_spliting.R
+++ b/tests/testthat/test_data_spliting.R
@@ -1,4 +1,5 @@
 test_that("createTimeSlices works as expected", {
+  skip_on_cran()
   s1 <- createTimeSlices(1:8, 5, horizon = 1)
   s2 <- createTimeSlices(1:8, 5, horizon = 1, skip = 3)
   s3 <- createTimeSlices(1:10, 5, horizon = 1, fixedWindow = FALSE, skip = 3)

--- a/tests/testthat/test_gafs.R
+++ b/tests/testthat/test_gafs.R
@@ -1,4 +1,5 @@
 test_that("gafsControl errors working", {
+  skip_on_cran()
   expect_snapshot(gafsControl(method = "larry"), error = TRUE)
 
   expect_snapshot(
@@ -13,6 +14,7 @@ test_that("gafsControl errors working", {
 })
 
 test_that("high level tests", {
+  skip_on_cran()
   expect_silent(pop <- gafs_initial(vars = 10, popSize = 10))
   expect_silent(gafs_lrSelection(population = pop, fitness = 1:10))
   expect_silent(gafs_spCrossover(

--- a/tests/testthat/test_ggplot.R
+++ b/tests/testthat/test_ggplot.R
@@ -1,6 +1,7 @@
 skip_if_not_installed("kernlab")
 
 test_that("ggplot.train correctly orders factors", {
+  skip_on_cran()
   library(caret)
   library(kernlab)
   data(mtcars)
@@ -27,6 +28,7 @@ test_that("ggplot.train correctly orders factors", {
 })
 
 test_that("ggplot.train correctly orders facets' labels", {
+  skip_on_cran()
   library(caret)
   library(kernlab)
   data(mtcars)

--- a/tests/testthat/test_minimal.R
+++ b/tests/testthat/test_minimal.R
@@ -7,6 +7,7 @@ expect_equal(stats[['Neg Pred Value']], 1)
 
 # fmt: skip
 test_that("resampling method 'none' doesn't conflict with default tuneLength", {
+  skip_on_cran()
 
     data(BloodBrain)
 

--- a/tests/testthat/test_misc.R
+++ b/tests/testthat/test_misc.R
@@ -1,4 +1,5 @@
 test_that("R2 and RMSE are calculating correctly", {
+  skip_on_cran()
   pred <- runif(25)
   obs <- runif(25)
 
@@ -8,6 +9,7 @@ test_that("R2 and RMSE are calculating correctly", {
 
 
 test_that("auc calculation is > .5 when Xs provide prediction", {
+  skip_on_cran()
   skip_if_not_installed("MLmetrics")
   skip_if_not_installed("earth")
   skip_if_not_installed("mda")

--- a/tests/testthat/test_mnLogLoss.R
+++ b/tests/testthat/test_mnLogLoss.R
@@ -10,6 +10,7 @@ test_dat1 <- data.frame(
 )
 
 test_that("Multiclass logloss returns expected values", {
+  skip_on_cran()
   result1 <- mnLogLoss(test_dat1, classes)
 
   test_dat2 <- test_dat1
@@ -38,6 +39,7 @@ test_dat1.b <- data.frame(
 )
 
 test_that("Twoclass logloss returns expected values", {
+  skip_on_cran()
   result1 <- mnLogLoss(test_dat1.b, classes.b)
 
   test_dat2.b <- test_dat1.b

--- a/tests/testthat/test_models_bagEarth.R
+++ b/tests/testthat/test_models_bagEarth.R
@@ -8,8 +8,8 @@ test_that('bagEarth simple regression', {
   data$Y <- data$X * 2
   data$training <- data$X %% 2
   fit <- bagEarth(Y ~ X, data = data[1 == data$training, ], B = 3)
-  expect_that(format(fit, cat = FALSE), is_a('character'))
-  expect_that(fit, is_a('bagEarth'))
+  expect_type(format(fit, cat = FALSE), "character")
+  expect_s3_class(fit, "bagEarth")
   data$pred <- predict(fit, newdata = data)
   data$resid <- with(data, Y - pred)
   mae <- mean(abs(data$resid))
@@ -20,19 +20,19 @@ test_that('bagEarth simple classification', {
   skip_on_cran()
   data <- twoClassSim(n = 1000)
   fit <- bagEarth(Class ~ ., data = data, B = 3, glm = list(family = binomial))
-  expect_that(format(fit, cat = FALSE), is_a('character'))
-  expect_that(fit, is_a('bagEarth'))
+  expect_type(format(fit, cat = FALSE), "character")
+  expect_s3_class(fit, "bagEarth")
 
   pred_response <- predict(fit, newdata = data)
-  expect_is(pred_response, "factor")
-  expect_equal(length(pred_response), nrow(data))
+  expect_s3_class(pred_response, "factor")
+  expect_length(pred_response, nrow(data))
 
   pred_class <- predict(fit, newdata = data, type = "class")
-  expect_is(pred_class, "factor")
-  expect_equal(length(pred_class), 1000)
+  expect_s3_class(pred_class, "factor")
+  expect_length(pred_class, 1000)
 
   pred_prob <- predict(fit, newdata = data, type = "prob")
-  expect_is(pred_prob, "data.frame")
+  expect_s3_class(pred_prob, "data.frame")
   expect_equal(ncol(pred_prob), 2)
   expect_equal(nrow(pred_prob), 1000)
   expect_true(0 <= min(pred_prob))

--- a/tests/testthat/test_multiclassSummary.R
+++ b/tests/testthat/test_multiclassSummary.R
@@ -1,4 +1,5 @@
 test_that("multiClassSummary presenting warnings from train", {
+  skip_on_cran()
   skip_if_not_installed("MLmetrics")
   skip_if_not_installed("ModelMetrics", "1.2.2.2")
   library(caret)
@@ -37,6 +38,7 @@ test_that("multiClassSummary presenting warnings from train", {
 })
 
 test_that("multiClassSummary ROC values", {
+  skip_on_cran()
   skip_if_not_installed("MLmetrics")
 
   lvls <- levels(iris$Species)

--- a/tests/testthat/test_nearZeroVar.R
+++ b/tests/testthat/test_nearZeroVar.R
@@ -1,4 +1,5 @@
 test_that("nearZeroVar works properly with foreach", {
+  skip_on_cran()
   ## shouldn't trigger error
   r <- nearZeroVar(iris, foreach = T)
 

--- a/tests/testthat/test_preProcess.R
+++ b/tests/testthat/test_preProcess.R
@@ -31,14 +31,17 @@ x[, 3] <- NA
 colnames(x) <- paste0("Var.", 1:ncol(x))
 
 test_that("median Impute works for matrix with named columns", {
+  skip_on_cran()
   check.medianImpute(x)
 })
 
 test_that("median Impute works for data.frames", {
+  skip_on_cran()
   check.medianImpute(as.data.frame(x, stringsAsFactors = TRUE))
 })
 
 test_that("correlation filter", {
+  skip_on_cran()
   expect_equal(
     preProcess(iris, "corr")$method,
     list(ignore = "Species", remove = "Petal.Length")

--- a/tests/testthat/test_preProcess_internals.R
+++ b/tests/testthat/test_preProcess_internals.R
@@ -1,4 +1,5 @@
 test_that("handles situation when there's a single column per transformation", {
+  skip_on_cran()
   # For the data below, the list of transformations used internally by
   # "preProcess" contains a single related attribute
   # for each transformation; namely, `method=list(center="y", ignore="x")`.

--- a/tests/testthat/test_preProcess_methods.R
+++ b/tests/testthat/test_preProcess_methods.R
@@ -208,8 +208,8 @@ test_that('issue #825 for pca threshold choice', {
 ## test ica
 
 test_that('ICA trans', {
-  skip_if_not_installed("fastICA")
   skip_on_cran()
+  skip_if_not_installed("fastICA")
   set.seed(1)
   ica_dat1 <- twoClassSim(30)[, 1:5]
   ica_dat2 <- twoClassSim(30)[, 1:5]

--- a/tests/testthat/test_ptypes.R
+++ b/tests/testthat/test_ptypes.R
@@ -35,6 +35,7 @@ xy_dmmy <- train(
 # ------------------------------------------------------------------------------
 
 test_that("ptypes for formulas", {
+  skip_on_cran()
   expect_equal(f_plain$ptype, mtcars_0)
   expect_equal(f_oned$ptype, wt_0)
   expect_equal(f_inter$ptype, mtcars_0)
@@ -42,6 +43,7 @@ test_that("ptypes for formulas", {
 })
 
 test_that("ptypes for formulas", {
+  skip_on_cran()
   expect_equal(xy_plain$ptype, mtcars_0)
   expect_equal(xy_oned$ptype, wt_0)
   expect_equal(xy_dmmy$ptype, sac_0)

--- a/tests/testthat/test_recipe_fs.R
+++ b/tests/testthat/test_recipe_fs.R
@@ -13,6 +13,7 @@ x_dat$mw <- log(x_dat$mw)
 # ------------------------------------------------------------------------------
 
 test_that("sbf with recipes", {
+  skip_on_cran()
   ctrl <- sbfControl(functions = lmSBF, method = "cv")
 
   set.seed(3997)
@@ -37,6 +38,7 @@ test_that("sbf with recipes", {
 # ------------------------------------------------------------------------------
 
 test_that("safs with recipes", {
+  skip_on_cran()
   ctrl <- safsControl(functions = caretSA, method = "cv", number = 3)
 
   set.seed(3997)
@@ -77,6 +79,7 @@ test_that("safs with recipes", {
 # ------------------------------------------------------------------------------
 
 test_that("gafs with recipes", {
+  skip_on_cran()
   ctrl <- gafsControl(functions = caretGA, method = "cv", number = 3)
 
   set.seed(3997)

--- a/tests/testthat/test_recipe_upsample.R
+++ b/tests/testthat/test_recipe_upsample.R
@@ -1,4 +1,5 @@
 test_that("model test", {
+  skip_on_cran()
   skip_if_not_installed("themis")
   withr::local_seed(2542)
   dat <- twoClassSim(200, intercept = 6)
@@ -13,8 +14,9 @@ test_that("model test", {
     method = "knn",
     trControl = trainControl(method = "cv")
   )
-  expect_equivalent(
+  expect_equal(
     rep(max(table(dat$Class)), 2),
-    as.vector(table(mod$finalModel$learn$y))
+    as.vector(table(mod$finalModel$learn$y)),
+    ignore_attr = TRUE
   )
 })

--- a/tests/testthat/test_resamples.R
+++ b/tests/testthat/test_resamples.R
@@ -1,6 +1,7 @@
 library(caret)
 
 test_that('resample calculations', {
+  skip_on_cran()
   library(MASS)
   set.seed(4793)
   tr_dat <- SLC14_1(200)
@@ -23,24 +24,41 @@ test_that('resample calculations', {
   rlm_t_test <- t.test(rs$values$`rlm~RMSE`)
 
   rs_plot_dat <- ggplot(rs, metric = "RMSE")$data
-  expect_equivalent(lm_t_test$estimate, rs_plot_dat$Estimate[1])
-  expect_equivalent(rlm_t_test$estimate, rs_plot_dat$Estimate[2])
-  expect_equivalent(lm_t_test$conf.int[1], rs_plot_dat$LowerLimit[1])
-  expect_equivalent(rlm_t_test$conf.int[1], rs_plot_dat$LowerLimit[2])
-  expect_equivalent(lm_t_test$conf.int[2], rs_plot_dat$UpperLimit[1])
-  expect_equivalent(rlm_t_test$conf.int[2], rs_plot_dat$UpperLimit[2])
+  expect_equal(lm_t_test$estimate, rs_plot_dat$Estimate[1], ignore_attr = TRUE)
+  expect_equal(rlm_t_test$estimate, rs_plot_dat$Estimate[2], ignore_attr = TRUE)
+  expect_equal(
+    lm_t_test$conf.int[1],
+    rs_plot_dat$LowerLimit[1],
+    ignore_attr = TRUE
+  )
+  expect_equal(
+    rlm_t_test$conf.int[1],
+    rs_plot_dat$LowerLimit[2],
+    ignore_attr = TRUE
+  )
+  expect_equal(
+    lm_t_test$conf.int[2],
+    rs_plot_dat$UpperLimit[1],
+    ignore_attr = TRUE
+  )
+  expect_equal(
+    rlm_t_test$conf.int[2],
+    rs_plot_dat$UpperLimit[2],
+    ignore_attr = TRUE
+  )
 
   rs_const <- rs
   rs_const$values$`lm~RMSE` <- 3
 
   rs_plot_const_dat <- ggplot(rs_const, metric = "RMSE")$data
-  expect_equivalent(rs_plot_const_dat$Estimate[1], 3.0)
-  expect_equivalent(rs_plot_const_dat$LowerLimit[1], NA_real_)
-  expect_equivalent(rs_plot_const_dat$UpperLimit[1], NA_real_)
+  expect_equal(rs_plot_const_dat$Estimate[1], 3.0, ignore_attr = TRUE)
+  expect_equal(rs_plot_const_dat$LowerLimit[1], NA_real_, ignore_attr = TRUE)
+  expect_equal(rs_plot_const_dat$UpperLimit[1], NA_real_, ignore_attr = TRUE)
 })
 
 
 test_that('test group-k-fold', {
+  skip_on_cran()
   get_data <- function(n = 500) {
     prevalence <- seq(.1, .9, length.out = 26)
     dat <- sample(letters, size = n, replace = TRUE, prob = sample(prevalence))

--- a/tests/testthat/test_safs.R
+++ b/tests/testthat/test_safs.R
@@ -1,4 +1,5 @@
 test_that("safsControl errors working", {
+  skip_on_cran()
   expect_snapshot(safsControl(method = "larry"), error = TRUE)
 
   expect_snapshot(
@@ -17,6 +18,7 @@ test_that("safsControl errors working", {
 })
 
 test_that("high level tests", {
+  skip_on_cran()
   expect_silent(pop <- safs_initial(vars = 10, popSize = 10))
 
   expect_silent(selected_vars <- safs_initial(vars = 10, prob = 0.2))

--- a/tests/testthat/test_sampling_options.R
+++ b/tests/testthat/test_sampling_options.R
@@ -13,7 +13,7 @@ test_that('check appropriate sampling calls by name', {
   for (i in arg_names) {
     out <- caret:::parse_sampling(i, check_install = FALSE)
     expected <- list(name = i, func = sampling_methods[[i]], first = TRUE)
-    expect_equivalent(out, expected)
+    expect_equal(out, expected, ignore_attr = TRUE)
   }
 })
 
@@ -31,7 +31,7 @@ test_that('check appropriate sampling calls by function', {
       func = sampling_methods[[i]],
       first = TRUE
     )
-    expect_equivalent(out, expected)
+    expect_equal(out, expected, ignore_attr = TRUE)
   }
 })
 
@@ -86,7 +86,7 @@ test_that('check call', {
 
 test_that('check getting all methods', {
   skip_on_cran()
-  expect_equivalent(getSamplingInfo(), sampling_methods)
+  expect_equal(getSamplingInfo(), sampling_methods, ignore_attr = TRUE)
 })
 
 test_that('check getting one method', {
@@ -96,7 +96,7 @@ test_that('check getting one method', {
     out <- getSamplingInfo(i, regex = FALSE)
     expected <- list(sampling_methods[[i]])
     names(expected) <- i
-    expect_equivalent(out, expected)
+    expect_equal(out, expected, ignore_attr = TRUE)
   }
 })
 

--- a/tests/testthat/test_spatialSign.R
+++ b/tests/testthat/test_spatialSign.R
@@ -1,4 +1,5 @@
 test_that("errors working", {
+  skip_on_cran()
   # vector
   expect_snapshot(spatialSign(iris$Species), error = TRUE)
 
@@ -10,6 +11,7 @@ test_that("errors working", {
 })
 
 test_that("results match", {
+  skip_on_cran()
   x = -100:100
   expect_true(all(spatialSign(x) == x / sqrt(sum(x^2))))
 
@@ -19,6 +21,7 @@ test_that("results match", {
 
 
 test_that("high level tests", {
+  skip_on_cran()
   i4 <- spatialSign(iris[, 1:4])
 
   expect_true(all(colnames(i4) == names(iris[1:4])))
@@ -27,6 +30,7 @@ test_that("high level tests", {
 
 
 test_that("missing data", {
+  skip_on_cran()
   iris[c(1, 51, 101), 1] <- NA
 
   i5 <- spatialSign(iris[, 1:4])
@@ -34,5 +38,5 @@ test_that("missing data", {
   exp_res <- iris[, 1:4] /
     apply(iris[, 1:4], 1, function(x) sqrt(sum(x^2, na.rm = TRUE)))
 
-  expect_equivalent(i5, as.matrix(exp_res))
+  expect_equal(i5, as.matrix(exp_res), ignore_attr = TRUE)
 })

--- a/tests/testthat/test_tibble.R
+++ b/tests/testthat/test_tibble.R
@@ -19,6 +19,7 @@ ctrl <- trainControl(
 )
 
 test_that('train runs on tibbles and recipes with glm', {
+  skip_on_cran()
   expect_no_error(
     train(
       rec,
@@ -32,6 +33,7 @@ test_that('train runs on tibbles and recipes with glm', {
 })
 
 test_that('train runs on tibbles and formulas with glm', {
+  skip_on_cran()
   expect_no_error(
     train(
       y ~ .,
@@ -45,6 +47,7 @@ test_that('train runs on tibbles and formulas with glm', {
 })
 
 test_that('train runs on tibbles and recipes with glm', {
+  skip_on_cran()
   expect_no_error(
     train(
       rec,
@@ -59,12 +62,14 @@ test_that('train runs on tibbles and recipes with glm', {
 
 
 test_that('downsampling on tibble', {
+  skip_on_cran()
   expect_no_error(
     caret:::parse_sampling("down")$func(dat_tb[, 1], dat_tb$Class)
   )
 })
 
 test_that('upsampling on tibble', {
+  skip_on_cran()
   expect_no_error(
     caret:::parse_sampling("up")$func(dat_tb[, 1], dat_tb$Class)
   )

--- a/tests/testthat/test_twoClassSummary.R
+++ b/tests/testthat/test_twoClassSummary.R
@@ -1,4 +1,5 @@
 test_that("twoClassSummary is calculating correctly", {
+  skip_on_cran()
   set.seed(8225)
   tr_dat <- twoClassSim(100)
   te_dat <- twoClassSim(100)

--- a/tests/testthat/test_updates.R
+++ b/tests/testthat/test_updates.R
@@ -20,6 +20,7 @@ y_ind <- which(names(dat) == "y")
 # ------------------------------------------------------------------------------
 
 test_that("train updating", {
+  skip_on_cran()
   ctrl <- trainControl(method = "cv")
 
   lm_obj_form <- train(
@@ -29,19 +30,20 @@ test_that("train updating", {
     trControl = ctrl
   )
   lm_obj_form_2 <- update(lm_obj_form, list(intercept = FALSE))
-  expect_equal(length(lm_obj_form_2$finalModel$coefficients), 2)
+  expect_length(lm_obj_form_2$finalModel$coefficients, 2)
 
   rec <- recipe(y ~ Var01 + Var02, data = dat) %>%
     step_mutate(Var01 = Var01 / 2)
   lm_obj_rec <- train(rec, data = dat, method = "lm", trControl = ctrl)
   lm_obj_rec_2 <- update(lm_obj_rec, list(intercept = FALSE))
-  expect_equal(length(lm_obj_rec_2$finalModel$coefficients), 2)
+  expect_length(lm_obj_rec_2$finalModel$coefficients, 2)
 })
 
 
 # ------------------------------------------------------------------------------
 
 test_that("safs updating", {
+  skip_on_cran()
   ctrl <- safsControl(functions = caretSA, method = "cv", number = 3)
 
   set.seed(3997)
@@ -83,6 +85,7 @@ test_that("safs updating", {
 # ------------------------------------------------------------------------------
 
 test_that("gafs updating", {
+  skip_on_cran()
   ctrl <- gafsControl(functions = caretGA, method = "cv", number = 3)
 
   set.seed(3997)
@@ -127,6 +130,7 @@ test_that("gafs updating", {
 # ------------------------------------------------------------------------------
 
 test_that("rfe updating", {
+  skip_on_cran()
   ctrl <- rfeControl(functions = caretFuncs, method = "cv", number = 3)
 
   set.seed(3997)
@@ -147,7 +151,7 @@ test_that("rfe updating", {
       y = dat$y
     )
   )
-  expect_equal(length(rfe_xy_2$fit$finalModel$coefficients), 6)
+  expect_length(rfe_xy_2$fit$finalModel$coefficients, 6)
   expect_snapshot(update(rfe_xy, size = 5), error = TRUE)
 
   rec <- recipe(y ~ ., data = dat) %>%
@@ -163,7 +167,7 @@ test_that("rfe updating", {
       trControl = trainControl(method = "none")
     )
   expect_snapshot_warning(rfe_rec_2 <- update(rfe_rec, size = 5))
-  expect_equal(length(rfe_rec_2$fit$finalModel$coefficients), 6)
+  expect_length(rfe_rec_2$fit$finalModel$coefficients, 6)
   rfe_rec$recipe$template <- NULL
   expect_snapshot(update(rfe_rec, size = 5), error = TRUE)
 })

--- a/tests/testthat/test_varImp.R
+++ b/tests/testthat/test_varImp.R
@@ -1,4 +1,5 @@
 test_that("high level tests", {
+  skip_on_cran()
   data(iris)
   TrainData <- iris[, 1:4]
   TrainClasses <- iris[, 5]


### PR DESCRIPTION
Part of the test-suite overhaul (#1418, step 5). Two related items:

## 1. Convert to modern expectations
- `expect_equivalent(a, b)` → `expect_equal(a, b, ignore_attr = TRUE)` (15×)
- `expect_is(x, "cls")` → `expect_s3_class(x, "cls")` (3×)
- `expect_that(x, is_a("cls"))` → `expect_s3_class()` / `expect_type()` (4×)
- `expect_true(inherits(x, "cls"))` → `expect_s3_class(x, "cls")` (4×)
- `expect_equal(length(x), n)` → `expect_length(x, n)` (6×)

## 2. Apply skip_on_cran() consistently
- Added `skip_on_cran()` as the first line of every `test_that()` block that lacked it — 49 blocks across 24 files.
- De-duplicated the ICA block (it already had one, after `skip_if_not_installed`).
- `test_BoxCox.R` had no `test_that` at all (ran via a top-level helper); wrapped its calls in a named `test_that()` so it's covered too.
- Result: all **82** test_that blocks now `skip_on_cran()`.