### PR TITLE
CI: trigger on main only (default branch rename master -> main)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -6,7 +6,7 @@
 # usethis::use_github_action("check-standard") will install it.
 on:
   push:
-    branches: [main, master]
+    branches: [main]
   pull_request:
 
 name: R-CMD-check.yaml

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -2,7 +2,7 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [main]
   pull_request:
 
 name: test-coverage.yaml


### PR DESCRIPTION
Merge only after the default branch is renamed to main; dropping master before that would leave the current default branch without push-triggered CI.