### PR TITLE
fix compiler warnings (June 2026 edition)

### DIFF
--- a/src/caret.c
+++ b/src/caret.c
@@ -23,7 +23,7 @@ knn3(Sint *kin, Sint *lin, Sint *pntr, Sint *pnte, Sint *p,
        double *train, Sint *class, double *test,
        Sint *votes, Sint *nc, Sint *cv, Sint *use_all,double *all_vote)
 {
-    int   i, index, j, k, k1, kinit = *kin, kn, l = *lin, mm, npat, ntie,
+    int   i, j, k, k1, kinit = *kin, kn, l = *lin, mm, npat, ntie,
           ntr = *pntr, nte = *pnte, extras;
     int   pos[MAX_TIES], nclass[MAX_TIES];
     int   j1, j2, needed, t;
@@ -114,15 +114,13 @@ knn3(Sint *kin, Sint *lin, Sint *pntr, Sint *pnte, Sint *p,
 	    mm = l - 1 + extras;
 	else
 	    mm = 0;
-	index = 0;
 	for (i = 1; i <= *nc; i++){
 	    if (votes[i] > mm) {
 		ntie = 1;
-		index = i;
 		mm = votes[i];
 	    } else if (votes[i] == mm && votes[i] >= l) {
-		if (++ntie * UNIF < 1.0)
-		    index = i;
+		/* consume an RNG draw to preserve tie-breaking behavior */
+		(void) (++ntie * UNIF < 1.0);
 	    }
 
 		all_vote[npat*(*nc) + (i-1)] = (double)votes[i]/(kinit+extras);
@@ -184,7 +182,7 @@ knn3reg(Sint *kin, Sint *pntr, Sint *pnte, Sint *p,
 								error("too many ties in knn");
 						break;
 					}
-					nndist[kn] = 0.99 * DBL_MAX;
+			nndist[kn] = 0.99 * DBL_MAX;
 		}
 
 		if (*use_all) {


### PR DESCRIPTION
We were getting these warnings: 

```
caret.c:26:14: warning: variable 'index' set but not used [-Wunused-but-set-variable]
   26 |     int   i, index, j, k, k1, kinit = *kin, kn, l = *lin, mm, npat, ntie,
      |              ^
caret.c:187:6: warning: misleading indentation; statement is not part of the previous 'for' [-Wmisleading-indentation]
  187 |                                         nndist[kn] = 0.99 * DBL_MAX;
      |                                         ^
caret.c:173:5: note: previous statement is here
  173 |                                 for (k = 0; k <= kn; k++)
      |
```

Solutions: 

The index variable tracked the winning class during tie-breaking, but its value was never read. The function returns vote proportions via `all_vote`, not a single predicted class. The declaration and the three assignments were removed. Critically, the tie-break branch still performed an RNG draw (`++ntie * UNIF`), so a draw with `(void) (++ntie * UNIF < 1.0);` was preserved to keep the random-number stream bit-for-bit identical. `mm` and `ntie` are still updated as before.

`nndist[kn] = 0.99 * DBL_MAX;` was indented with 5 tabs, making it look like the body of the `for (k...)` loop when it actually runs once per outer for `(j...)` iteration. It was de-indented to 3 tabs to match the loop-body level. 

After these changes, there is a different warning: 

```
/Library/Frameworks/R.framework/Versions/4.6/Resources/include/R_ext/Boolean.h:66:16: warning: enumeration types with a fixed underlying type are a C23 extension [-Wc23-extensions]
      66 |   typedef enum :int { FALSE = 0, TRUE } Rboolean;  // so NOT NA
         |                ^~~~
```

I don't know if this is an issue for CRAN. caret's C standard is C17 and we would have to request C23 but I'm willing to let CRAN tell me to do that if/when the time comes. 