### PR TITLE
Consolidate imports into a usethis namespace block in R/caret-package.R

### DIFF
--- a/R/aaa.R
+++ b/R/aaa.R
@@ -17,7 +17,6 @@
 
 
 #' @useDynLib caret
-#' @import methods plyr reshape2 ggplot2 lattice nlme
 NULL
 
 

--- a/R/adaptive.R
+++ b/R/adaptive.R
@@ -2,9 +2,6 @@
 ##       add na.action to all eval functions
 ##       change multiplier and alpha to confidence
 
-#' @importFrom stats complete.cases
-#' @importFrom utils head
-#' @import foreach
 adaptiveWorkflow <- function(x, y, wts, info, method, ppOpts, ctrl, lev,
                              metric, maximize, testing = FALSE, ...) {
   loadNamespace("caret")
@@ -777,7 +774,6 @@ adaptiveWorkflow <- function(x, y, wts, info, method, ppOpts, ctrl, lev,
   list(performance = out, resamples = resamples, predictions = if(keep_pred) pred else NULL)
 }
 
-#' @importFrom stats reshape
 long2wide <- function(x, metric) {
   x2 <- reshape(x[, c(metric, "model_id", "Resample")],
                 idvar = "Resample",
@@ -796,7 +792,6 @@ get_id <- function(x, param) {
   params
 }
 
-#' @importFrom stats qnorm
 bt_eval <- function(rs, metric, maximize, alpha = 0.05) {
   if (!requireNamespace("BradleyTerry2")) stop("BradleyTerry2 package missing")
   se_thresh <- 100
@@ -865,7 +860,6 @@ skunked <- function(scores, verbose = TRUE) {
 }
 
 
-#' @importFrom stats cor t.test na.omit
 gls_eval <- function(x, metric, maximize, alpha = 0.05) {
   x <- x[!is.na(x[, metric]), ]
   means <- ddply(x[, c(metric, "model_id")],
@@ -901,8 +895,6 @@ gls_eval <- function(x, metric, maximize, alpha = 0.05) {
   unique(c(bl, keepers))
 }
 
-#' @importFrom stats4 coef
-#' @importFrom stats t.test lm pt
 seq_eval <- function(x, metric, maximize, alpha = 0.05) {
   means <- ddply(x[, c(metric, "model_id")],
                  .(model_id),
@@ -972,7 +964,6 @@ cccmat <- function(dat) {
   out
 }
 
-#' @importFrom stats cov
 ccc <- function(x, y) {
   covm <- cov(cbind(x, y), use = "pairwise.complete.obs")
   mnx <- mean(x, na.rm = TRUE)
@@ -980,7 +971,6 @@ ccc <- function(x, y) {
   2*covm[1,2]/(covm[1,1] + covm[2,2] + (mnx - mny)^2)
 }
 
-#' @importFrom stats sd
 diffmat <- function(dat) {
   p <- ncol(dat)
   out <- matrix(NA, ncol = p, nrow = p)

--- a/R/additive.R
+++ b/R/additive.R
@@ -1,5 +1,4 @@
 
-#' @importFrom stats median predict quantile
 additivePlot <- function(x, data, n = 100, quant = 0, plot = TRUE, ...)
   {
     if(inherits(x, "earth"))

--- a/R/avNNet.R
+++ b/R/avNNet.R
@@ -58,7 +58,6 @@ avNNet <- function(x, ...) {
 
 
 ## this is a near copy of nnet.formula
-#' @importFrom stats .getXlevels contrasts model.matrix model.response model.weights
 #' @rdname avNNet
 #' @export
 avNNet.formula <- function(
@@ -115,7 +114,6 @@ avNNet.formula <- function(
   res
 }
 
-#' @import foreach
 #' @rdname avNNet
 #' @export
 avNNet.default <- function(
@@ -200,7 +198,6 @@ print.avNNet <- function(x, ...) {
   invisible(x)
 }
 
-#' @importFrom stats .checkMFClasses delete.response fitted.values model.frame model.matrix predict na.omit
 #' @rdname avNNet
 #' @export
 predict.avNNet <- function(

--- a/R/bag.R
+++ b/R/bag.R
@@ -237,7 +237,6 @@ bagControl <- function(
   }
 
 
-#' @importFrom stats contrasts model.matrix model.response model.weights na.omit
 #' @export
 "bag.formula" <-
   function(formula, data = NULL, ..., subset, weights, na.action = na.omit) {
@@ -274,7 +273,6 @@ bagControl <- function(
   }
 
 #' @rdname bag
-#' @importFrom stats predict
 #' @export
 "predict.bag" <-
   function(object, newdata = NULL, ...) {
@@ -323,7 +321,6 @@ print.bag <- function(x, ...) {
 }
 
 #' @rdname bag
-#' @importFrom stats quantile
 #' @export
 "summary.bag" <-
   function(object, ...) {
@@ -368,7 +365,6 @@ print.bag <- function(x, ...) {
   }
 
 #' @rdname bag
-#' @importFrom stats median predict
 #' @export
 ldaBag <- list(
   fit = function(x, y, ...) {
@@ -408,7 +404,6 @@ ldaBag <- list(
 )
 
 #' @rdname bag
-#' @importFrom stats median predict
 #' @export
 plsBag <- list(
   fit = function(x, y, ...) {
@@ -440,7 +435,6 @@ plsBag <- list(
 )
 
 #' @rdname bag
-#' @importFrom stats median predict
 #' @export
 nbBag <- list(
   fit = function(x, y, ...) {
@@ -473,7 +467,6 @@ nbBag <- list(
 
 
 #' @rdname bag
-#' @importFrom stats median
 #' @export
 ctreeBag <- list(
   fit = function(x, y, ...) {
@@ -527,7 +520,6 @@ ctreeBag <- list(
 )
 
 #' @rdname bag
-#' @importFrom stats median predict
 #' @export
 svmBag <- list(
   fit = function(x, y, ...) {
@@ -572,7 +564,6 @@ svmBag <- list(
 
 
 #' @rdname bag
-#' @importFrom stats median predict
 #' @export
 nnetBag <- list(
   fit = function(x, y, ...) {

--- a/R/bagEarth.R
+++ b/R/bagEarth.R
@@ -47,7 +47,6 @@
   }
 
 #' @rdname bagEarth
-#' @importFrom stats predict
 #' @export
 "bagEarth.default" <-
   function(x, y, weights = NULL, B = 50, summary = mean, keepX = TRUE, ...) {
@@ -135,7 +134,6 @@
   }
 
 #' @rdname bagEarth
-#' @importFrom stats contrasts model.matrix model.response model.weights na.omit
 #' @export
 "bagEarth.formula" <-
   function(
@@ -362,7 +360,6 @@ print.bagEarth <- function(x, ...) {
     out
   }
 
-#' @importFrom stats quantile
 #' @export
 "print.summary.bagEarth" <-
   function(x, digits = max(3, getOption("digits") - 3), ...) {

--- a/R/bagFDA.R
+++ b/R/bagFDA.R
@@ -56,7 +56,6 @@ function(x, ...)
    UseMethod("bagFDA")
 
 #' @rdname bagFDA
-#' @importFrom stats predict
 #' @export
 "bagFDA.default" <-
 function(x, y, weights = NULL, B = 50, keepX = TRUE, ...)
@@ -101,7 +100,6 @@ function(x, y, weights = NULL, B = 50, keepX = TRUE, ...)
 }
 
 #' @rdname bagFDA
-#' @importFrom stats contrasts model.matrix model.response model.weights na.omit
 #' @export
 "bagFDA.formula" <-
 function (formula, data = NULL, B = 50, keepX = TRUE, ..., subset, weights = NULL, na.action = na.omit)
@@ -150,7 +148,6 @@ function (x, ...)
 
 
 #' @rdname predict.bagEarth
-#' @importFrom stats predict
 #' @export
 "predict.bagFDA" <-
 function(object, newdata = NULL, type = "class", ...)
@@ -199,7 +196,6 @@ function(object, newdata = NULL, type = "class", ...)
 }
 
 #' @rdname summary.bagEarth
-#' @importFrom stats quantile
 #' @export
 "summary.bagFDA" <-
 function(object, ...)

--- a/R/calibration.R
+++ b/R/calibration.R
@@ -195,7 +195,6 @@ print.calibration <- function(x, ...) {
   invisible(x)
 }
 
-#' @importFrom stats binom.test
 calibCalc <- function(x, class = levels(obs)[1], cuts = 11) {
   if (length(cuts) == 1) {
     num_cuts <- cuts
@@ -245,8 +244,6 @@ plot.calibration <- function(x, y = NULL, ...) {
 
 
 #' @rdname calibration
-#' @importFrom stats as.formula
-#' @importFrom grDevices extendrange
 #' @export
 xyplot.calibration <- function(x, data = NULL, ...) {
   lFormula <- "Percent ~ midpoint"

--- a/R/caret-package.R
+++ b/R/caret-package.R
@@ -1,3 +1,25 @@
+## usethis namespace: start
+#' @import foreach ggplot2 lattice methods nlme plyr recipes reshape2
+#' @importFrom ModelMetrics auc
+#' @importFrom grDevices extendrange
+#' @importFrom pROC roc
+#' @importFrom plyr ddply
+#' @importFrom recipes all_outcomes all_predictors bake has_role juice prep
+#' @importFrom stats .checkMFClasses .getXlevels aggregate anova approx
+#' @importFrom stats as.formula binom.test binomial complete.cases contrasts cor
+#' @importFrom stats cov delete.response dist fitted fitted.values glm hclust lm
+#' @importFrom stats loess mahalanobis mcnemar.test median model.extract
+#' @importFrom stats model.frame model.matrix model.response model.weights
+#' @importFrom stats na.fail na.omit na.pass optim p.adjust prcomp predict pt
+#' @importFrom stats qnorm quantile rbinom reorder reshape resid residuals rnorm
+#' @importFrom stats runif sd t.test terms toeplitz update var
+#' @importFrom stats4 coef
+#' @importFrom utils capture.output combn flush.console getFromNamespace
+#' @importFrom utils globalVariables head install.packages installed.packages
+#' @importFrom utils menu modifyList object.size stack
+#' @importFrom withr with_seed
+## usethis namespace: end
+NULL
 
 
 #' Blood Brain Barrier Data

--- a/R/classDist.R
+++ b/R/classDist.R
@@ -65,7 +65,6 @@
 classDist <- function (x, ...)  UseMethod("classDist")
 
 #' @rdname classDist
-#' @importFrom stats cov predict quantile prcomp
 #' @export
 classDist.default <- function(x, y, groups = 5,
                               pca = FALSE,
@@ -152,7 +151,6 @@ print.classDist <- function(x, ...)
   }
 
 #' @rdname classDist
-#' @importFrom stats mahalanobis predict
 #' @export
 predict.classDist <- function(object, newdata, trans = log, ...)
 {

--- a/R/common_code.R
+++ b/R/common_code.R
@@ -1,4 +1,3 @@
-#' @importFrom stats t.test
 get_fitness_differences <- function(pnames, subsets, fitness, label) {
   signs <- lapply(subsets, index2vec, vars = length(pnames))
   signs <- do.call("rbind", signs)
@@ -16,7 +15,6 @@ get_fitness_differences <- function(pnames, subsets, fitness, label) {
   melt(apply(signs, 2, snr, y = fitness))
 }
 
-#' @importFrom stats reshape
 process_diffs <- function(x, pnames) {
   is_null_res <- vapply(x, is.null, logical(1))
   if (all(is_null_res)) {

--- a/R/confusionMatrix.R
+++ b/R/confusionMatrix.R
@@ -135,7 +135,6 @@ confusionMatrix <-
   }
 
 #' @rdname confusionMatrix
-#' @importFrom utils getFromNamespace
 #' @export
 confusionMatrix.default <- function(data, reference,
                                     positive = NULL,
@@ -185,7 +184,6 @@ confusionMatrix.default <- function(data, reference,
 }
 
 #' @rdname confusionMatrix
-#' @importFrom utils getFromNamespace
 #' @export
 confusionMatrix.matrix <- function(data,
                                    positive = NULL,
@@ -200,7 +198,6 @@ confusionMatrix.matrix <- function(data,
 }
 
 #' @rdname confusionMatrix
-#' @importFrom stats binom.test mcnemar.test
 #' @export
 confusionMatrix.table <- function(data, positive = NULL,
                                   prevalence = NULL, mode = "sens_spec", ...){
@@ -550,7 +547,6 @@ confusionMatrix.rfe <- confusionMatrix.train
 #' @export
 confusionMatrix.sbf <- confusionMatrix.train
 
-#' @importFrom utils getFromNamespace
 #' @export
 print.confusionMatrix.train <- function(x, digits = 1, ...){
   cat(x$text, "\n")

--- a/R/createDataPartition.R
+++ b/R/createDataPartition.R
@@ -160,7 +160,6 @@ createDataPartition <- function (y, times = 1, p = 0.5, list = TRUE, groups = mi
 
 
 #' @rdname createDataPartition
-#' @importFrom stats quantile
 #' @export
 "createFolds" <-
   function(y, k = 10, list = TRUE, returnTrain = FALSE) {

--- a/R/createModel.R
+++ b/R/createModel.R
@@ -7,7 +7,6 @@
 #' @author Max Kuhn, but `caretTheme` uses an expanded grid of the "Blues"
 #'   palette designed by Cynthia Brewer and Mark Harrower
 #'
-#' @importFrom stats predict
 #' @export
 #' @keywords internal
 "createModel" <-function(x, y, wts, method, tuneValue, obsLevels, pp = NULL, last = FALSE, sampling = NULL, classProbs, ...) {

--- a/R/dummyVar.R
+++ b/R/dummyVar.R
@@ -145,7 +145,6 @@
   }
 
 #' @rdname dummyVars
-#' @importFrom stats as.formula model.frame
 #' @export
 dummyVars.default <- function(
   formula,
@@ -223,7 +222,6 @@ print.dummyVars <- function(x, ...) {
 }
 
 #' @rdname dummyVars
-#' @importFrom stats delete.response model.frame model.matrix na.pass
 #' @export
 predict.dummyVars <- function(object, newdata, na.action = na.pass, ...) {
   if (is.null(newdata)) {
@@ -366,7 +364,6 @@ contr.dummy <- function(n, ...) {
 }
 
 #' @rdname dummyVars
-#' @importFrom stats model.matrix
 #' @export
 #' @param drop2nd A logical: if the factor has two levels, should a single
 #'   binary vector be returned?

--- a/R/expoTrans.R
+++ b/R/expoTrans.R
@@ -2,7 +2,6 @@
 #' @export
 expoTrans <- function(y, ...) UseMethod("expoTrans")
 
-#' @importFrom stats optim
 #' @export
 expoTrans.default <- function(y, na.rm  = TRUE, init = 0, lim = c(-4, 4), method = "Brent", numUnique = 3, ...)
 {
@@ -84,7 +83,6 @@ predict.expoTrans <- function(object, newdata, ...)
 manly <- function(x, lambda)
   if(lambda == 0) x else (exp(lambda*x) - 1)/lambda
 
-#' @importFrom stats var
 manlyLik <- function(lambda, x, neg = FALSE)
 {
   y <- manly(x, lambda)

--- a/R/extractProb.R
+++ b/R/extractProb.R
@@ -1,6 +1,5 @@
  ## TODO use foreach to parallelize
 #' @rdname predict.train
-#' @importFrom utils flush.console
 #' @export
 extractProb <- function(models,
                         testX = NULL,

--- a/R/filterVarImp.R
+++ b/R/filterVarImp.R
@@ -1,11 +1,9 @@
 
-#' @importFrom ModelMetrics auc
 rocPerCol <- function(dat, cls){
   roc_auc <- auc(cls, dat)
   max(roc_auc, 1 - roc_auc)
 }
 
-#' @importFrom utils modifyList
 asNumeric <- function(data){
   fc <- sapply(data, is.factor)
   modifyList(data, lapply(data[, fc], as.numeric))
@@ -67,8 +65,6 @@ asNumeric <- function(data){
 #' filterVarImp(bbbDescr[, 1:5], logBBB, nonpara = TRUE)
 #' 
 #' @export filterVarImp
-#' @importFrom stats loess resid
-#' @importFrom utils combn
 filterVarImp <- function(x, y, nonpara = FALSE, ...){
   # converting factors to numeric
   notNumber <- sapply(x, function(x) !is.numeric(x))

--- a/R/findCorrelation.R
+++ b/R/findCorrelation.R
@@ -1,4 +1,3 @@
-#' @importFrom stats complete.cases
 findCorrelation_fast <- function(x, cutoff = 0.90, verbose = FALSE) {
   if (any(!complete.cases(x))) {
     stop("The correlation matrix has some missing values.")

--- a/R/findLinearCombos.R
+++ b/R/findLinearCombos.R
@@ -23,7 +23,6 @@ enumLC.lm <- function(object, ...)
    internalEnumLC(object$qr)
 }
 
-#' @importFrom stats lm
 #' @export
 enumLC.formula <- function(object, ...)
 {

--- a/R/gafs.R
+++ b/R/gafs.R
@@ -278,7 +278,6 @@ gafs_tourSelection <- function(population, fitness, k = 3, ...) {
 }
 
 #' @rdname gafs_initial
-#' @importFrom stats runif
 #' @export
 gafs_uCrossover <- function(population, parents, ...) {
   parents <- population[parents, , drop = FALSE]
@@ -449,8 +448,6 @@ ga_wrapper <- function(
 ###################################################################
 ##
 
-#' @importFrom stats runif
-#' @import foreach
 ga_select <- function(
   x,
   y,
@@ -822,7 +819,6 @@ ga_select <- function(
 ###################################################################
 ##
 
-#' @importFrom utils getFromNamespace
 #' @export
 print.gafs <- function(
   x,
@@ -1585,7 +1581,6 @@ ggplot.gafs <-
 ###################################################################
 ##
 
-#' @importFrom stats predict
 #' @export
 caretGA <- list(
   fit = function(x, y, lev = NULL, last = FALSE, ...) train(x, y, ...),
@@ -1619,7 +1614,6 @@ caretGA <- list(
   selectIter = best
 )
 
-#' @importFrom stats predict
 #' @export
 treebagGA <- list(
   fit = function(x, y, lev = NULL, last = FALSE, ...) {

--- a/R/ggplot.R
+++ b/R/ggplot.R
@@ -1,5 +1,4 @@
 #' @rdname plot.train
-#' @importFrom stats as.formula
 #' @export
 ggplot.train <- function(data = NULL, mapping = NULL, metric = data$metric[1], plotType = "scatter", output = "layered",
                nameInStrip = FALSE, highlight = FALSE, ..., environment = NULL) {
@@ -174,7 +173,6 @@ ggplot.rfe <- function(data = NULL, mapping = NULL, metric = data$metric[1],
   out
 }
 
-#' @importFrom stats complete.cases
 random_search_plot <- function(x, metric = x$metric[1]) {
 
   params <- x$modelInfo$parameters

--- a/R/heldout.R
+++ b/R/heldout.R
@@ -90,7 +90,6 @@ oob_pred.sbf <- function(x, average = TRUE, ...) {
   prd
 }
 
-#' @importFrom stats reshape
 #' @export
 oob_pred.list <- function(x, direction = "wide", what = "both", ...) {
   num <- length(x)
@@ -139,7 +138,6 @@ oob_pred.list <- function(x, direction = "wide", what = "both", ...) {
 
 get_averages <- function (x, ...) UseMethod("get_averages")
 
-#' @importFrom stats complete.cases
 #' @export
 get_averages.train <- function(x, prd, bycol = "rowIndex", ...) {
   if("Regression" %in% x$modelType) {
@@ -162,7 +160,6 @@ get_averages.train <- function(x, prd, bycol = "rowIndex", ...) {
   out
 }
 
-#' @importFrom stats complete.cases
 #' @export
 get_averages.rfe <- function(x, prd, bycol = "rowIndex", ...) {
   if(is.null(x$obsLevels)) {
@@ -185,7 +182,6 @@ get_averages.rfe <- function(x, prd, bycol = "rowIndex", ...) {
   out
 }
 
-#' @importFrom stats complete.cases
 #' @export
 get_averages.sbf <- function(x, prd, bycol = "rowIndex", ...) {
   if(is.null(x$obsLevels)) {
@@ -211,7 +207,6 @@ get_averages.sbf <- function(x, prd, bycol = "rowIndex", ...) {
 ###################################################################
 ##
 
-#' @importFrom stats complete.cases
 char_mode <- function(x, random = TRUE, na.rm = FALSE) {
   if(na.rm) x <- x[complete.cases(x)]
   tab <- table(x)
@@ -232,7 +227,6 @@ train_lev <- function(x) {
 }
 
 
-#' @importFrom stats cor
 corr_mat <- function (object, metric = object$metrics,
                        ...) {
   dat <- object$values[, grepl(paste0("~", metric[1]),

--- a/R/icr.R
+++ b/R/icr.R
@@ -75,7 +75,6 @@ icr.formula <- function (formula, data, weights, ...,
 }
 
 #' @rdname icr.formula
-#' @importFrom stats predict lm
 #' @export
 icr.default <- function(x, y, ...)
   {
@@ -100,7 +99,6 @@ icr.default <- function(x, y, ...)
   }
 
 
-#' @importFrom stats4 coef
 #' @export
 print.icr <- function (x, digits = max(3, getOption("digits") - 3), ...)
 {
@@ -123,7 +121,6 @@ print.icr <- function (x, digits = max(3, getOption("digits") - 3), ...)
 }
 
 #' @rdname icr.formula
-#' @importFrom stats .checkMFClasses delete.response model.frame model.matrix predict na.omit fitted
 #' @export
 predict.icr <- function(object, newdata, ...)
   {

--- a/R/knn3.R
+++ b/R/knn3.R
@@ -66,7 +66,6 @@ knn3.default <- function(x, ...)
 }
 
 #' @rdname knn3
-#' @importFrom stats model.matrix terms model.extract
 #' @export
 knn3.formula <- function (formula, data, subset, na.action, k = 5, ...)
 {

--- a/R/knnreg.R
+++ b/R/knnreg.R
@@ -61,7 +61,6 @@ knnreg.default <- function(x, ...)
 }
 
 #' @rdname knnreg
-#' @importFrom stats model.matrix terms model.extract
 #' @export
 knnreg.formula <- function (formula, data, subset, na.action, k = 5, ...)
 {

--- a/R/lattice.train.R
+++ b/R/lattice.train.R
@@ -1,4 +1,3 @@
-#' @importFrom stats as.formula
 #' @export
 densityplot.train <- function(x,
                               data = NULL,
@@ -152,7 +151,6 @@ histogram.train <- function(x,
     histogram(form, data = resamp, ...)
 }
 
-#' @importFrom stats as.formula
 #' @export
 stripplot.train <- function(x,
                               data = NULL,
@@ -223,7 +221,6 @@ stripplot.train <- function(x,
     stripplot(form, data = resamp, ...)
 }
 
-#' @importFrom stats as.formula
 #' @export
 xyplot.train <- function(x,
                               data = NULL,

--- a/R/lift.R
+++ b/R/lift.R
@@ -218,8 +218,6 @@ print.lift <- function(x, ...) {
 plot.lift <- function(x, y = NULL, ...) xyplot.lift(x = x, data = NULL, ...)
 
 #' @rdname lift
-#' @importFrom stats as.formula
-#' @importFrom grDevices extendrange
 #' @export
 xyplot.lift <- function(x, data = NULL, plot = "gain", values = NULL, ...) {
   if (!(plot %in% c("lift", "gain"))) {
@@ -272,7 +270,6 @@ xyplot.lift <- function(x, data = NULL, plot = "gain", values = NULL, ...) {
   do.call("xyplot", args)
 }
 
-#' @importFrom stats complete.cases
 liftCalc <- function(x, class = levels(x$liftClassVar)[1], cuts = NULL) {
   x <- x[complete.cases(x), ]
   lvl <- levels(x$liftClassVar)
@@ -390,7 +387,6 @@ panel.lift2 <- function(x, y, pct = 0, values = NULL, ...) {
   }
 }
 
-#' @importFrom stats approx
 plotRef <- function(x, y, v, iter = 0) {
   if (iter == 0) {
     lineStyle <- trellis.par.get("plot.line")

--- a/R/misc.R
+++ b/R/misc.R
@@ -29,7 +29,6 @@ well_numbered <- function(prefix, items) {
 }
 
 
-#' @importFrom stats runif
 evalSummaryFunction <- function(y, wts = NULL, perf = NULL, ctrl, lev, metric, method) {
   n <- if(inherits(y, "Surv")) nrow(y) else length(y)
   ## sample doesn't work for Surv objects
@@ -96,7 +95,6 @@ model2method <- function(x)
          x)
 }
 
-#' @importFrom stats runif binomial
 Kim2009 <- function(n)
 {
   grid <- matrix(runif(n*10), ncol = 10)
@@ -111,7 +109,6 @@ Kim2009 <- function(n)
 }
 
 #' @rdname caret-internal
-#' @importFrom stats as.formula
 #' @export
 gamFormula <- function(data, smoother = "s", cut = 8, y = "y")
 {
@@ -169,7 +166,6 @@ cforestStats  <- function(x) getModelInfo("cforest", regex = FALSE)[[1]]$oob(x)
 bagEarthStats <- function(x) getModelInfo("bagEarth", regex = FALSE)[[1]]$oob(x)
 
 
-#' @importFrom stats complete.cases cor
 #' @export
 R2 <- function(pred, obs, formula = "corr", na.rm = FALSE)
 {
@@ -185,7 +181,6 @@ RMSE <- function(pred, obs, na.rm = FALSE) sqrt(mean((pred - obs)^2, na.rm = na.
 #' @export
 MAE <- function(pred, obs, na.rm = FALSE) mean(abs(pred - obs), na.rm = na.rm)
 
-#' @importFrom utils capture.output
 partRuleSummary <- function(x)
 {
   predictors <- all.vars(x$terms)
@@ -210,7 +205,6 @@ partRuleSummary <- function(x)
 
 }
 
-#' @importFrom utils capture.output
 ripperRuleSummary <- function(x)
 {
   predictors <- all.vars(x$terms)
@@ -265,7 +259,6 @@ useMathSymbols <- function(x)
   x
 }
 
-#' @importFrom stats approx
 depth2cp <- function(x, depth)
 {
   out <- approx(x[,"nsplit"], x[,"CP"], depth)$y
@@ -273,7 +266,6 @@ depth2cp <- function(x, depth)
   out
 }
 
-#' @importFrom stats as.formula
 smootherFormula <- function(data, smoother = "s", cut = 10, df = 0, span = 0.5, degree = 1, y = ".outcome")
 {
   nzv <- nearZeroVar(data)
@@ -555,7 +547,6 @@ get_model_type <- function(y, method = NULL) {
   type
 }
 
-#' @importFrom grDevices extendrange
 get_range <- function(y) {
   if(class(y)[1] == "factor") return(NA)
   if(class(y)[1] %in% c("numeric", "integer")) extendrange(y) else extendrange(y[, "time"])

--- a/R/modelLookup.R
+++ b/R/modelLookup.R
@@ -72,7 +72,6 @@ modelLookup <- function(model = NULL){
   out[order(out$model),]
 }
 
-#' @importFrom utils installed.packages
 missing_packages <- function(mods = getModelInfo()) {
   libs <- unique(unlist(lapply(mods, function(x) x$library)))
   here <- rownames(installed.packages())
@@ -80,7 +79,6 @@ missing_packages <- function(mods = getModelInfo()) {
 }
 
 #' @rdname modelLookup
-#' @importFrom utils install.packages menu
 #' @export
 checkInstall <- function(pkg){
   good <- rep(TRUE, length(pkg))

--- a/R/pcaNNet.R
+++ b/R/pcaNNet.R
@@ -73,7 +73,6 @@ pcaNNet <- function (x, ...)
 
 # this is a near copy of nnet.formula
 #' @rdname pcaNNet
-#' @importFrom stats .getXlevels contrasts model.matrix model.response model.weights
 #' @export
 pcaNNet.formula <- function (formula, data, weights, ...,
                              thresh = 0.99,
@@ -163,7 +162,6 @@ print.pcaNNet <- function (x, ...)
 }
 
 #' @rdname pcaNNet
-#' @importFrom stats .checkMFClasses delete.response model.frame model.matrix predict na.omit fitted
 #' @export
 predict.pcaNNet <- function(object, newdata, type = c("raw", "class", "prob"), ...)
   {

--- a/R/plot.varImp.train.R
+++ b/R/plot.varImp.train.R
@@ -70,7 +70,6 @@ function(x, top = dim(x$importance)[1],  ...)
 }
 
 #' @rdname plot.varImp.train
-#' @importFrom utils stack
 #' @export
 ggplot.varImp.train <- function (data, mapping = NULL, top = dim(data$importance)[1], ..., environment = NULL)  {
   plotObj <- sortImp(data, top)

--- a/R/plsda.R
+++ b/R/plsda.R
@@ -100,7 +100,6 @@ plsda <- function (x, ...)
   UseMethod("plsda")
 
 #' @rdname plsda
-#' @importFrom stats predict
 #' @export
 predict.plsda <- function(object, newdata = NULL, ncomp = NULL, type = "class", ...){
   requireNamespaceQuietStop('pls')
@@ -190,7 +189,6 @@ predict.plsda <- function(object, newdata = NULL, ncomp = NULL, type = "class", 
 }
 
 #' @rdname plsda
-#' @importFrom stats predict
 #' @export
 plsda.default <- function(x, y, ncomp = 2, probMethod = "softmax", prior = NULL, ...) {
   requireNamespaceQuietStop('pls')

--- a/R/postResample.R
+++ b/R/postResample.R
@@ -147,7 +147,6 @@ postResample <- function(pred, obs)
 
 
 #' @rdname postResample
-#' @importFrom pROC roc
 #' @export
 twoClassSummary <- function (data, lev = NULL, model = NULL) {
   if(length(lev) > 2) {
@@ -168,7 +167,6 @@ twoClassSummary <- function (data, lev = NULL, model = NULL) {
 }
 
 #' @rdname postResample
-#' @importFrom stats complete.cases
 #' @export
 mnLogLoss <- function(data, lev = NULL, model = NULL){
   if(is.null(lev)) stop("'lev' cannot be NULL")

--- a/R/preProcess.R
+++ b/R/preProcess.R
@@ -210,7 +210,6 @@ getRangeBounds <- function(pp) {
 preProcess <- function(x, ...) UseMethod("preProcess")
 
 #' @rdname preProcess
-#' @importFrom stats complete.cases median sd prcomp
 #' @export
 preProcess.default <- function(
   x,
@@ -724,7 +723,6 @@ preProcess.default <- function(
 }
 
 #' @rdname preProcess
-#' @importFrom stats complete.cases
 #' @export
 predict.preProcess <- function(object, newdata, ...) {
   if (is.vector(object$method) && !is.list(object$method)) {
@@ -1089,7 +1087,6 @@ nnimp <- function(new, old, k, foo) {
   new
 }
 
-#' @importFrom stats as.formula
 bagImp <- function(var, x, B = 10) {
   requireNamespaceQuietStop("ipred")
   ## The formula interface is much slower than the

--- a/R/prec_rec.R
+++ b/R/prec_rec.R
@@ -118,7 +118,6 @@ recall <- function(data, ...) UseMethod("recall")
 }
 
 #' @rdname recall
-#' @importFrom stats complete.cases
 #' @export
 recall.default <- function(data, reference, relevant = levels(reference)[1],
                            na.rm = TRUE, ...) {
@@ -142,7 +141,6 @@ recall.default <- function(data, reference, relevant = levels(reference)[1],
 precision <- function(data, ...) UseMethod("precision")
 
 #' @rdname recall
-#' @importFrom stats complete.cases
 #' @export
 precision.default <- function(data, reference, relevant = levels(reference)[1],
                               na.rm = TRUE, ...) {
@@ -194,7 +192,6 @@ precision.table <- function (data, relevant = rownames(data)[1], ...) {
 F_meas <- function(data, ...) UseMethod("F_meas")
 
 #' @rdname recall
-#' @importFrom stats complete.cases
 #' @export
 F_meas.default <- function(data, reference, relevant = levels(reference)[1],
                            beta = 1,  na.rm = TRUE, ...) {

--- a/R/predict.train.R
+++ b/R/predict.train.R
@@ -1,4 +1,3 @@
-#' @importFrom stats predict
 #' @export
 predict.list <- function(object, ...) {
   out <- lapply(object, predict, ... = ...)

--- a/R/predictionFunction.R
+++ b/R/predictionFunction.R
@@ -1,5 +1,4 @@
 #' @rdname caret-internal
-#' @importFrom stats predict
 #' @export
 predictionFunction <- function(method, modelFit, newdata, preProc = NULL, param = NULL)
 {

--- a/R/reg_sims.R
+++ b/R/reg_sims.R
@@ -1,5 +1,4 @@
 
-#' @importFrom stats rnorm toeplitz
 make_noise <- function(n, noiseVars = 0, 
                        corrVars = 0, corrType = "AR1", corrValue = 0,
                        binary = FALSE) {
@@ -29,7 +28,6 @@ make_noise <- function(n, noiseVars = 0,
 }
 
 #' @rdname twoClassSim
-#' @importFrom stats rnorm
 #' @export
 SLC14_1 <- function(n = 100, noiseVars = 0, 
                     corrVars = 0, corrType = "AR1", corrValue = 0) {
@@ -57,7 +55,6 @@ SLC14_1 <- function(n = 100, noiseVars = 0,
 }
 
 #' @rdname twoClassSim
-#' @importFrom stats rnorm
 #' @export
 SLC14_2 <- function(n = 100, noiseVars = 0, 
                     corrVars = 0, corrType = "AR1", corrValue = 0) {
@@ -78,7 +75,6 @@ SLC14_2 <- function(n = 100, noiseVars = 0,
 }
 
 #' @rdname twoClassSim
-#' @importFrom stats rbinom rnorm runif binomial
 #' @export
 LPH07_1 <- function(n = 100, noiseVars = 0, 
                     corrVars = 0, corrType = "AR1", corrValue = 0, factors = FALSE, class = FALSE) {
@@ -114,7 +110,6 @@ LPH07_1 <- function(n = 100, noiseVars = 0,
 }
 
 #' @rdname twoClassSim
-#' @importFrom stats rnorm
 #' @export
 LPH07_2 <- function(n = 100, noiseVars = 0, 
                     corrVars = 0, corrType = "AR1", corrValue = 0) {

--- a/R/resamples.R
+++ b/R/resamples.R
@@ -292,7 +292,6 @@ as.data.frame.resamples <- function(
 }
 
 #' @rdname resamples
-#' @importFrom stats cor
 #' @export
 modelCor <- function(x, metric = x$metric[1], ...) {
   dat <- x$values[, grep(paste("~", metric[1], sep = ""), names(x$values))]
@@ -415,7 +414,6 @@ cluster.default <- function(x, ...) {
   stop("only implemented for resamples objects")
 }
 
-#' @importFrom stats dist hclust
 #' @export
 cluster.resamples <- function(x, metric = x$metrics[1], ...) {
   if (length(metric) != 1) {
@@ -443,7 +441,6 @@ cluster.resamples <- function(x, metric = x$metrics[1], ...) {
 }
 
 #' @rdname prcomp.resamples
-#' @importFrom grDevices extendrange
 #' @export
 plot.prcomp.resamples <- function(
   x,
@@ -844,7 +841,6 @@ xyplot.resamples <- function(
 }
 
 #' @rdname xyplot.resamples
-#' @importFrom stats median
 #' @export
 parallelplot.resamples <- function(
   x,
@@ -883,7 +879,6 @@ parallelplot.resamples <- function(
 }
 
 #' @rdname xyplot.resamples
-#' @importFrom grDevices extendrange
 #' @export
 splom.resamples <- function(
   x,
@@ -948,7 +943,6 @@ splom.resamples <- function(
 }
 
 #' @rdname xyplot.resamples
-#' @importFrom stats as.formula
 #' @export
 densityplot.resamples <- function(
   x,
@@ -979,7 +973,6 @@ densityplot.resamples <- function(
 }
 
 #' @rdname xyplot.resamples
-#' @importFrom stats as.formula
 #' @export
 bwplot.resamples <- function(
   x,
@@ -1013,7 +1006,6 @@ bwplot.resamples <- function(
 }
 
 #' @rdname xyplot.resamples
-#' @importFrom stats aggregate as.formula median t.test
 #' @export
 dotplot.resamples <- function(
   x,
@@ -1123,7 +1115,6 @@ dotplot.resamples <- function(
 }
 
 #' @rdname xyplot.resamples
-#' @importFrom stats reorder
 #' @param mapping,environment Not used.
 #' @export
 ggplot.resamples <-
@@ -1331,8 +1322,6 @@ diff.resamples <- function(
   out
 }
 
-#' @importFrom stats as.formula
-#' @importFrom utils stack
 #' @export
 densityplot.diff.resamples <- function(x, data, metric = x$metric, ...) {
   plotData <- lapply(x$difs, function(x) {
@@ -1358,8 +1347,6 @@ densityplot.diff.resamples <- function(x, data, metric = x$metric, ...) {
   )
 }
 
-#' @importFrom stats as.formula
-#' @importFrom utils stack
 #' @export
 bwplot.diff.resamples <- function(x, data, metric = x$metric, ...) {
   plotData <- lapply(x$difs, function(x) {
@@ -1394,7 +1381,6 @@ print.diff.resamples <- function(x, ...) {
   invisible(x)
 }
 
-#' @importFrom stats p.adjust
 #' @rdname diff.resamples
 #' @export
 summary.diff.resamples <- function(
@@ -1464,7 +1450,6 @@ summary.diff.resamples <- function(
   out
 }
 
-#' @importFrom stats complete.cases
 #' @export
 levelplot.diff.resamples <- function(
   x,
@@ -1704,5 +1689,4 @@ compare_models <- function(a, b, metric = a$metric[1]) {
 }
 
 
-#' @importFrom utils globalVariables
 utils::globalVariables(c("LowerLimit", "UpperLimit"))

--- a/R/rfe.R
+++ b/R/rfe.R
@@ -176,7 +176,6 @@
 rfe <- function(x, ...) UseMethod("rfe")
 
 #' @rdname rfe
-#' @importFrom stats predict runif
 #' @export
 "rfe.default" <-
   function(
@@ -415,7 +414,6 @@ rfe <- function(x, ...) UseMethod("rfe")
   }
 
 #' @inheritParams train
-#' @importFrom stats .getXlevels contrasts model.matrix model.response
 #' @rdname rfe
 #' @export
 rfe.formula <- function(form, data, ..., subset, na.action, contrasts = NULL) {
@@ -486,8 +484,6 @@ print.rfe <- function(
 ######################################################################
 
 #' @rdname rfe
-#' @importFrom stats complete.cases
-#' @importFrom utils flush.console
 #' @export
 rfeIter <- function(
   x,
@@ -1062,7 +1058,6 @@ caretFuncs <- list(
 
 ## write a better imp sort function
 #' @rdname caretFuncs
-#' @importFrom stats predict
 #' @export
 ldaFuncs <- list(
   summary = defaultSummary,
@@ -1097,7 +1092,6 @@ ldaFuncs <- list(
 )
 
 #' @rdname caretFuncs
-#' @importFrom stats predict
 #' @export
 treebagFuncs <- list(
   summary = defaultSummary,
@@ -1132,7 +1126,6 @@ treebagFuncs <- list(
 )
 
 #' @rdname caretFuncs
-#' @importFrom stats predict
 #' @export
 gamFuncs <- list(
   summary = defaultSummary,
@@ -1204,7 +1197,6 @@ gamFuncs <- list(
 )
 
 #' @rdname caretFuncs
-#' @importFrom stats predict
 #' @export
 rfFuncs <- list(
   summary = defaultSummary,
@@ -1251,7 +1243,6 @@ rfFuncs <- list(
 
 
 #' @rdname caretFuncs
-#' @importFrom stats predict lm
 #' @export
 lmFuncs <- list(
   summary = defaultSummary,
@@ -1285,7 +1276,6 @@ lmFuncs <- list(
 
 
 #' @rdname caretFuncs
-#' @importFrom stats predict
 #' @export
 nbFuncs <- list(
   summary = defaultSummary,
@@ -1319,7 +1309,6 @@ nbFuncs <- list(
 
 
 #' @rdname caretFuncs
-#' @importFrom stats predict glm
 #' @export
 lrFuncs <- ldaFuncs
 lrFuncs$fit <- function(x, y, first, last, ...) {
@@ -1406,7 +1395,6 @@ lrFuncs$rank <- function(object, x, y) {
 #' histogram(lmProfile)
 #' densityplot(lmProfile)
 #'
-#' @importFrom stats as.formula
 #' @export
 densityplot.rfe <- function(x, data = NULL, metric = x$metric, ...) {
   if (!is.null(match.call()$data)) {
@@ -1429,7 +1417,6 @@ densityplot.rfe <- function(x, data = NULL, metric = x$metric, ...) {
   densityplot(form, data = data, ...)
 }
 
-#' @importFrom stats as.formula
 #' @export
 histogram.rfe <- function(x, data = NULL, metric = x$metric, ...) {
   if (!is.null(match.call()$data)) {
@@ -1452,7 +1439,6 @@ histogram.rfe <- function(x, data = NULL, metric = x$metric, ...) {
   histogram(form, data = data, ...)
 }
 
-#' @importFrom stats as.formula
 #' @export
 stripplot.rfe <- function(x, data = NULL, metric = x$metric, ...) {
   if (!is.null(match.call()$data)) {
@@ -1486,7 +1472,6 @@ stripplot.rfe <- function(x, data = NULL, metric = x$metric, ...) {
   stripplot(form, data = data, ...)
 }
 
-#' @importFrom stats as.formula
 #' @export
 xyplot.rfe <- function(x, data = NULL, metric = x$metric, ...) {
   if (!is.null(match.call()$data)) {
@@ -1528,7 +1513,6 @@ varImp.rfe <- function(object, drop = FALSE, ...) {
   imp[order(-imp$Overall), , drop = FALSE]
 }
 
-#' @importFrom stats .checkMFClasses delete.response model.frame model.matrix na.omit
 #' @export
 predict.rfe <- function(object, newdata, ...) {
   if (length(list(...)) > 0) {

--- a/R/safs.R
+++ b/R/safs.R
@@ -93,7 +93,6 @@ sa_bl_correct0 <- function(x) {
 
 sa_bl_correct <- function(x) ddply(x, .(Resample), sa_bl_correct0)
 
-#' @importFrom utils getFromNamespace
 #' @export
 print.safs <- function(
   x,
@@ -1058,7 +1057,6 @@ sa_wrapper <- function(
 ###################################################################
 ##
 
-#' @importFrom stats runif
 sa_select <- function(
   x,
   y,
@@ -1330,7 +1328,6 @@ sa_select <- function(
 ###################################################################
 ##
 
-#' @importFrom stats update
 #' @export
 #' @export plot.safs
 plot.safs <- function(
@@ -1411,7 +1408,6 @@ ggplot.safs <-
 ###################################################################
 ##
 #' @rdname safs_initial
-#' @importFrom stats predict
 #' @export
 caretSA <- list(
   fit = function(x, y, lev = NULL, last = FALSE, ...) train(x, y, ...),
@@ -1623,7 +1619,6 @@ update.safs <- function(object, iter, x, y, ...) {
 }
 
 #' @rdname safs
-#' @import recipes
 #' @export
 "safs.recipe" <-
   function(

--- a/R/selectByFilter.R
+++ b/R/selectByFilter.R
@@ -174,7 +174,6 @@ sbfIter <- function(x, y, testX, testY, testPerf = NULL,
 sbf <- function (x, ...) UseMethod("sbf")
 
 #' @rdname sbf
-#' @importFrom stats predict runif
 #' @export
 "sbf.default" <-
   function(x, y,
@@ -317,7 +316,6 @@ sbf <- function (x, ...) UseMethod("sbf")
   }
 
 #' @rdname sbf
-#' @importFrom stats .getXlevels contrasts model.matrix model.response
 #' @export
 sbf.formula <- function (form, data, ..., subset, na.action, contrasts = NULL) {
   m <- match.call(expand.dots = FALSE)
@@ -515,7 +513,6 @@ sbf.formula <- function (form, data, ..., subset, na.action, contrasts = NULL) {
   }
 
 
-#' @import foreach
 sbf_rec <- function(rec, data, ctrl, lev, ...) {
   loadNamespace("caret")
 
@@ -783,7 +780,6 @@ print.sbf <- function(x, top = 5, digits = max(3, getOption("digits") - 3), ...)
 ######################################################################
 ######################################################################
 #' @rdname sbf
-#' @importFrom stats .checkMFClasses delete.response model.frame model.matrix na.omit
 #' @export
 predict.sbf <- function(object, newdata = NULL, ...) {
   if (!is.null(newdata)) {
@@ -1049,7 +1045,6 @@ caretSBF <- list(summary = defaultSummary,
                  filter = function(score, x, y) score <= 0.05
 )
 
-#' @importFrom stats predict
 #' @export
 rfSBF <- list(summary = defaultSummary,
               fit = function(x, y, ...)
@@ -1089,7 +1084,6 @@ rfSBF <- list(summary = defaultSummary,
               filter = function(score, x, y) score <= 0.05
 )
 
-#' @importFrom stats predict lm
 #' @export
 lmSBF <- list(summary = defaultSummary,
               fit = function(x, y, ...)
@@ -1112,7 +1106,6 @@ lmSBF <- list(summary = defaultSummary,
               filter = function(score, x, y) score <= 0.05
 )
 
-#' @importFrom stats predict
 #' @export
 ldaSBF <- list(summary = defaultSummary,
                fit = function(x, y, ...)
@@ -1148,7 +1141,6 @@ ldaSBF <- list(summary = defaultSummary,
                filter = function(score, x, y) score <= 0.05
 )
 
-#' @importFrom stats predict
 #' @export
 nbSBF <- list(summary = defaultSummary,
               fit = function(x, y, ...)
@@ -1190,7 +1182,6 @@ nbSBF <- list(summary = defaultSummary,
               filter = function(score, x, y) score <= 0.05
 )
 
-#' @importFrom stats predict
 #' @export
 treebagSBF <- list(summary = defaultSummary,
                    fit = function(x, y, ...)
@@ -1232,7 +1223,6 @@ treebagSBF <- list(summary = defaultSummary,
 
 
 #' @rdname caretSBF
-#' @importFrom stats anova lm
 #' @export
 anovaScores <- function(x, y) {
   if(is.factor(x)) stop("The predictors should be numeric")
@@ -1242,7 +1232,6 @@ anovaScores <- function(x, y) {
 }
 
 #' @rdname caretSBF
-#' @importFrom stats anova lm
 #' @export
 gamScores <- function(x, y) {
   if(is.factor(x)) stop("The predictors should be numeric")
@@ -1259,7 +1248,6 @@ gamScores <- function(x, y) {
 ######################################################################
 ## lattice functions
 
-#' @importFrom stats as.formula
 #' @export
 densityplot.sbf <- function(x,
                             data = NULL,
@@ -1277,7 +1265,6 @@ densityplot.sbf <- function(x,
   densityplot(form, data = data, ...)
 }
 
-#' @importFrom stats as.formula
 #' @export
 histogram.sbf <- function(x,
                           data = NULL,

--- a/R/sensitivity.R
+++ b/R/sensitivity.R
@@ -136,7 +136,6 @@ sensitivity <-
   }
 
 #' @rdname sensitivity
-#' @importFrom stats complete.cases
 #' @export
 "sensitivity.default" <-
   function(data, reference, positive = levels(reference)[1], na.rm = TRUE, ...)

--- a/R/sortImp.R
+++ b/R/sortImp.R
@@ -1,5 +1,4 @@
 #' @rdname caret-internal
-#' @importFrom stats runif
 #' @export
 sortImp <- function(object, top)
 {

--- a/R/specificity.R
+++ b/R/specificity.R
@@ -5,7 +5,6 @@ specificity <-
     UseMethod("specificity")
   }
 
-#' @importFrom stats complete.cases
 #' @export
 #' @rdname sensitivity
 "specificity.default" <-

--- a/R/splsda.R
+++ b/R/splsda.R
@@ -2,7 +2,6 @@
 splsda <- function (x, ...)
   UseMethod("splsda")
 
-#' @importFrom stats predict
 #' @export
 predict.splsda <- function(object, newdata = NULL, type = "class", ...)
 {
@@ -33,7 +32,6 @@ predict.splsda <- function(object, newdata = NULL, type = "class", ...)
   out
 }
 
-#' @importFrom stats predict
 #' @export
 splsda.default <- function(x, y, probMethod = "softmax", prior = NULL, ...)
 {

--- a/R/thresholder.R
+++ b/R/thresholder.R
@@ -46,7 +46,6 @@
 #'   the distance to the best possible cutoff (i.e. perfect sensitivity and
 #'   specificity.
 #' @export
-#' @importFrom plyr ddply
 #' @examplesIf !caret:::is_cran_check()
 #' set.seed(2444)
 #' dat <- twoClassSim(500, intercept = -10)

--- a/R/train.default.R
+++ b/R/train.default.R
@@ -274,9 +274,6 @@
   }
 
 #' @rdname train
-#' @importFrom stats predict
-#' @importFrom utils object.size flush.console
-#' @importFrom withr with_seed
 #' @export
 train.default <- function(
   x,
@@ -1196,7 +1193,6 @@ train.default <- function(
 }
 
 #' @rdname train
-#' @importFrom stats .getXlevels complete.cases contrasts model.frame model.matrix model.response model.weights na.fail
 #' @export
 train.formula <- function(
   form,
@@ -1261,7 +1257,6 @@ train.formula <- function(
 }
 
 #' @rdname train
-#' @importFrom withr with_seed
 #' @export
 train.recipe <- function(
   x,
@@ -2033,7 +2028,6 @@ train.recipe <- function(
 #' @export
 summary.train <- function(object, ...) summary(object$finalModel, ...)
 
-#' @importFrom stats predict residuals
 #' @export
 residuals.train <- function(object, ...) {
   if (object$modelType != "Regression") {
@@ -2060,7 +2054,6 @@ residuals.train <- function(object, ...) {
   resid
 }
 
-#' @importFrom stats predict fitted
 #' @export
 fitted.train <- function(object, ...) {
   prd <- fitted(object$finalModel)

--- a/R/train_recipes.R
+++ b/R/train_recipes.R
@@ -71,7 +71,6 @@ pred_failed <- function(x)
   inherits(x, "try-error")
 
 ## Convert the recipe to holdout data.
-#' @importFrom recipes bake all_predictors all_outcomes has_role
 holdout_rec <- function(object, dat, index) {
   ##
   ho_data <- bake(object$recipe,
@@ -100,7 +99,6 @@ holdout_rec <- function(object, dat, index) {
   ho_data <- as.data.frame(ho_data, stringsAsFactors = FALSE)
 }
 
-#' @importFrom recipes bake prep juice has_role
 rec_model <- function(rec, dat, method, tuneValue, obsLevels,
                       last = FALSE, sampling = NULL, classProbs, ...) {
 
@@ -172,7 +170,6 @@ rec_model <- function(rec, dat, method, tuneValue, obsLevels,
   list(fit = modelFit, recipe = trained_rec)
 }
 
-#' @importFrom recipes bake all_predictors
 rec_pred <- function (method, object, newdata, param = NULL)  {
   x <- bake(object$recipe, new_data = newdata, all_predictors())
   out <- method$predict(modelFit = object$fit, newdata = x,
@@ -182,7 +179,6 @@ rec_pred <- function (method, object, newdata, param = NULL)  {
   out
 }
 
-#' @importFrom recipes bake all_predictors
 rec_prob <- function (method, object, newdata = NULL, param = NULL)  {
   x <- bake(object$recipe, new_data = newdata, all_predictors())
   obsLevels <- levels(object$fit)

--- a/R/updates.R
+++ b/R/updates.R
@@ -41,7 +41,6 @@
 #' 
 #' update(knnFit1, list(.k = 3))
 #' @export
-#' @importFrom recipes juice all_predictors all_outcomes
 update.train <- function(object, param = NULL, ...) {
   if(is.null(param)) {
     if (all(names(object) != "modelInfo")) {

--- a/R/varImp.R
+++ b/R/varImp.R
@@ -155,7 +155,6 @@
     UseMethod("varImp")
   }
 
-#' @importFrom stats4 coef
 GarsonWeights <- function(object) {
   beta <- coef(object)
   abeta <- abs(beta)

--- a/R/varImp.train.R
+++ b/R/varImp.train.R
@@ -1,6 +1,5 @@
 #' @rdname varImp
 #' @export
-#' @importFrom recipes juice all_predictors all_outcomes
 "varImp.train" <- function(object, useModel = TRUE, nonpara = TRUE, scale = TRUE, ...) {
   code <- object$modelInfo
   if(is.null(code$varImp)) useModel <- FALSE

--- a/R/workflows.R
+++ b/R/workflows.R
@@ -22,7 +22,6 @@ progress <- function(x, names, iter, start = TRUE)
 }
 
 #' @rdname caret-internal
-#' @importFrom stats sd
 #' @export
 MeanSD <- function(x, exclude = NULL)
 {
@@ -49,9 +48,6 @@ expandParameters <- function(fixed, seq)
   out
 }
 
-#' @importFrom utils head
-#' @importFrom stats complete.cases
-#' @import foreach
 nominalTrainWorkflow <- function(x, y, wts, info, method, ppOpts, ctrl, lev, testing = FALSE, ...)
 {
   loadNamespace("caret")
@@ -331,7 +327,6 @@ nominalTrainWorkflow <- function(x, y, wts, info, method, ppOpts, ctrl, lev, tes
 }
 
 
-#' @import foreach
 looTrainWorkflow <- function(x, y, wts, info, method, ppOpts, ctrl, lev, testing = FALSE, ...)
 {
   loadNamespace("caret")
@@ -469,7 +464,6 @@ looTrainWorkflow <- function(x, y, wts, info, method, ppOpts, ctrl, lev, testing
   list(performance = out, predictions = result)
 }
 
-#' @import foreach
 oobTrainWorkflow <- function(x, y, wts, info, method, ppOpts, ctrl, lev, testing = FALSE, ...)
 {
   loadNamespace("caret")
@@ -511,7 +505,6 @@ oobTrainWorkflow <- function(x, y, wts, info, method, ppOpts, ctrl, lev, testing
 
 ################################################################################################
 
-#' @import foreach
 nominalSbfWorkflow <- function(x, y, ppOpts, ctrl, lev, ...) {
   loadNamespace("caret")
   ppp <- list(options = ppOpts)
@@ -597,7 +590,6 @@ nominalSbfWorkflow <- function(x, y, ppOpts, ctrl, lev, ...) {
   )
 }
 
-#' @import foreach
 looSbfWorkflow <- function(x, y, ppOpts, ctrl, lev, ...) {
   loadNamespace("caret")
   ppp <- list(options = ppOpts)
@@ -648,7 +640,6 @@ looSbfWorkflow <- function(x, y, ppOpts, ctrl, lev, ...) {
 
 ################################################################################################
 
-#' @import foreach
 nominalRfeWorkflow <- function(x, y, sizes, ppOpts, ctrl, lev, ...)
 {
   loadNamespace("caret")
@@ -740,7 +731,6 @@ nominalRfeWorkflow <- function(x, y, sizes, ppOpts, ctrl, lev, ...)
   list(performance = externPerf, everything = result)
 }
 
-#' @import foreach
 looRfeWorkflow <- function(x, y, sizes, ppOpts, ctrl, lev, ...)
 {
   loadNamespace("caret")


### PR DESCRIPTION
Gather the @importFrom / @import roxygen tags that were scattered across ~53 files into a single deduplicated block at the top of R/caret-package.R, wrapped in the standard usethis namespace markers:

    ## usethis namespace: start
    ...
    ## usethis namespace: end

Tags are grouped by package and wrapped to respect the 80-column line width. Verified with roxygen2 that the generated NAMESPACE is byte-identical, so this is a pure source refactor with no change to imported symbols.