### PR TITLE
quiet tests and snapshots

### DIFF
--- a/tests/testthat/_snaps/Dummies.md
+++ b/tests/testthat/_snaps/Dummies.md
@@ -1,0 +1,13 @@
+# dummyVars print method
+
+    Code
+      print(dummyVars(~ Species + Sepal.Length, data = iris))
+    Output
+      Dummy Variable Object
+      
+      Formula: ~Species + Sepal.Length
+      <environment>
+      2 variables, 1 factors
+      Variables and levels will be separated by '.'
+      A less than full rank encoding is used
+

--- a/tests/testthat/_snaps/preProcess.md
+++ b/tests/testthat/_snaps/preProcess.md
@@ -6,3 +6,30 @@
 
     These variables are never filled: Var.3
 
+# preProcess print method
+
+    Code
+      print(preProcess(iris[, 1:4], method = c("center", "scale", "pca")))
+    Output
+      Created from 150 samples and 4 variables
+      
+      Pre-processing:
+        - centered (4)
+        - ignored (0)
+        - principal component signal extraction (4)
+        - scaled (4)
+      
+      PCA needed 2 components to capture 95 percent of the variance
+
+---
+
+    Code
+      print(preProcess(iris[, 1:4], method = "range"))
+    Output
+      Created from 150 samples and 4 variables
+      
+      Pre-processing:
+        - ignored (0)
+        - re-scaling to [0, 1] (4)
+      
+

--- a/tests/testthat/helper-startup.R
+++ b/tests/testthat/helper-startup.R
@@ -1,0 +1,7 @@
+# Quietly attach packages that are imported/depended on by caret and used
+# across many tests (so individual test files don't need to load them).
+suppressPackageStartupMessages({
+  library(recipes)
+  library(ggplot2)
+  library(lattice)
+})

--- a/tests/testthat/test_BoxCox.R
+++ b/tests/testthat/test_BoxCox.R
@@ -2,25 +2,10 @@
 ## Generate data and do BC using the source function to get
 ## expected results
 
-suppressPackageStartupMessages(library(MASS))
-
 set.seed(1)
 dat <- matrix(runif(30), ncol = 3)
 dat[, 1] <- exp(dat[, 1])
 colnames(dat) <- paste0("x", 1:3)
-
-exp_lambdas <- rep(NA, 3)
-for (i in 1:ncol(dat)) {
-  tmp <- as.data.frame(dat, stringsAsFactors = TRUE)[, i, drop = FALSE]
-  names(tmp)[1] <- "x"
-  tmp_bc <- boxcox(
-    x ~ 1,
-    data = tmp,
-    plotit = FALSE,
-    lambda = seq(-2, 2, by = .1)
-  )
-  exp_lambdas[i] <- tmp_bc$x[which.max(tmp_bc$y)]
-}
 
 check_BoxCox <- function(x, expected = NULL) {
   pp1 <- preProcess(x, method = "BoxCox")
@@ -31,6 +16,21 @@ check_BoxCox <- function(x, expected = NULL) {
 
 test_that("BoxCox lambdas match MASS::boxcox", {
   skip_on_cran()
+  skip_if_not_installed("MASS")
+
+  exp_lambdas <- rep(NA, 3)
+  for (i in 1:ncol(dat)) {
+    tmp <- as.data.frame(dat, stringsAsFactors = TRUE)[, i, drop = FALSE]
+    names(tmp)[1] <- "x"
+    tmp_bc <- MASS::boxcox(
+      x ~ 1,
+      data = tmp,
+      plotit = FALSE,
+      lambda = seq(-2, 2, by = .1)
+    )
+    exp_lambdas[i] <- tmp_bc$x[which.max(tmp_bc$y)]
+  }
+
   check_BoxCox(dat, expected = exp_lambdas)
   check_BoxCox(
     as.data.frame(dat, stringsAsFactors = TRUE),

--- a/tests/testthat/test_BoxCox.R
+++ b/tests/testthat/test_BoxCox.R
@@ -2,7 +2,7 @@
 ## Generate data and do BC using the source function to get
 ## expected results
 
-library(MASS)
+suppressPackageStartupMessages(library(MASS))
 
 set.seed(1)
 dat <- matrix(runif(30), ncol = 3)

--- a/tests/testthat/test_Dummies.R
+++ b/tests/testthat/test_Dummies.R
@@ -170,3 +170,12 @@ test_that("Good names for dummies with reocurring patterns", {
   res_names_lvls <- colnames(predict(essai_dummyVars, data))
   expect_true(all(exp_names_lvls %in% res_names_lvls))
 })
+
+test_that("dummyVars print method", {
+  skip_on_cran()
+  # scrub the formula's environment address, which is not deterministic
+  expect_snapshot(
+    print(dummyVars(~ Species + Sepal.Length, data = iris)),
+    transform = function(x) sub("<environment: 0x[0-9a-f]+>", "<environment>", x)
+  )
+})

--- a/tests/testthat/test_bad_class_options.R
+++ b/tests/testthat/test_bad_class_options.R
@@ -1,4 +1,4 @@
-library(caret)
+suppressPackageStartupMessages(library(caret))
 
 test_that('bad class levels', {
   skip_on_cran()

--- a/tests/testthat/test_bad_class_options.R
+++ b/tests/testthat/test_bad_class_options.R
@@ -1,5 +1,3 @@
-suppressPackageStartupMessages(library(caret))
-
 test_that('bad class levels', {
   skip_on_cran()
   set.seed(5131)

--- a/tests/testthat/test_confusionMatrix.R
+++ b/tests/testthat/test_confusionMatrix.R
@@ -3,7 +3,7 @@ set.seed(442)
 
 test_that("Confusion matrix works", {
   skip_on_cran()
-  library(caret)
+  suppressPackageStartupMessages(library(caret))
   train <- twoClassSim(
     n = 1000,
     intercept = -8,

--- a/tests/testthat/test_confusionMatrix.R
+++ b/tests/testthat/test_confusionMatrix.R
@@ -3,7 +3,6 @@ set.seed(442)
 
 test_that("Confusion matrix works", {
   skip_on_cran()
-  suppressPackageStartupMessages(library(caret))
   train <- twoClassSim(
     n = 1000,
     intercept = -8,

--- a/tests/testthat/test_ggplot.R
+++ b/tests/testthat/test_ggplot.R
@@ -1,9 +1,6 @@
-skip_if_not_installed("kernlab")
-
 test_that("ggplot.train correctly orders factors", {
   skip_on_cran()
-  suppressPackageStartupMessages(library(caret))
-  suppressPackageStartupMessages(library(kernlab))
+  skip_if_not_installed("kernlab")
   data(mtcars)
   m <- train(
     mpg ~ cyl + disp,
@@ -29,8 +26,7 @@ test_that("ggplot.train correctly orders factors", {
 
 test_that("ggplot.train correctly orders facets' labels", {
   skip_on_cran()
-  suppressPackageStartupMessages(library(caret))
-  suppressPackageStartupMessages(library(kernlab))
+  skip_if_not_installed("kernlab")
   data(mtcars)
   m <- suppressWarnings(train(
     mpg ~ cyl + disp,

--- a/tests/testthat/test_ggplot.R
+++ b/tests/testthat/test_ggplot.R
@@ -2,8 +2,8 @@ skip_if_not_installed("kernlab")
 
 test_that("ggplot.train correctly orders factors", {
   skip_on_cran()
-  library(caret)
-  library(kernlab)
+  suppressPackageStartupMessages(library(caret))
+  suppressPackageStartupMessages(library(kernlab))
   data(mtcars)
   m <- train(
     mpg ~ cyl + disp,
@@ -29,8 +29,8 @@ test_that("ggplot.train correctly orders factors", {
 
 test_that("ggplot.train correctly orders facets' labels", {
   skip_on_cran()
-  library(caret)
-  library(kernlab)
+  suppressPackageStartupMessages(library(caret))
+  suppressPackageStartupMessages(library(kernlab))
   data(mtcars)
   m <- suppressWarnings(train(
     mpg ~ cyl + disp,

--- a/tests/testthat/test_glmnet_varImp.R
+++ b/tests/testthat/test_glmnet_varImp.R
@@ -1,4 +1,4 @@
-library(caret)
+suppressPackageStartupMessages(library(caret))
 
 
 test_that('glmnet varImp returns non-negative values', {

--- a/tests/testthat/test_glmnet_varImp.R
+++ b/tests/testthat/test_glmnet_varImp.R
@@ -1,6 +1,3 @@
-suppressPackageStartupMessages(library(caret))
-
-
 test_that('glmnet varImp returns non-negative values', {
   skip_on_cran()
   skip_if_not_installed('glmnet')

--- a/tests/testthat/test_misc.R
+++ b/tests/testthat/test_misc.R
@@ -33,8 +33,6 @@ test_that("auc calculation is > .5 when Xs provide prediction", {
 
   expect_true(all(knnFit$resample$AUC > .5))
 
-  suppressPackageStartupMessages(library(caret))
-
   set.seed(7686)
   tr_dat <- twoClassSim(200)
   te_dat <- tr_dat

--- a/tests/testthat/test_misc.R
+++ b/tests/testthat/test_misc.R
@@ -33,7 +33,7 @@ test_that("auc calculation is > .5 when Xs provide prediction", {
 
   expect_true(all(knnFit$resample$AUC > .5))
 
-  library(caret)
+  suppressPackageStartupMessages(library(caret))
 
   set.seed(7686)
   tr_dat <- twoClassSim(200)

--- a/tests/testthat/test_multiclassSummary.R
+++ b/tests/testthat/test_multiclassSummary.R
@@ -2,7 +2,7 @@ test_that("multiClassSummary presenting warnings from train", {
   skip_on_cran()
   skip_if_not_installed("MLmetrics")
   skip_if_not_installed("ModelMetrics", "1.2.2.2")
-  library(caret)
+  suppressPackageStartupMessages(library(caret))
   N = 1000
 
   M = 2

--- a/tests/testthat/test_multiclassSummary.R
+++ b/tests/testthat/test_multiclassSummary.R
@@ -2,7 +2,6 @@ test_that("multiClassSummary presenting warnings from train", {
   skip_on_cran()
   skip_if_not_installed("MLmetrics")
   skip_if_not_installed("ModelMetrics", "1.2.2.2")
-  suppressPackageStartupMessages(library(caret))
   N = 1000
 
   M = 2

--- a/tests/testthat/test_preProcess.R
+++ b/tests/testthat/test_preProcess.R
@@ -47,3 +47,11 @@ test_that("correlation filter", {
     list(ignore = "Species", remove = "Petal.Length")
   )
 })
+
+test_that("preProcess print method", {
+  skip_on_cran()
+  expect_snapshot(
+    print(preProcess(iris[, 1:4], method = c("center", "scale", "pca")))
+  )
+  expect_snapshot(print(preProcess(iris[, 1:4], method = "range")))
+})

--- a/tests/testthat/test_recipe_fs.R
+++ b/tests/testthat/test_recipe_fs.R
@@ -1,6 +1,6 @@
-library(testthat)
-library(caret)
-library(recipes)
+suppressPackageStartupMessages(library(testthat))
+suppressPackageStartupMessages(library(caret))
+suppressPackageStartupMessages(library(recipes))
 
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test_recipe_fs.R
+++ b/tests/testthat/test_recipe_fs.R
@@ -1,8 +1,3 @@
-suppressPackageStartupMessages(library(testthat))
-suppressPackageStartupMessages(library(caret))
-suppressPackageStartupMessages(library(recipes))
-
-
 # ------------------------------------------------------------------------------
 
 data(BloodBrain)

--- a/tests/testthat/test_resamples.R
+++ b/tests/testthat/test_resamples.R
@@ -1,8 +1,8 @@
-library(caret)
+suppressPackageStartupMessages(library(caret))
 
 test_that('resample calculations', {
   skip_on_cran()
-  library(MASS)
+  suppressPackageStartupMessages(library(MASS))
   set.seed(4793)
   tr_dat <- SLC14_1(200)
 

--- a/tests/testthat/test_resamples.R
+++ b/tests/testthat/test_resamples.R
@@ -1,8 +1,6 @@
-suppressPackageStartupMessages(library(caret))
-
 test_that('resample calculations', {
   skip_on_cran()
-  suppressPackageStartupMessages(library(MASS))
+  skip_if_not_installed("MASS")
   set.seed(4793)
   tr_dat <- SLC14_1(200)
 

--- a/tests/testthat/test_sampling_options.R
+++ b/tests/testthat/test_sampling_options.R
@@ -1,5 +1,5 @@
-library(caret)
-library(testthat)
+suppressPackageStartupMessages(library(caret))
+suppressPackageStartupMessages(library(testthat))
 
 load(system.file("models", "sampling.RData", package = "caret"))
 

--- a/tests/testthat/test_sampling_options.R
+++ b/tests/testthat/test_sampling_options.R
@@ -1,6 +1,3 @@
-suppressPackageStartupMessages(library(caret))
-suppressPackageStartupMessages(library(testthat))
-
 load(system.file("models", "sampling.RData", package = "caret"))
 
 test_that('check appropriate sampling calls by name', {

--- a/tests/testthat/test_tibble.R
+++ b/tests/testthat/test_tibble.R
@@ -1,7 +1,7 @@
-library(caret)
-library(recipes)
-library(dplyr)
-library(testthat)
+suppressPackageStartupMessages(library(caret))
+suppressPackageStartupMessages(library(recipes))
+suppressPackageStartupMessages(library(dplyr))
+suppressPackageStartupMessages(library(testthat))
 
 set.seed(8801)
 dat <- twoClassSim(100)

--- a/tests/testthat/test_tibble.R
+++ b/tests/testthat/test_tibble.R
@@ -1,11 +1,5 @@
-suppressPackageStartupMessages(library(caret))
-suppressPackageStartupMessages(library(recipes))
-suppressPackageStartupMessages(library(dplyr))
-suppressPackageStartupMessages(library(testthat))
-
 set.seed(8801)
 dat <- twoClassSim(100)
-dat_tb <- as_tibble(dat)
 a <- dat[, 5]
 y <- dat[["Class"]]
 df <- data.frame(a, y, stringsAsFactors = TRUE)
@@ -20,10 +14,11 @@ ctrl <- trainControl(
 
 test_that('train runs on tibbles and recipes with glm', {
   skip_on_cran()
+  skip_if_not_installed("dplyr")
   expect_no_error(
     train(
       rec,
-      data = as_tibble(df),
+      data = dplyr::as_tibble(df),
       method = "glm",
       family = "binomial",
       metric = "ROC",
@@ -34,10 +29,11 @@ test_that('train runs on tibbles and recipes with glm', {
 
 test_that('train runs on tibbles and formulas with glm', {
   skip_on_cran()
+  skip_if_not_installed("dplyr")
   expect_no_error(
     train(
       y ~ .,
-      data = as_tibble(df),
+      data = dplyr::as_tibble(df),
       method = "glm",
       family = "binomial",
       metric = "ROC",
@@ -48,10 +44,11 @@ test_that('train runs on tibbles and formulas with glm', {
 
 test_that('train runs on tibbles and recipes with glm', {
   skip_on_cran()
+  skip_if_not_installed("dplyr")
   expect_no_error(
     train(
       rec,
-      data = as_tibble(df),
+      data = dplyr::as_tibble(df),
       method = "glm",
       family = "binomial",
       metric = "ROC",
@@ -63,6 +60,8 @@ test_that('train runs on tibbles and recipes with glm', {
 
 test_that('downsampling on tibble', {
   skip_on_cran()
+  skip_if_not_installed("dplyr")
+  dat_tb <- dplyr::as_tibble(dat)
   expect_no_error(
     caret:::parse_sampling("down")$func(dat_tb[, 1], dat_tb$Class)
   )
@@ -70,6 +69,8 @@ test_that('downsampling on tibble', {
 
 test_that('upsampling on tibble', {
   skip_on_cran()
+  skip_if_not_installed("dplyr")
+  dat_tb <- dplyr::as_tibble(dat)
   expect_no_error(
     caret:::parse_sampling("up")$func(dat_tb[, 1], dat_tb$Class)
   )

--- a/tests/testthat/test_twoClassSummary.R
+++ b/tests/testthat/test_twoClassSummary.R
@@ -9,7 +9,7 @@ test_that("twoClassSummary is calculating correctly", {
   te_prob <- as.data.frame(te_prob, stringsAsFactors = TRUE)
 
   cm <- caret::confusionMatrix(te_pred, te_dat$Class)
-  library(pROC)
+  suppressPackageStartupMessages(library(pROC))
   roc_crv <- pROC::roc(
     te_dat$Class,
     te_prob$Class1,

--- a/tests/testthat/test_twoClassSummary.R
+++ b/tests/testthat/test_twoClassSummary.R
@@ -9,7 +9,6 @@ test_that("twoClassSummary is calculating correctly", {
   te_prob <- as.data.frame(te_prob, stringsAsFactors = TRUE)
 
   cm <- caret::confusionMatrix(te_pred, te_dat$Class)
-  suppressPackageStartupMessages(library(pROC))
   roc_crv <- pROC::roc(
     te_dat$Class,
     te_prob$Class1,

--- a/tests/testthat/test_updates.R
+++ b/tests/testthat/test_updates.R
@@ -1,7 +1,3 @@
-suppressPackageStartupMessages(library(recipes))
-suppressPackageStartupMessages(library(caret))
-suppressPackageStartupMessages(library(testthat))
-
 # ------------------------------------------------------------------------------
 
 diff_coef <- function(x, y) {

--- a/tests/testthat/test_updates.R
+++ b/tests/testthat/test_updates.R
@@ -1,6 +1,6 @@
-library(recipes)
-library(caret)
-library(testthat)
+suppressPackageStartupMessages(library(recipes))
+suppressPackageStartupMessages(library(caret))
+suppressPackageStartupMessages(library(testthat))
 
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
1. Snapshot testing where output is static.
2. No stray printed output in devtools::test(),  wrapping library() in suppressPackageStartupMessages() removes the banner, leaving only the test results.
