### PR TITLE
Apply air formatting to R/ and tests/

### DIFF
--- a/R/BoxCoxTrans.R
+++ b/R/BoxCoxTrans.R
@@ -55,20 +55,20 @@
 #'
 #' @examples
 #' data(BloodBrain)
-#' 
+#'
 #' ratio <- exp(logBBB)
 #' bc <- BoxCoxTrans(ratio)
 #' bc
-#' 
+#'
 #' predict(bc, ratio[1:5])
-#' 
+#'
 #' ratio[5] <- NA
 #' bc2 <- BoxCoxTrans(ratio, bbbDescr$tpsa, na.rm = TRUE)
 #' bc2
-#' 
+#'
 #' manly <- expoTrans(ratio)
 #' manly
-#' 
+#'
 #' @family preprocessing
 #' @keywords utilities
 #'
@@ -80,29 +80,35 @@ BoxCoxTrans <- function(y, ...) UseMethod("BoxCoxTrans")
 ## TODO add exclusion list to preProc?
 #' @rdname BoxCoxTrans
 #' @export
-BoxCoxTrans.default <- function(y, x = rep(1, length(y)), fudge = 0.2, numUnique = 3,  na.rm = FALSE, ...) {
+BoxCoxTrans.default <- function(
+  y,
+  x = rep(1, length(y)),
+  fudge = 0.2,
+  numUnique = 3,
+  na.rm = FALSE,
+  ...
+) {
   requireNamespaceQuietStop("MASS")
   requireNamespaceQuietStop("e1071")
-  if(na.rm && (anyNA(y) | anyNA(x))) {
+  if (na.rm && (anyNA(y) | anyNA(x))) {
     rmv <- is.na(y) | is.na(x)
     y <- y[!rmv]
     x <- x[!rmv]
   }
-  if(!is.numeric(y) || is.factor(y) || is.character(y)) stop("y must be numeric")
+  if (!is.numeric(y) || is.factor(y) || is.character(y)) {
+    stop("y must be numeric")
+  }
 
-  if(any(y <= 0) || length(unique(y)) < numUnique) {
-    out <- list(lambda = NA,
-                summary = summary(y),
-                ratio = NA,
-                n = length(y))
+  if (any(y <= 0) || length(unique(y)) < numUnique) {
+    out <- list(lambda = NA, summary = summary(y), ratio = NA, n = length(y))
   } else {
-    bc <- MASS::boxcox(y~x, plotit = FALSE, ...)
+    bc <- MASS::boxcox(y ~ x, plotit = FALSE, ...)
     out <- list(lambda = bc$x[which.max(bc$y)])
   }
   out$fudge <- fudge
   out$n <- length(y)
   out$summary <- summary(y)
-  out$ratio <- max(y)/min(y)
+  out$ratio <- max(y) / min(y)
   out$skewness <- e1071::skewness(y)
   class(out) <- "BoxCoxTrans"
   out
@@ -111,21 +117,25 @@ BoxCoxTrans.default <- function(y, x = rep(1, length(y)), fudge = 0.2, numUnique
 
 #' @rdname BoxCoxTrans
 #' @export
-print.BoxCoxTrans <- function(x, newdata, digits = 3, ...){
+print.BoxCoxTrans <- function(x, newdata, digits = 3, ...) {
   cat("Box-Cox Transformation\n\n")
 
   cat(x$n, "data points used to estimate Lambda\n\n")
   cat("Input data summary:\n")
   print(x$summary)
-  if(!is.na(x$lambda)) {
+  if (!is.na(x$lambda)) {
     cat("\nLargest/Smallest:", signif(x$ratio, digits), "\n")
     cat("Sample Skewness:", signif(x$skewness, digits), "\n")
     cat("\nEstimated Lambda:", signif(x$lambda, digits), "\n")
-    if(x$lambda < x$fudge && x$lambda > -x$fudge)
+    if (x$lambda < x$fudge && x$lambda > -x$fudge) {
       cat("With fudge factor, Lambda = 0 will be used for transformations\n")
-    if(x$lambda < 1+x$fudge && x$lambda > 1-x$fudge)
+    }
+    if (x$lambda < 1 + x$fudge && x$lambda > 1 - x$fudge) {
       cat("With fudge factor, no transformation is applied\n")
-  } else cat("\nLambda could not be estimated; no transformation is applied\n")
+    }
+  } else {
+    cat("\nLambda could not be estimated; no transformation is applied\n")
+  }
   cat("\n")
   invisible(x)
 }
@@ -134,17 +144,25 @@ print.BoxCoxTrans <- function(x, newdata, digits = 3, ...){
 #' @rdname BoxCoxTrans
 #' @export
 predict.BoxCoxTrans <- function(object, newdata, ...) {
-  if(!is.vector(newdata) || !is.numeric(newdata)) stop("newdata should be a numeric vector")
-  if(is.na(object$lambda))  {
+  if (!is.vector(newdata) || !is.numeric(newdata)) {
+    stop("newdata should be a numeric vector")
+  }
+  if (is.na(object$lambda)) {
     out <- newdata
   } else {
-    if(object$lambda < object$fudge && object$lambda > -object$fudge)  {
-      if(any(newdata[!is.na(newdata)] <= 0)) warning("newdata should have values > 0")
+    if (object$lambda < object$fudge && object$lambda > -object$fudge) {
+      if (any(newdata[!is.na(newdata)] <= 0)) {
+        warning("newdata should have values > 0")
+      }
       out <- log(newdata)
     } else {
-      if(object$lambda < 1+object$fudge && object$lambda > 1-object$fudge) {
+      if (
+        object$lambda < 1 + object$fudge && object$lambda > 1 - object$fudge
+      ) {
         out <- newdata
-      } else out <- (newdata^object$lambda - 1)/object$lambda
+      } else {
+        out <- (newdata^object$lambda - 1) / object$lambda
+      }
     }
   }
   out

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -17,10 +17,10 @@ altTrainWorkflow <- function(x) x
 
 #' @export
 best <- function(x, metric, maximize) {
-  bestIter <- if (maximize) {
-    which.max(x[, metric])
+  if (maximize) {
+    bestIter <- which.max(x[, metric])
   } else {
-    which.min(x[, metric])
+    bestIter <- which.min(x[, metric])
   }
 
   bestIter

--- a/R/adaptive.R
+++ b/R/adaptive.R
@@ -2,8 +2,20 @@
 ##       add na.action to all eval functions
 ##       change multiplier and alpha to confidence
 
-adaptiveWorkflow <- function(x, y, wts, info, method, ppOpts, ctrl, lev,
-                             metric, maximize, testing = FALSE, ...) {
+adaptiveWorkflow <- function(
+  x,
+  y,
+  wts,
+  info,
+  method,
+  ppOpts,
+  ctrl,
+  lev,
+  metric,
+  maximize,
+  testing = FALSE,
+  ...
+) {
   loadNamespace("caret")
   ppp <- list(options = ppOpts)
   ppp <- c(ppp, ctrl$preProcOptions)
@@ -17,488 +29,719 @@ adaptiveWorkflow <- function(x, y, wts, info, method, ppOpts, ctrl, lev,
   `%op%` <- getOper(ctrl$allowParallel && getDoParWorkers() > 1)
 
   pkgs <- c("methods", "caret")
-  if(!is.null(method$library)) pkgs <- c(pkgs, method$library)
+  if (!is.null(method$library)) {
+    pkgs <- c(pkgs, method$library)
+  }
 
-  init_index <- seq(along.with = resampleIndex)[1:(ctrl$adaptive$min-1)]
-  extra_index <- seq(along.with = resampleIndex)[-(1:(ctrl$adaptive$min-1))]
+  init_index <- seq(along.with = resampleIndex)[1:(ctrl$adaptive$min - 1)]
+  extra_index <- seq(along.with = resampleIndex)[-(1:(ctrl$adaptive$min - 1))]
 
-  keep_pred <- isTRUE(ctrl$savePredictions) || ctrl$savePredictions %in% c("all", "final")
+  keep_pred <- isTRUE(ctrl$savePredictions) ||
+    ctrl$savePredictions %in% c("all", "final")
 
-  init_result <- foreach(iter = seq(along.with = init_index),
-                         .combine = "c",
-                         .verbose = FALSE,
-                         .errorhandling = "stop") %:%
-    foreach(parm = seq_len(nrow(info$loop)),
-            .combine = "c",
-            .verbose = FALSE,
-            .packages = pkgs,
-            .errorhandling = "stop")  %op% {
-              testing <- FALSE
-              if(!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds))) set.seed(ctrl$seeds[[iter]][parm])
+  init_result <- foreach(
+    iter = seq(along.with = init_index),
+    .combine = "c",
+    .verbose = FALSE,
+    .errorhandling = "stop"
+  ) %:%
+    foreach(
+      parm = seq_len(nrow(info$loop)),
+      .combine = "c",
+      .verbose = FALSE,
+      .packages = pkgs,
+      .errorhandling = "stop"
+    ) %op%
+    {
+      testing <- FALSE
+      if (!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds))) {
+        set.seed(ctrl$seeds[[iter]][parm])
+      }
 
-              loadNamespace("caret")
-              lapply(pkgs, requireNamespaceQuietStop)
+      loadNamespace("caret")
+      lapply(pkgs, requireNamespaceQuietStop)
 
-              if(ctrl$verboseIter) progress(printed[parm,,drop = FALSE],
-                                            names(resampleIndex), iter)
+      if (ctrl$verboseIter) {
+        progress(printed[parm, , drop = FALSE], names(resampleIndex), iter)
+      }
 
-              modelIndex <- resampleIndex[[iter]]
-              holdoutIndex <- ctrl$indexOut[[iter]]
+      modelIndex <- resampleIndex[[iter]]
+      holdoutIndex <- ctrl$indexOut[[iter]]
 
-              if(testing) cat("pre-model\n")
+      if (testing) {
+        cat("pre-model\n")
+      }
 
-              if(is.null(info$submodels[[parm]]) || nrow(info$submodels[[parm]]) > 0) {
-                submod <- info$submodels[[parm]]
-              } else submod <- NULL
+      if (is.null(info$submodels[[parm]]) || nrow(info$submodels[[parm]]) > 0) {
+        submod <- info$submodels[[parm]]
+      } else {
+        submod <- NULL
+      }
 
-              mod <- try(
-                createModel(x = x[modelIndex,,drop = FALSE ],
-                            y = y[modelIndex],
-                            wts = wts[modelIndex],
-                            method = method,
-                            tuneValue = info$loop[parm,,drop = FALSE],
-                            obsLevels = lev,
-                            pp = ppp,
-                            classProbs = ctrl$classProbs,
-                            sampling = ctrl$sampling,
-                            ...),
-                silent = TRUE)
+      mod <- try(
+        createModel(
+          x = x[modelIndex, , drop = FALSE],
+          y = y[modelIndex],
+          wts = wts[modelIndex],
+          method = method,
+          tuneValue = info$loop[parm, , drop = FALSE],
+          obsLevels = lev,
+          pp = ppp,
+          classProbs = ctrl$classProbs,
+          sampling = ctrl$sampling,
+          ...
+        ),
+        silent = TRUE
+      )
 
-              if(class(mod)[1] != "try-error") {
-                predicted <- try(
-                  predictionFunction(method = method,
-                                     modelFit = mod$fit,
-                                     newdata = x[holdoutIndex,, drop = FALSE],
-                                     preProc = mod$preProc,
-                                     param = submod),
-                  silent = TRUE)
+      if (class(mod)[1] != "try-error") {
+        predicted <- try(
+          predictionFunction(
+            method = method,
+            modelFit = mod$fit,
+            newdata = x[holdoutIndex, , drop = FALSE],
+            preProc = mod$preProc,
+            param = submod
+          ),
+          silent = TRUE
+        )
 
-                if (inherits(predicted, "try-error")) {
-                  wrn <- paste(colnames(printed[parm,,drop = FALSE]),
-                               printed[parm,,drop = FALSE],
-                               sep = "=",
-                               collapse = ", ")
-                  wrn <- paste("predictions failed for ", names(resampleIndex)[iter],
-                               ": ", wrn, " ", as.character(predicted), sep = "")
-                  if(ctrl$verboseIter) cat(wrn, "\n")
-                  warning(wrn)
-                  rm(wrn)
+        if (inherits(predicted, "try-error")) {
+          wrn <- paste(
+            colnames(printed[parm, , drop = FALSE]),
+            printed[parm, , drop = FALSE],
+            sep = "=",
+            collapse = ", "
+          )
+          wrn <- paste(
+            "predictions failed for ",
+            names(resampleIndex)[iter],
+            ": ",
+            wrn,
+            " ",
+            as.character(predicted),
+            sep = ""
+          )
+          if (ctrl$verboseIter) {
+            cat(wrn, "\n")
+          }
+          warning(wrn)
+          rm(wrn)
 
-                  ## setup a dummy results with NA values for all predictions
-                  nPred <- length(holdoutIndex)
-                  if(!is.null(lev)) {
-                    predicted <- rep("", nPred)
-                    predicted[seq(along.with = predicted)] <- NA
-                  } else {
-                    predicted <- rep(NA, nPred)
-                  }
-                  if(!is.null(submod)) {
-                    tmp <- predicted
-                    predicted <- vector(mode = "list", length = nrow(info$submodels[[parm]]) + 1)
-                    for(i in seq(along.with = predicted)) predicted[[i]] <- tmp
-                    rm(tmp)
-                  }
-                }
-              } else {
-                wrn <- paste(colnames(printed[parm,,drop = FALSE]),
-                             printed[parm,,drop = FALSE],
-                             sep = "=",
-                             collapse = ", ")
-                wrn <- paste("model fit failed for ", names(resampleIndex)[iter],
-                             ": ", wrn, " ", as.character(mod), sep = "")
-                if(ctrl$verboseIter) cat(wrn, "\n")
-                warning(wrn)
-                rm(wrn)
+          ## setup a dummy results with NA values for all predictions
+          nPred <- length(holdoutIndex)
+          if (!is.null(lev)) {
+            predicted <- rep("", nPred)
+            predicted[seq(along.with = predicted)] <- NA
+          } else {
+            predicted <- rep(NA, nPred)
+          }
+          if (!is.null(submod)) {
+            tmp <- predicted
+            predicted <- vector(
+              mode = "list",
+              length = nrow(info$submodels[[parm]]) + 1
+            )
+            for (i in seq(along.with = predicted)) {
+              predicted[[i]] <- tmp
+            }
+            rm(tmp)
+          }
+        }
+      } else {
+        wrn <- paste(
+          colnames(printed[parm, , drop = FALSE]),
+          printed[parm, , drop = FALSE],
+          sep = "=",
+          collapse = ", "
+        )
+        wrn <- paste(
+          "model fit failed for ",
+          names(resampleIndex)[iter],
+          ": ",
+          wrn,
+          " ",
+          as.character(mod),
+          sep = ""
+        )
+        if (ctrl$verboseIter) {
+          cat(wrn, "\n")
+        }
+        warning(wrn)
+        rm(wrn)
 
-                ## setup a dummy results with NA values for all predictions
-                nPred <- length(holdoutIndex)
-                if(!is.null(lev)) {
-                  predicted <- rep("", nPred)
-                  predicted[seq(along.with = predicted)] <- NA
-                } else {
-                  predicted <- rep(NA, nPred)
-                }
-                if(!is.null(submod)) {
-                  tmp <- predicted
-                  predicted <- vector(mode = "list", length = nrow(info$submodels[[parm]]) + 1)
-                  for(i in seq(along.with = predicted)) predicted[[i]] <- tmp
-                  rm(tmp)
-                }
-              }
+        ## setup a dummy results with NA values for all predictions
+        nPred <- length(holdoutIndex)
+        if (!is.null(lev)) {
+          predicted <- rep("", nPred)
+          predicted[seq(along.with = predicted)] <- NA
+        } else {
+          predicted <- rep(NA, nPred)
+        }
+        if (!is.null(submod)) {
+          tmp <- predicted
+          predicted <- vector(
+            mode = "list",
+            length = nrow(info$submodels[[parm]]) + 1
+          )
+          for (i in seq(along.with = predicted)) {
+            predicted[[i]] <- tmp
+          }
+          rm(tmp)
+        }
+      }
 
-              if(testing) print(head(predicted))
-              if(ctrl$classProbs)
-              {
-                if(class(mod)[1] != "try-error") {
-                  probValues <- probFunction(method = method,
-                                             modelFit = mod$fit,
-                                             newdata = x[holdoutIndex,, drop = FALSE],
-                                             preProc = mod$preProc,
-                                             param = submod)
-                } else {
-                  probValues <- as.data.frame(matrix(NA, nrow = nPred, ncol = length(lev)), stringsAsFactors = FALSE)
-                  colnames(probValues) <- lev
-                  if(!is.null(submod))
-                  {
-                    tmp <- probValues
-                    probValues <- vector(mode = "list", length = nrow(info$submodels[[parm]]) + 1)
-                    for(i in seq(along.with = probValues)) probValues[[i]] <- tmp
-                    rm(tmp)
-                  }
-                }
-                if(testing) print(head(probValues))
-              }
+      if (testing) {
+        print(head(predicted))
+      }
+      if (ctrl$classProbs) {
+        if (class(mod)[1] != "try-error") {
+          probValues <- probFunction(
+            method = method,
+            modelFit = mod$fit,
+            newdata = x[holdoutIndex, , drop = FALSE],
+            preProc = mod$preProc,
+            param = submod
+          )
+        } else {
+          probValues <- as.data.frame(
+            matrix(NA, nrow = nPred, ncol = length(lev)),
+            stringsAsFactors = FALSE
+          )
+          colnames(probValues) <- lev
+          if (!is.null(submod)) {
+            tmp <- probValues
+            probValues <- vector(
+              mode = "list",
+              length = nrow(info$submodels[[parm]]) + 1
+            )
+            for (i in seq(along.with = probValues)) {
+              probValues[[i]] <- tmp
+            }
+            rm(tmp)
+          }
+        }
+        if (testing) print(head(probValues))
+      }
 
-              ##################################
+      ##################################
 
-              if(!is.null(submod))
-              {
-                ## merge the fixed and seq parameter values together
-                allParam <- expandParameters(info$loop[parm,,drop = FALSE], info$submodels[[parm]])
-                allParam <- allParam[complete.cases(allParam),, drop = FALSE]
+      if (!is.null(submod)) {
+        ## merge the fixed and seq parameter values together
+        allParam <- expandParameters(
+          info$loop[parm, , drop = FALSE],
+          info$submodels[[parm]]
+        )
+        allParam <- allParam[complete.cases(allParam), , drop = FALSE]
 
-                ## collate the predicitons across all the sub-models
-                predicted <- lapply(predicted,
-                                    function(x, y, wts, lv) {
-                                      if(!is.factor(x) && is.character(x)) x <- factor(as.character(x), levels = lv)
-                                      out <- data.frame(pred = x, obs = y, stringsAsFactors = FALSE)
-                                      if(!is.null(wts)) out$weights <- wts
-                                      out
-                                    },
-                                    y = y[holdoutIndex],
-                                    wts = wts[holdoutIndex],
-                                    lv = lev)
-                if(testing) print(head(predicted))
+        ## collate the predicitons across all the sub-models
+        predicted <- lapply(
+          predicted,
+          function(x, y, wts, lv) {
+            if (!is.factor(x) && is.character(x)) {
+              x <- factor(as.character(x), levels = lv)
+            }
+            out <- data.frame(pred = x, obs = y, stringsAsFactors = FALSE)
+            if (!is.null(wts)) {
+              out$weights <- wts
+            }
+            out
+          },
+          y = y[holdoutIndex],
+          wts = wts[holdoutIndex],
+          lv = lev
+        )
+        if (testing) {
+          print(head(predicted))
+        }
 
-                ## same for the class probabilities
-                if(ctrl$classProbs) {
-                  for(k in seq(along.with = predicted)) predicted[[k]] <- cbind(predicted[[k]], probValues[[k]])
-                }
+        ## same for the class probabilities
+        if (ctrl$classProbs) {
+          for (k in seq(along.with = predicted)) {
+            predicted[[k]] <- cbind(predicted[[k]], probValues[[k]])
+          }
+        }
 
-                if(keep_pred) {
-                  tmpPred <- predicted
-                  for(modIndex in seq(along.with = tmpPred))
-                  {
-                    tmpPred[[modIndex]]$rowIndex <- holdoutIndex
-                    tmpPred[[modIndex]] <- merge(tmpPred[[modIndex]],
-                                                 allParam[modIndex,,drop = FALSE],
-                                                 all = TRUE)
-                  }
-                  tmpPred <- rbind.fill(tmpPred)
-                  tmpPred$Resample <- names(resampleIndex)[iter]
-                } else tmpPred <- NULL
+        if (keep_pred) {
+          tmpPred <- predicted
+          for (modIndex in seq(along.with = tmpPred)) {
+            tmpPred[[modIndex]]$rowIndex <- holdoutIndex
+            tmpPred[[modIndex]] <- merge(
+              tmpPred[[modIndex]],
+              allParam[modIndex, , drop = FALSE],
+              all = TRUE
+            )
+          }
+          tmpPred <- rbind.fill(tmpPred)
+          tmpPred$Resample <- names(resampleIndex)[iter]
+        } else {
+          tmpPred <- NULL
+        }
 
-                ## get the performance for this resample for each sub-model
-                thisResample <- lapply(predicted,
-                                       ctrl$summaryFunction,
-                                       lev = lev,
-                                       model = method)
-                if(testing) print(head(thisResample))
-                ## for classification, add the cell counts
-                if(length(lev) > 1) {
-                  cells <- lapply(predicted,
-                                  function(x) flatTable(x$pred, x$obs))
-                  for(ind in seq(along.with = cells)) thisResample[[ind]] <- c(thisResample[[ind]], cells[[ind]])
-                }
-                thisResample <- do.call("rbind", thisResample)
-                thisResample <- cbind(allParam, thisResample)
+        ## get the performance for this resample for each sub-model
+        thisResample <- lapply(
+          predicted,
+          ctrl$summaryFunction,
+          lev = lev,
+          model = method
+        )
+        if (testing) {
+          print(head(thisResample))
+        }
+        ## for classification, add the cell counts
+        if (length(lev) > 1) {
+          cells <- lapply(predicted, function(x) flatTable(x$pred, x$obs))
+          for (ind in seq(along.with = cells)) {
+            thisResample[[ind]] <- c(thisResample[[ind]], cells[[ind]])
+          }
+        }
+        thisResample <- do.call("rbind", thisResample)
+        thisResample <- cbind(allParam, thisResample)
+      } else {
+        if (is.factor(y)) {
+          predicted <- factor(as.character(predicted), levels = lev)
+        }
+        tmp <- data.frame(
+          pred = predicted,
+          obs = y[holdoutIndex],
+          stringsAsFactors = FALSE
+        )
+        ## Sometimes the code above does not coerce the first
+        ## columnn to be named "pred" so force it
+        names(tmp)[1] <- "pred"
+        if (!is.null(wts)) {
+          tmp$weights <- wts[holdoutIndex]
+        }
+        if (ctrl$classProbs) {
+          tmp <- cbind(tmp, probValues)
+        }
 
-              } else {
-                if(is.factor(y)) predicted <- factor(as.character(predicted), levels = lev)
-                tmp <-  data.frame(pred = predicted,
-                                   obs = y[holdoutIndex],
-                                   stringsAsFactors = FALSE)
-                ## Sometimes the code above does not coerce the first
-                ## columnn to be named "pred" so force it
-                names(tmp)[1] <- "pred"
-                if(!is.null(wts)) tmp$weights <- wts[holdoutIndex]
-                if(ctrl$classProbs) tmp <- cbind(tmp, probValues)
+        if (keep_pred) {
+          tmpPred <- tmp
+          tmpPred$rowIndex <- holdoutIndex
+          tmpPred <- merge(tmpPred, info$loop[parm, , drop = FALSE], all = TRUE)
+          tmpPred$Resample <- names(resampleIndex)[iter]
+        } else {
+          tmpPred <- NULL
+        }
 
-                if(keep_pred) {
-                  tmpPred <- tmp
-                  tmpPred$rowIndex <- holdoutIndex
-                  tmpPred <- merge(tmpPred, info$loop[parm,,drop = FALSE],
-                                   all = TRUE)
-                  tmpPred$Resample <- names(resampleIndex)[iter]
-                } else tmpPred <- NULL
+        ##################################
+        thisResample <- ctrl$summaryFunction(tmp, lev = lev, model = method)
 
-                ##################################
-                thisResample <- ctrl$summaryFunction(tmp,
-                                                     lev = lev,
-                                                     model = method)
-
-                ## if classification, get the confusion matrix
-                if(length(lev) > 1) thisResample <- c(thisResample, flatTable(tmp$pred, tmp$obs))
-                thisResample <- as.data.frame(t(thisResample), stringsAsFactors = FALSE)
-                thisResample <- cbind(thisResample, info$loop[parm,,drop = FALSE])
-
-              }
-              thisResample$Resample <- names(resampleIndex)[iter]
-              if(ctrl$verboseIter) progress(printed[parm,,drop = FALSE],
-                                            names(resampleIndex), iter, FALSE)
-              list(resamples = thisResample, pred = tmpPred)
-            } ## end initial loop over resamples and models
-
+        ## if classification, get the confusion matrix
+        if (length(lev) > 1) {
+          thisResample <- c(thisResample, flatTable(tmp$pred, tmp$obs))
+        }
+        thisResample <- as.data.frame(t(thisResample), stringsAsFactors = FALSE)
+        thisResample <- cbind(thisResample, info$loop[parm, , drop = FALSE])
+      }
+      thisResample$Resample <- names(resampleIndex)[iter]
+      if (ctrl$verboseIter) {
+        progress(
+          printed[parm, , drop = FALSE],
+          names(resampleIndex),
+          iter,
+          FALSE
+        )
+      }
+      list(resamples = thisResample, pred = tmpPred)
+    } ## end initial loop over resamples and models
 
   init_resamp <- rbind.fill(init_result[names(init_result) == "resamples"])
-  init_pred <- if(keep_pred)  rbind.fill(init_result[names(init_result) == "pred"]) else NULL
+  init_pred <- if (keep_pred) {
+    rbind.fill(init_result[names(init_result) == "pred"])
+  } else {
+    NULL
+  }
   names(init_resamp) <- gsub("^\\.", "", names(init_resamp))
-  if(any(!complete.cases(init_resamp[,!grepl("^cell|Resample", colnames(init_resamp)),drop = FALSE])))
+  if (
+    any(
+      !complete.cases(init_resamp[,
+        !grepl("^cell|Resample", colnames(init_resamp)),
+        drop = FALSE
+      ])
+    )
+  ) {
     warning("There were missing values in resampled performance measures.")
+  }
 
-  init_summary <- ddply(init_resamp[,!grepl("^cell|Resample", colnames(init_resamp)),drop = FALSE],
-                        ## TODO check this for seq models
-                        gsub("^\\.", "", colnames(info$loop)),
-                        MeanSD,
-                        exclude = gsub("^\\.", "", colnames(info$loop)))
+  init_summary <- ddply(
+    init_resamp[,
+      !grepl("^cell|Resample", colnames(init_resamp)),
+      drop = FALSE
+    ],
+    ## TODO check this for seq models
+    gsub("^\\.", "", colnames(info$loop)),
+    MeanSD,
+    exclude = gsub("^\\.", "", colnames(info$loop))
+  )
 
   new_info <- info
   num_left <- Inf
-  for(iter in ctrl$adaptive$min:length(resampleIndex)) {
-
-    if(num_left > 1) {
+  for (iter in ctrl$adaptive$min:length(resampleIndex)) {
+    if (num_left > 1) {
       modelIndex <- resampleIndex[[iter]]
       holdoutIndex <- ctrl$indexOut[[iter]]
 
       printed <- format(new_info$loop, digits = 4)
       colnames(printed) <- gsub("^\\.", "", colnames(printed))
 
-      adapt_results <- foreach(parm = seq_len(nrow(new_info$loop)),
-                               .combine = "c",
-                               .verbose = FALSE,
-                               .packages = pkgs)  %op% {
-                                 requireNamespaceQuietStop("methods")
-                                 requireNamespaceQuietStop("caret")
-                                 if(ctrl$verboseIter) progress(printed[parm,,drop = FALSE],
-                                                               names(resampleIndex), iter, TRUE)
+      adapt_results <- foreach(
+        parm = seq_len(nrow(new_info$loop)),
+        .combine = "c",
+        .verbose = FALSE,
+        .packages = pkgs
+      ) %op%
+        {
+          requireNamespaceQuietStop("methods")
+          requireNamespaceQuietStop("caret")
+          if (ctrl$verboseIter) {
+            progress(
+              printed[parm, , drop = FALSE],
+              names(resampleIndex),
+              iter,
+              TRUE
+            )
+          }
 
-                                 if(is.null(new_info$submodels[[parm]]) || nrow(new_info$submodels[[parm]]) > 0) {
-                                   submod <- new_info$submodels[[parm]]
-                                 } else submod <- NULL
-                                 mod <- try(
-                                   createModel(x = x[modelIndex,,drop = FALSE ],
-                                               y = y[modelIndex],
-                                               wts = wts[modelIndex],
-                                               method = method,
-                                               tuneValue = new_info$loop[parm,,drop = FALSE],
-                                               obsLevels = lev,
-                                               pp = ppp,
-                                               classProbs = ctrl$classProbs,
-                                               sampling = ctrl$sampling,
-                                               ...),
-                                   silent = TRUE)
+          if (
+            is.null(new_info$submodels[[parm]]) ||
+              nrow(new_info$submodels[[parm]]) > 0
+          ) {
+            submod <- new_info$submodels[[parm]]
+          } else {
+            submod <- NULL
+          }
+          mod <- try(
+            createModel(
+              x = x[modelIndex, , drop = FALSE],
+              y = y[modelIndex],
+              wts = wts[modelIndex],
+              method = method,
+              tuneValue = new_info$loop[parm, , drop = FALSE],
+              obsLevels = lev,
+              pp = ppp,
+              classProbs = ctrl$classProbs,
+              sampling = ctrl$sampling,
+              ...
+            ),
+            silent = TRUE
+          )
 
-                                 if(class(mod)[1] != "try-error") {
-                                   predicted <- try(
-                                     predictionFunction(method = method,
-                                                        modelFit = mod$fit,
-                                                        newdata = x[holdoutIndex,, drop = FALSE],
-                                                        preProc = mod$preProc,
-                                                        param = submod),
-                                     silent = TRUE)
+          if (class(mod)[1] != "try-error") {
+            predicted <- try(
+              predictionFunction(
+                method = method,
+                modelFit = mod$fit,
+                newdata = x[holdoutIndex, , drop = FALSE],
+                preProc = mod$preProc,
+                param = submod
+              ),
+              silent = TRUE
+            )
 
-                                   if (inherits(predicted, "try-error"))  {
-                                     wrn <- paste(colnames(printed[parm,,drop = FALSE]),
-                                                  printed[parm,,drop = FALSE],
-                                                  sep = "=",
-                                                  collapse = ", ")
-                                     wrn <- paste("predictions failed for ", names(resampleIndex)[iter],
-                                                  ": ", wrn, " ", as.character(predicted), sep = "")
-                                     if(ctrl$verboseIter) cat(wrn, "\n")
-                                     warning(wrn)
-                                     rm(wrn)
+            if (inherits(predicted, "try-error")) {
+              wrn <- paste(
+                colnames(printed[parm, , drop = FALSE]),
+                printed[parm, , drop = FALSE],
+                sep = "=",
+                collapse = ", "
+              )
+              wrn <- paste(
+                "predictions failed for ",
+                names(resampleIndex)[iter],
+                ": ",
+                wrn,
+                " ",
+                as.character(predicted),
+                sep = ""
+              )
+              if (ctrl$verboseIter) {
+                cat(wrn, "\n")
+              }
+              warning(wrn)
+              rm(wrn)
 
-                                     ## setup a dummy results with NA values for all predictions
-                                     nPred <- length(holdoutIndex)
-                                     if(!is.null(lev)) {
-                                       predicted <- rep("", nPred)
-                                       predicted[seq(along.with = predicted)] <- NA
-                                     } else {
-                                       predicted <- rep(NA, nPred)
-                                     }
-                                     if(!is.null(submod)) {
-                                       tmp <- predicted
-                                       predicted <- vector(mode = "list", length = nrow(new_info$submodels[[parm]]) + 1)
-                                       for(i in seq(along.with = predicted)) predicted[[i]] <- tmp
-                                       rm(tmp)
-                                     }
-                                   }
-                                 } else {
-                                   wrn <- paste(colnames(printed[parm,,drop = FALSE]),
-                                                printed[parm,,drop = FALSE],
-                                                sep = "=",
-                                                collapse = ", ")
-                                   wrn <- paste("model fit failed for ", names(resampleIndex)[iter],
-                                                ": ", wrn, " ", as.character(mod), sep = "")
-                                   if(ctrl$verboseIter) cat(wrn, "\n")
-                                   warning(wrn)
-                                   rm(wrn)
+              ## setup a dummy results with NA values for all predictions
+              nPred <- length(holdoutIndex)
+              if (!is.null(lev)) {
+                predicted <- rep("", nPred)
+                predicted[seq(along.with = predicted)] <- NA
+              } else {
+                predicted <- rep(NA, nPred)
+              }
+              if (!is.null(submod)) {
+                tmp <- predicted
+                predicted <- vector(
+                  mode = "list",
+                  length = nrow(new_info$submodels[[parm]]) + 1
+                )
+                for (i in seq(along.with = predicted)) {
+                  predicted[[i]] <- tmp
+                }
+                rm(tmp)
+              }
+            }
+          } else {
+            wrn <- paste(
+              colnames(printed[parm, , drop = FALSE]),
+              printed[parm, , drop = FALSE],
+              sep = "=",
+              collapse = ", "
+            )
+            wrn <- paste(
+              "model fit failed for ",
+              names(resampleIndex)[iter],
+              ": ",
+              wrn,
+              " ",
+              as.character(mod),
+              sep = ""
+            )
+            if (ctrl$verboseIter) {
+              cat(wrn, "\n")
+            }
+            warning(wrn)
+            rm(wrn)
 
-                                   ## setup a dummy results with NA values for all predictions
-                                   nPred <- length(holdoutIndex)
-                                   if(!is.null(lev)) {
-                                     predicted <- rep("", nPred)
-                                     predicted[seq(along.with = predicted)] <- NA
-                                   } else {
-                                     predicted <- rep(NA, nPred)
-                                   }
-                                   if(!is.null(submod)) {
-                                     tmp <- predicted
-                                     predicted <- vector(mode = "list", length = nrow(new_info$submodels[[parm]]) + 1)
-                                     for(i in seq(along.with = predicted)) predicted[[i]] <- tmp
-                                     rm(tmp)
-                                   }
-                                 }
+            ## setup a dummy results with NA values for all predictions
+            nPred <- length(holdoutIndex)
+            if (!is.null(lev)) {
+              predicted <- rep("", nPred)
+              predicted[seq(along.with = predicted)] <- NA
+            } else {
+              predicted <- rep(NA, nPred)
+            }
+            if (!is.null(submod)) {
+              tmp <- predicted
+              predicted <- vector(
+                mode = "list",
+                length = nrow(new_info$submodels[[parm]]) + 1
+              )
+              for (i in seq(along.with = predicted)) {
+                predicted[[i]] <- tmp
+              }
+              rm(tmp)
+            }
+          }
 
-                                 if(testing) print(head(predicted))
-                                 if(ctrl$classProbs)
-                                 {
-                                   if(class(mod)[1] != "try-error") {
-                                     probValues <- probFunction(method = method,
-                                                                modelFit = mod$fit,
-                                                                newdata = x[holdoutIndex,, drop = FALSE],
-                                                                preProc = mod$preProc,
-                                                                param = submod)
-                                   } else {
-                                     probValues <- as.data.frame(matrix(NA, nrow = nPred, ncol = length(lev)), stringsAsFactors = FALSE)
-                                     colnames(probValues) <- lev
-                                     if(!is.null(submod))
-                                     {
-                                       tmp <- probValues
-                                       probValues <- vector(mode = "list", length = nrow(new_info$submodels[[parm]]) + 1)
-                                       for(i in seq(along.with = probValues)) probValues[[i]] <- tmp
-                                       rm(tmp)
-                                     }
-                                   }
-                                   if(testing) print(head(probValues))
-                                 }
+          if (testing) {
+            print(head(predicted))
+          }
+          if (ctrl$classProbs) {
+            if (class(mod)[1] != "try-error") {
+              probValues <- probFunction(
+                method = method,
+                modelFit = mod$fit,
+                newdata = x[holdoutIndex, , drop = FALSE],
+                preProc = mod$preProc,
+                param = submod
+              )
+            } else {
+              probValues <- as.data.frame(
+                matrix(NA, nrow = nPred, ncol = length(lev)),
+                stringsAsFactors = FALSE
+              )
+              colnames(probValues) <- lev
+              if (!is.null(submod)) {
+                tmp <- probValues
+                probValues <- vector(
+                  mode = "list",
+                  length = nrow(new_info$submodels[[parm]]) + 1
+                )
+                for (i in seq(along.with = probValues)) {
+                  probValues[[i]] <- tmp
+                }
+                rm(tmp)
+              }
+            }
+            if (testing) print(head(probValues))
+          }
 
-                                 ##################################
+          ##################################
 
-                                 if(!is.null(submod))
-                                 {
-                                   ## merge the fixed and seq parameter values together
-                                   allParam <- expandParameters(new_info$loop[parm,,drop = FALSE],
-                                                                submod)
-                                   allParam <- allParam[complete.cases(allParam),, drop = FALSE]
+          if (!is.null(submod)) {
+            ## merge the fixed and seq parameter values together
+            allParam <- expandParameters(
+              new_info$loop[parm, , drop = FALSE],
+              submod
+            )
+            allParam <- allParam[complete.cases(allParam), , drop = FALSE]
 
-                                   ## collate the predicitons across all the sub-models
-                                   predicted <- lapply(predicted,
-                                                       function(x, y, wts, lv) {
-                                                         if(!is.factor(x) && is.character(x)) x <- factor(as.character(x), levels = lv)
-                                                         out <- data.frame(pred = x, obs = y, stringsAsFactors = FALSE)
-                                                         if(!is.null(wts)) out$weights <- wts
-                                                         out
-                                                       },
-                                                       y = y[holdoutIndex],
-                                                       wts = wts[holdoutIndex],
-                                                       lv = lev)
-                                   if(testing) print(head(predicted))
+            ## collate the predicitons across all the sub-models
+            predicted <- lapply(
+              predicted,
+              function(x, y, wts, lv) {
+                if (!is.factor(x) && is.character(x)) {
+                  x <- factor(as.character(x), levels = lv)
+                }
+                out <- data.frame(pred = x, obs = y, stringsAsFactors = FALSE)
+                if (!is.null(wts)) {
+                  out$weights <- wts
+                }
+                out
+              },
+              y = y[holdoutIndex],
+              wts = wts[holdoutIndex],
+              lv = lev
+            )
+            if (testing) {
+              print(head(predicted))
+            }
 
-                                   ## same for the class probabilities
-                                   if(ctrl$classProbs) {
-                                     for(k in seq(along.with = predicted)) predicted[[k]] <- cbind(predicted[[k]], probValues[[k]])
-                                   }
+            ## same for the class probabilities
+            if (ctrl$classProbs) {
+              for (k in seq(along.with = predicted)) {
+                predicted[[k]] <- cbind(predicted[[k]], probValues[[k]])
+              }
+            }
 
-                                   if(keep_pred) {
-                                     tmpPred <- predicted
-                                     for(modIndex in seq(along.with = tmpPred))
-                                     {
-                                       tmpPred[[modIndex]]$rowIndex <- holdoutIndex
-                                       tmpPred[[modIndex]] <- merge(tmpPred[[modIndex]],
-                                                                    allParam[modIndex,,drop = FALSE],
-                                                                    all = TRUE)
-                                     }
-                                     tmpPred <- rbind.fill(tmpPred)
-                                     tmpPred$Resample <- names(resampleIndex)[iter]
-                                   } else tmpPred <- NULL
+            if (keep_pred) {
+              tmpPred <- predicted
+              for (modIndex in seq(along.with = tmpPred)) {
+                tmpPred[[modIndex]]$rowIndex <- holdoutIndex
+                tmpPred[[modIndex]] <- merge(
+                  tmpPred[[modIndex]],
+                  allParam[modIndex, , drop = FALSE],
+                  all = TRUE
+                )
+              }
+              tmpPred <- rbind.fill(tmpPred)
+              tmpPred$Resample <- names(resampleIndex)[iter]
+            } else {
+              tmpPred <- NULL
+            }
 
-                                   ## get the performance for this resample for each sub-model
-                                   thisResample <- lapply(predicted,
-                                                          ctrl$summaryFunction,
-                                                          lev = lev,
-                                                          model = method)
-                                   if(testing) print(head(thisResample))
-                                   ## for classification, add the cell counts
-                                   if(length(lev) > 1) {
-                                     cells <- lapply(predicted,
-                                                     function(x) flatTable(x$pred, x$obs))
-                                     for(ind in seq(along.with = cells)) thisResample[[ind]] <- c(thisResample[[ind]], cells[[ind]])
-                                   }
-                                   thisResample <- do.call("rbind", thisResample)
-                                   thisResample <- cbind(allParam, thisResample)
+            ## get the performance for this resample for each sub-model
+            thisResample <- lapply(
+              predicted,
+              ctrl$summaryFunction,
+              lev = lev,
+              model = method
+            )
+            if (testing) {
+              print(head(thisResample))
+            }
+            ## for classification, add the cell counts
+            if (length(lev) > 1) {
+              cells <- lapply(predicted, function(x) flatTable(x$pred, x$obs))
+              for (ind in seq(along.with = cells)) {
+                thisResample[[ind]] <- c(thisResample[[ind]], cells[[ind]])
+              }
+            }
+            thisResample <- do.call("rbind", thisResample)
+            thisResample <- cbind(allParam, thisResample)
+          } else {
+            if (is.factor(y)) {
+              predicted <- factor(as.character(predicted), levels = lev)
+            }
+            tmp <- data.frame(
+              pred = predicted,
+              obs = y[holdoutIndex],
+              stringsAsFactors = FALSE
+            )
+            ## Sometimes the code above does not coerce the first
+            ## columnn to be named "pred" so force it
+            names(tmp)[1] <- "pred"
+            if (!is.null(wts)) {
+              tmp$weights <- wts[holdoutIndex]
+            }
+            if (ctrl$classProbs) {
+              tmp <- cbind(tmp, probValues)
+            }
 
-                                 } else {
-                                   if(is.factor(y)) predicted <- factor(as.character(predicted), levels = lev)
-                                   tmp <-  data.frame(pred = predicted,
-                                                      obs = y[holdoutIndex],
-                                                      stringsAsFactors = FALSE)
-                                   ## Sometimes the code above does not coerce the first
-                                   ## columnn to be named "pred" so force it
-                                   names(tmp)[1] <- "pred"
-                                   if(!is.null(wts)) tmp$weights <- wts[holdoutIndex]
-                                   if(ctrl$classProbs) tmp <- cbind(tmp, probValues)
+            if (keep_pred) {
+              tmpPred <- tmp
+              tmpPred$rowIndex <- holdoutIndex
+              tmpPred <- merge(
+                tmpPred,
+                new_info$loop[parm, , drop = FALSE],
+                all = TRUE
+              )
+              tmpPred$Resample <- names(resampleIndex)[iter]
+            } else {
+              tmpPred <- NULL
+            }
 
-                                   if(keep_pred) {
-                                     tmpPred <- tmp
-                                     tmpPred$rowIndex <- holdoutIndex
-                                     tmpPred <- merge(tmpPred, new_info$loop[parm,,drop = FALSE],
-                                                      all = TRUE)
-                                     tmpPred$Resample <- names(resampleIndex)[iter]
-                                   } else tmpPred <- NULL
+            ##################################
+            thisResample <- ctrl$summaryFunction(tmp, lev = lev, model = method)
 
-                                   ##################################
-                                   thisResample <- ctrl$summaryFunction(tmp,
-                                                                        lev = lev,
-                                                                        model = method)
-
-                                   ## if classification, get the confusion matrix
-                                   if(length(lev) > 1) thisResample <- c(thisResample, flatTable(tmp$pred, tmp$obs))
-                                   thisResample <- as.data.frame(t(thisResample), stringsAsFactors = FALSE)
-                                   thisResample <- cbind(thisResample, new_info$loop[parm,,drop = FALSE])
-
-                                 }
-                                 thisResample$Resample <- names(resampleIndex)[iter]
-                                 if(ctrl$verboseIter) progress(printed[parm,,drop = FALSE],
-                                                               names(resampleIndex), iter, FALSE)
-                                 list(resamples = thisResample, pred = tmpPred)
-                               } ## end initial loop over resamples and models
-
+            ## if classification, get the confusion matrix
+            if (length(lev) > 1) {
+              thisResample <- c(thisResample, flatTable(tmp$pred, tmp$obs))
+            }
+            thisResample <- as.data.frame(
+              t(thisResample),
+              stringsAsFactors = FALSE
+            )
+            thisResample <- cbind(
+              thisResample,
+              new_info$loop[parm, , drop = FALSE]
+            )
+          }
+          thisResample$Resample <- names(resampleIndex)[iter]
+          if (ctrl$verboseIter) {
+            progress(
+              printed[parm, , drop = FALSE],
+              names(resampleIndex),
+              iter,
+              FALSE
+            )
+          }
+          list(resamples = thisResample, pred = tmpPred)
+        } ## end initial loop over resamples and models
     }
 
     init_result <- c(init_result, adapt_results)
     rs <- do.call("rbind", init_result[names(init_result) == "resamples"])
 
-
     current_mods <- get_id(rs, as.character(method$param$parameter))
-    if(iter > ctrl$adaptive$min) {
-      latest <- do.call("rbind", adapt_results[names(adapt_results) == "resamples"])
-      latest <- latest[,as.character(method$param$parameter),drop = FALSE]
-      latest <- latest[!duplicated(latest),,drop = FALSE]
+    if (iter > ctrl$adaptive$min) {
+      latest <- do.call(
+        "rbind",
+        adapt_results[names(adapt_results) == "resamples"]
+      )
+      latest <- latest[, as.character(method$param$parameter), drop = FALSE]
+      latest <- latest[!duplicated(latest), , drop = FALSE]
 
       current_mods <- merge(current_mods, latest)
     }
     rs <- merge(rs, current_mods)
 
-    if(iter == ctrl$adaptive$min+1) {
-      rs <- filter_on_diff(rs, metric,
-                           cutoff = 0.001,
-                           maximize = maximize,
-                           verbose = ctrl$verboseIter)
+    if (iter == ctrl$adaptive$min + 1) {
+      rs <- filter_on_diff(
+        rs,
+        metric,
+        cutoff = 0.001,
+        maximize = maximize,
+        verbose = ctrl$verboseIter
+      )
     }
 
-    if(ctrl$adaptive$method == "BT") {
-      filtered_mods <- try(bt_eval(rs, metric = metric, maximize = maximize,
-                                   alpha = ctrl$adaptive$alpha),
-                           silent = TRUE)
+    if (ctrl$adaptive$method == "BT") {
+      filtered_mods <- try(
+        bt_eval(
+          rs,
+          metric = metric,
+          maximize = maximize,
+          alpha = ctrl$adaptive$alpha
+        ),
+        silent = TRUE
+      )
     } else {
-      filtered_mods <- try(gls_eval(rs, metric = metric, maximize = maximize,
-                                    alpha = ctrl$adaptive$alpha),
-                           silent = TRUE)
+      filtered_mods <- try(
+        gls_eval(
+          rs,
+          metric = metric,
+          maximize = maximize,
+          alpha = ctrl$adaptive$alpha
+        ),
+        silent = TRUE
+      )
     }
 
-    if(class(filtered_mods)[1] == "try-error") {
-      if(ctrl$verboseIter) {
+    if (class(filtered_mods)[1] == "try-error") {
+      if (ctrl$verboseIter) {
         cat("x parameter filtering failed:")
         print(filtered_mods)
         cat("\n")
@@ -506,332 +749,504 @@ adaptiveWorkflow <- function(x, y, wts, info, method, ppOpts, ctrl, lev,
       filtered_mods <- current_mods
     }
 
-    if(ctrl$verboseIter) {
+    if (ctrl$verboseIter) {
       excluded <- unique(rs$model_id)[!(unique(rs$model_id) %in% filtered_mods)]
-      if(length(excluded) > 0) {
+      if (length(excluded) > 0) {
         cat(paste("o", length(excluded), "eliminated;"))
-      } else cat("o no models eliminated;",
-                 nrow(current_mods),
-                 ifelse(nrow(current_mods) > 1, "remain\n", "remains\n"))
+      } else {
+        cat(
+          "o no models eliminated;",
+          nrow(current_mods),
+          ifelse(nrow(current_mods) > 1, "remain\n", "remains\n")
+        )
+      }
     }
 
-    current_mods <- current_mods[current_mods$model_id %in% filtered_mods,,drop = FALSE]
-    if(iter == ctrl$adaptive$min) {
+    current_mods <- current_mods[
+      current_mods$model_id %in% filtered_mods,
+      ,
+      drop = FALSE
+    ]
+    if (iter == ctrl$adaptive$min) {
       last_mods <- current_mods
     }
     current_mods$model_id <- NULL
     num_left <- nrow(current_mods)
 
-    if(ctrl$verboseIter && length(excluded) > 0) cat(num_left,
-                                                     ifelse(num_left > 1, "remain\n", "remains\n"))
+    if (ctrl$verboseIter && length(excluded) > 0) {
+      cat(num_left, ifelse(num_left > 1, "remain\n", "remains\n"))
+    }
 
-    if(!is.null(method$loop)) {
+    if (!is.null(method$loop)) {
       new_info <- method$loop(current_mods)
-    } else new_info$loop <- current_mods
+    } else {
+      new_info$loop <- current_mods
+    }
 
     last_iter <- iter
 
-    if(num_left == 1) break
+    if (num_left == 1) break
   }
   ## finish up last resamples
-  if(ctrl$adaptive$complete && last_iter < length(ctrl$index)) {
+  if (ctrl$adaptive$complete && last_iter < length(ctrl$index)) {
     printed <- format(new_info$loop, digits = 4)
     colnames(printed) <- gsub("^\\.", "", colnames(printed))
 
-    final_index <- seq(along.with = resampleIndex)[(last_iter+1):length(ctrl$index)]
-    final_result <- foreach(iter = final_index,
-                            .combine = "c",
-                            .verbose = FALSE) %:%
-      foreach(parm = seq_len(nrow(new_info$loop)),
-              .combine = "c",
-              .verbose = FALSE,
-              .packages = pkgs)  %op% {
-                testing <- FALSE
-                if(!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds))) set.seed(ctrl$seeds[[iter]][parm])
+    final_index <- seq(along.with = resampleIndex)[
+      (last_iter + 1):length(ctrl$index)
+    ]
+    final_result <- foreach(
+      iter = final_index,
+      .combine = "c",
+      .verbose = FALSE
+    ) %:%
+      foreach(
+        parm = seq_len(nrow(new_info$loop)),
+        .combine = "c",
+        .verbose = FALSE,
+        .packages = pkgs
+      ) %op%
+      {
+        testing <- FALSE
+        if (!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds))) {
+          set.seed(ctrl$seeds[[iter]][parm])
+        }
 
-                loadNamespace("caret")
-                lapply(pkgs, requireNamespaceQuietStop)
+        loadNamespace("caret")
+        lapply(pkgs, requireNamespaceQuietStop)
 
-                if(ctrl$verboseIter) progress(printed[parm,,drop = FALSE],
-                                              names(resampleIndex), iter)
+        if (ctrl$verboseIter) {
+          progress(printed[parm, , drop = FALSE], names(resampleIndex), iter)
+        }
 
-                modelIndex <- resampleIndex[[iter]]
-                holdoutIndex <- ctrl$indexOut[[iter]]
+        modelIndex <- resampleIndex[[iter]]
+        holdoutIndex <- ctrl$indexOut[[iter]]
 
-                if(testing) cat("pre-model\n")
+        if (testing) {
+          cat("pre-model\n")
+        }
 
-                if(is.null(info$submodels[[parm]]) || nrow(info$submodels[[parm]]) > 0) {
-                  submod <- info$submodels[[parm]]
-                } else submod <- NULL
+        if (
+          is.null(info$submodels[[parm]]) || nrow(info$submodels[[parm]]) > 0
+        ) {
+          submod <- info$submodels[[parm]]
+        } else {
+          submod <- NULL
+        }
 
-                mod <- try(
-                  createModel(x = x[modelIndex,,drop = FALSE ],
-                              y = y[modelIndex],
-                              wts = wts[modelIndex],
-                              method = method,
-                              tuneValue = new_info$loop[parm,,drop = FALSE],
-                              obsLevels = lev,
-                              pp = ppp,
-                              classProbs = ctrl$classProbs,
-                              sampling = ctrl$sampling,
-                              ...),
-                  silent = TRUE)
+        mod <- try(
+          createModel(
+            x = x[modelIndex, , drop = FALSE],
+            y = y[modelIndex],
+            wts = wts[modelIndex],
+            method = method,
+            tuneValue = new_info$loop[parm, , drop = FALSE],
+            obsLevels = lev,
+            pp = ppp,
+            classProbs = ctrl$classProbs,
+            sampling = ctrl$sampling,
+            ...
+          ),
+          silent = TRUE
+        )
 
-                if(class(mod)[1] != "try-error") {
-                  predicted <- try(
-                    predictionFunction(method = method,
-                                       modelFit = mod$fit,
-                                       newdata = x[holdoutIndex,, drop = FALSE],
-                                       preProc = mod$preProc,
-                                       param = submod),
-                    silent = TRUE)
+        if (class(mod)[1] != "try-error") {
+          predicted <- try(
+            predictionFunction(
+              method = method,
+              modelFit = mod$fit,
+              newdata = x[holdoutIndex, , drop = FALSE],
+              preProc = mod$preProc,
+              param = submod
+            ),
+            silent = TRUE
+          )
 
-                  if (inherits(predicted, "try-error")) {
-                    wrn <- paste(colnames(printed[parm,,drop = FALSE]),
-                                 printed[parm,,drop = FALSE],
-                                 sep = "=",
-                                 collapse = ", ")
-                    wrn <- paste("predictions failed for ", names(resampleIndex)[iter],
-                                 ": ", wrn, " ", as.character(predicted), sep = "")
-                    if(ctrl$verboseIter) cat(wrn, "\n")
-                    warning(wrn)
-                    rm(wrn)
+          if (inherits(predicted, "try-error")) {
+            wrn <- paste(
+              colnames(printed[parm, , drop = FALSE]),
+              printed[parm, , drop = FALSE],
+              sep = "=",
+              collapse = ", "
+            )
+            wrn <- paste(
+              "predictions failed for ",
+              names(resampleIndex)[iter],
+              ": ",
+              wrn,
+              " ",
+              as.character(predicted),
+              sep = ""
+            )
+            if (ctrl$verboseIter) {
+              cat(wrn, "\n")
+            }
+            warning(wrn)
+            rm(wrn)
 
-                    ## setup a dummy results with NA values for all predictions
-                    nPred <- length(holdoutIndex)
-                    if(!is.null(lev)) {
-                      predicted <- rep("", nPred)
-                      predicted[seq(along.with = predicted)] <- NA
-                    } else {
-                      predicted <- rep(NA, nPred)
-                    }
-                    if(!is.null(submod)) {
-                      tmp <- predicted
-                      predicted <- vector(mode = "list", length = nrow(info$submodels[[parm]]) + 1)
-                      for(i in seq(along.with = predicted)) predicted[[i]] <- tmp
-                      rm(tmp)
-                    }
-                  }
-                } else {
-                  wrn <- paste(colnames(printed[parm,,drop = FALSE]),
-                               printed[parm,,drop = FALSE],
-                               sep = "=",
-                               collapse = ", ")
-                  wrn <- paste("model fit failed for ", names(resampleIndex)[iter],
-                               ": ", wrn, " ", as.character(mod), sep = "")
-                  if(ctrl$verboseIter) cat(wrn, "\n")
-                  warning(wrn)
-                  rm(wrn)
+            ## setup a dummy results with NA values for all predictions
+            nPred <- length(holdoutIndex)
+            if (!is.null(lev)) {
+              predicted <- rep("", nPred)
+              predicted[seq(along.with = predicted)] <- NA
+            } else {
+              predicted <- rep(NA, nPred)
+            }
+            if (!is.null(submod)) {
+              tmp <- predicted
+              predicted <- vector(
+                mode = "list",
+                length = nrow(info$submodels[[parm]]) + 1
+              )
+              for (i in seq(along.with = predicted)) {
+                predicted[[i]] <- tmp
+              }
+              rm(tmp)
+            }
+          }
+        } else {
+          wrn <- paste(
+            colnames(printed[parm, , drop = FALSE]),
+            printed[parm, , drop = FALSE],
+            sep = "=",
+            collapse = ", "
+          )
+          wrn <- paste(
+            "model fit failed for ",
+            names(resampleIndex)[iter],
+            ": ",
+            wrn,
+            " ",
+            as.character(mod),
+            sep = ""
+          )
+          if (ctrl$verboseIter) {
+            cat(wrn, "\n")
+          }
+          warning(wrn)
+          rm(wrn)
 
-                  ## setup a dummy results with NA values for all predictions
-                  nPred <- length(holdoutIndex)
-                  if(!is.null(lev)) {
-                    predicted <- rep("", nPred)
-                    predicted[seq(along.with = predicted)] <- NA
-                  } else {
-                    predicted <- rep(NA, nPred)
-                  }
-                  if(!is.null(submod)) {
-                    tmp <- predicted
-                    predicted <- vector(mode = "list", length = nrow(info$submodels[[parm]]) + 1)
-                    for(i in seq(along.with = predicted)) predicted[[i]] <- tmp
-                    rm(tmp)
-                  }
-                }
+          ## setup a dummy results with NA values for all predictions
+          nPred <- length(holdoutIndex)
+          if (!is.null(lev)) {
+            predicted <- rep("", nPred)
+            predicted[seq(along.with = predicted)] <- NA
+          } else {
+            predicted <- rep(NA, nPred)
+          }
+          if (!is.null(submod)) {
+            tmp <- predicted
+            predicted <- vector(
+              mode = "list",
+              length = nrow(info$submodels[[parm]]) + 1
+            )
+            for (i in seq(along.with = predicted)) {
+              predicted[[i]] <- tmp
+            }
+            rm(tmp)
+          }
+        }
 
-                if(testing) print(head(predicted))
-                if(ctrl$classProbs)
-                {
-                  if(class(mod)[1] != "try-error") {
-                    probValues <- probFunction(method = method,
-                                               modelFit = mod$fit,
-                                               newdata = x[holdoutIndex,, drop = FALSE],
-                                               preProc = mod$preProc,
-                                               param = submod)
-                  } else {
-                    probValues <- as.data.frame(matrix(NA, nrow = nPred, ncol = length(lev)), stringsAsFactors = FALSE)
-                    colnames(probValues) <- lev
-                    if(!is.null(submod))
-                    {
-                      tmp <- probValues
-                      probValues <- vector(mode = "list", length = nrow(info$submodels[[parm]]) + 1)
-                      for(i in seq(along.with = probValues)) probValues[[i]] <- tmp
-                      rm(tmp)
-                    }
-                  }
-                  if(testing) print(head(probValues))
-                }
+        if (testing) {
+          print(head(predicted))
+        }
+        if (ctrl$classProbs) {
+          if (class(mod)[1] != "try-error") {
+            probValues <- probFunction(
+              method = method,
+              modelFit = mod$fit,
+              newdata = x[holdoutIndex, , drop = FALSE],
+              preProc = mod$preProc,
+              param = submod
+            )
+          } else {
+            probValues <- as.data.frame(
+              matrix(NA, nrow = nPred, ncol = length(lev)),
+              stringsAsFactors = FALSE
+            )
+            colnames(probValues) <- lev
+            if (!is.null(submod)) {
+              tmp <- probValues
+              probValues <- vector(
+                mode = "list",
+                length = nrow(info$submodels[[parm]]) + 1
+              )
+              for (i in seq(along.with = probValues)) {
+                probValues[[i]] <- tmp
+              }
+              rm(tmp)
+            }
+          }
+          if (testing) print(head(probValues))
+        }
 
-                ##################################
+        ##################################
 
-                if(!is.null(submod))
-                {
-                  ## merge the fixed and seq parameter values together
-                  allParam <- expandParameters(new_info$loop[parm,,drop = FALSE],
-                                               new_info$submodels[[parm]])
-                  allParam <- allParam[complete.cases(allParam),, drop = FALSE]
+        if (!is.null(submod)) {
+          ## merge the fixed and seq parameter values together
+          allParam <- expandParameters(
+            new_info$loop[parm, , drop = FALSE],
+            new_info$submodels[[parm]]
+          )
+          allParam <- allParam[complete.cases(allParam), , drop = FALSE]
 
-                  ## collate the predicitons across all the sub-models
-                  predicted <- lapply(predicted,
-                                      function(x, y, wts, lv) {
-                                        if(!is.factor(x) && is.character(x)) x <- factor(as.character(x), levels = lv)
-                                        out <- data.frame(pred = x, obs = y, stringsAsFactors = FALSE)
-                                        if(!is.null(wts)) out$weights <- wts
-                                        out
-                                      },
-                                      y = y[holdoutIndex],
-                                      wts = wts[holdoutIndex],
-                                      lv = lev)
-                  if(testing) print(head(predicted))
+          ## collate the predicitons across all the sub-models
+          predicted <- lapply(
+            predicted,
+            function(x, y, wts, lv) {
+              if (!is.factor(x) && is.character(x)) {
+                x <- factor(as.character(x), levels = lv)
+              }
+              out <- data.frame(pred = x, obs = y, stringsAsFactors = FALSE)
+              if (!is.null(wts)) {
+                out$weights <- wts
+              }
+              out
+            },
+            y = y[holdoutIndex],
+            wts = wts[holdoutIndex],
+            lv = lev
+          )
+          if (testing) {
+            print(head(predicted))
+          }
 
-                  ## same for the class probabilities
-                  if(ctrl$classProbs) {
-                    for(k in seq(along.with = predicted)) predicted[[k]] <- cbind(predicted[[k]], probValues[[k]])
-                  }
+          ## same for the class probabilities
+          if (ctrl$classProbs) {
+            for (k in seq(along.with = predicted)) {
+              predicted[[k]] <- cbind(predicted[[k]], probValues[[k]])
+            }
+          }
 
-                  if(keep_pred) {
-                    tmpPred <- predicted
-                    for(modIndex in seq(along.with = tmpPred))
-                    {
-                      tmpPred[[modIndex]]$rowIndex <- holdoutIndex
-                      tmpPred[[modIndex]] <- merge(tmpPred[[modIndex]],
-                                                   allParam[modIndex,,drop = FALSE],
-                                                   all = TRUE)
-                    }
-                    tmpPred <- rbind.fill(tmpPred)
-                    tmpPred$Resample <- names(resampleIndex)[iter]
-                  } else tmpPred <- NULL
+          if (keep_pred) {
+            tmpPred <- predicted
+            for (modIndex in seq(along.with = tmpPred)) {
+              tmpPred[[modIndex]]$rowIndex <- holdoutIndex
+              tmpPred[[modIndex]] <- merge(
+                tmpPred[[modIndex]],
+                allParam[modIndex, , drop = FALSE],
+                all = TRUE
+              )
+            }
+            tmpPred <- rbind.fill(tmpPred)
+            tmpPred$Resample <- names(resampleIndex)[iter]
+          } else {
+            tmpPred <- NULL
+          }
 
-                  ## get the performance for this resample for each sub-model
-                  thisResample <- lapply(predicted,
-                                         ctrl$summaryFunction,
-                                         lev = lev,
-                                         model = method)
-                  if(testing) print(head(thisResample))
-                  ## for classification, add the cell counts
-                  if(length(lev) > 1) {
-                    cells <- lapply(predicted,
-                                    function(x) flatTable(x$pred, x$obs))
-                    for(ind in seq(along.with = cells)) thisResample[[ind]] <- c(thisResample[[ind]], cells[[ind]])
-                  }
-                  thisResample <- do.call("rbind", thisResample)
-                  thisResample <- cbind(allParam, thisResample)
+          ## get the performance for this resample for each sub-model
+          thisResample <- lapply(
+            predicted,
+            ctrl$summaryFunction,
+            lev = lev,
+            model = method
+          )
+          if (testing) {
+            print(head(thisResample))
+          }
+          ## for classification, add the cell counts
+          if (length(lev) > 1) {
+            cells <- lapply(predicted, function(x) flatTable(x$pred, x$obs))
+            for (ind in seq(along.with = cells)) {
+              thisResample[[ind]] <- c(thisResample[[ind]], cells[[ind]])
+            }
+          }
+          thisResample <- do.call("rbind", thisResample)
+          thisResample <- cbind(allParam, thisResample)
+        } else {
+          if (is.factor(y)) {
+            predicted <- factor(as.character(predicted), levels = lev)
+          }
+          tmp <- data.frame(
+            pred = predicted,
+            obs = y[holdoutIndex],
+            stringsAsFactors = FALSE
+          )
+          ## Sometimes the code above does not coerce the first
+          ## columnn to be named "pred" so force it
+          names(tmp)[1] <- "pred"
+          if (!is.null(wts)) {
+            tmp$weights <- wts[holdoutIndex]
+          }
+          if (ctrl$classProbs) {
+            tmp <- cbind(tmp, probValues)
+          }
 
-                } else {
-                  if(is.factor(y)) predicted <- factor(as.character(predicted), levels = lev)
-                  tmp <-  data.frame(pred = predicted,
-                                     obs = y[holdoutIndex],
-                                     stringsAsFactors = FALSE)
-                  ## Sometimes the code above does not coerce the first
-                  ## columnn to be named "pred" so force it
-                  names(tmp)[1] <- "pred"
-                  if(!is.null(wts)) tmp$weights <- wts[holdoutIndex]
-                  if(ctrl$classProbs) tmp <- cbind(tmp, probValues)
+          if (keep_pred) {
+            tmpPred <- tmp
+            tmpPred$rowIndex <- holdoutIndex
+            tmpPred <- merge(
+              tmpPred,
+              new_info$loop[parm, , drop = FALSE],
+              all = TRUE
+            )
+            tmpPred$Resample <- names(resampleIndex)[iter]
+          } else {
+            tmpPred <- NULL
+          }
 
-                  if(keep_pred) {
-                    tmpPred <- tmp
-                    tmpPred$rowIndex <- holdoutIndex
-                    tmpPred <- merge(tmpPred, new_info$loop[parm,,drop = FALSE],
-                                     all = TRUE)
-                    tmpPred$Resample <- names(resampleIndex)[iter]
-                  } else tmpPred <- NULL
+          ##################################
+          thisResample <- ctrl$summaryFunction(tmp, lev = lev, model = method)
 
-                  ##################################
-                  thisResample <- ctrl$summaryFunction(tmp,
-                                                       lev = lev,
-                                                       model = method)
-
-                  ## if classification, get the confusion matrix
-                  if(length(lev) > 1) thisResample <- c(thisResample, flatTable(tmp$pred, tmp$obs))
-                  thisResample <- as.data.frame(t(thisResample), stringsAsFactors = FALSE)
-                  thisResample <- cbind(thisResample, new_info$loop[parm,,drop = FALSE])
-
-                }
-                thisResample$Resample <- names(resampleIndex)[iter]
-                if(ctrl$verboseIter) progress(printed[parm,,drop = FALSE],
-                                              names(resampleIndex), iter, FALSE)
-                list(resamples = thisResample, pred = tmpPred)
-              } ## end final loop to finish cleanup resamples and models
+          ## if classification, get the confusion matrix
+          if (length(lev) > 1) {
+            thisResample <- c(thisResample, flatTable(tmp$pred, tmp$obs))
+          }
+          thisResample <- as.data.frame(
+            t(thisResample),
+            stringsAsFactors = FALSE
+          )
+          thisResample <- cbind(
+            thisResample,
+            new_info$loop[parm, , drop = FALSE]
+          )
+        }
+        thisResample$Resample <- names(resampleIndex)[iter]
+        if (ctrl$verboseIter) {
+          progress(
+            printed[parm, , drop = FALSE],
+            names(resampleIndex),
+            iter,
+            FALSE
+          )
+        }
+        list(resamples = thisResample, pred = tmpPred)
+      } ## end final loop to finish cleanup resamples and models
     init_result <- c(init_result, final_result)
   }
   resamples <- rbind.fill(init_result[names(init_result) == "resamples"])
-  pred <- if(keep_pred)  rbind.fill(init_result[names(init_result) == "pred"]) else NULL
+  pred <- if (keep_pred) {
+    rbind.fill(init_result[names(init_result) == "pred"])
+  } else {
+    NULL
+  }
   names(resamples) <- gsub("^\\.", "", names(resamples))
 
-  if(any(!complete.cases(resamples[,!grepl("^cell|Resample", colnames(resamples)),drop = FALSE])))
+  if (
+    any(
+      !complete.cases(resamples[,
+        !grepl("^cell|Resample", colnames(resamples)),
+        drop = FALSE
+      ])
+    )
+  ) {
     warning("There were missing values in resampled performance measures.")
+  }
 
-  out <- ddply(resamples[,!grepl("^cell|Resample", colnames(resamples)),drop = FALSE],
-               ## TODO check this for seq models
-               gsub("^\\.", "", colnames(info$loop)),
-               MeanSD,
-               exclude = gsub("^\\.", "", colnames(info$loop)))
-  num_resamp <- ddply(resamples,
-                      gsub("^\\.", "", colnames(info$loop)),
-                      function(x) c(.B = nrow(x)))
+  out <- ddply(
+    resamples[, !grepl("^cell|Resample", colnames(resamples)), drop = FALSE],
+    ## TODO check this for seq models
+    gsub("^\\.", "", colnames(info$loop)),
+    MeanSD,
+    exclude = gsub("^\\.", "", colnames(info$loop))
+  )
+  num_resamp <- ddply(
+    resamples,
+    gsub("^\\.", "", colnames(info$loop)),
+    function(x) c(.B = nrow(x))
+  )
   out <- merge(out, num_resamp)
 
-  list(performance = out, resamples = resamples, predictions = if(keep_pred) pred else NULL)
+  list(
+    performance = out,
+    resamples = resamples,
+    predictions = if (keep_pred) pred else NULL
+  )
 }
 
 long2wide <- function(x, metric) {
-  x2 <- reshape(x[, c(metric, "model_id", "Resample")],
-                idvar = "Resample",
-                timevar = "model_id",
-                v.names = metric,
-                direction = "wide")
+  x2 <- reshape(
+    x[, c(metric, "model_id", "Resample")],
+    idvar = "Resample",
+    timevar = "model_id",
+    v.names = metric,
+    direction = "wide"
+  )
   colnames(x2) <- gsub(paste(metric, "\\.", sep = ""), "", colnames(x2))
   x2[order(x2$Resample), c("Resample", sort(as.character(unique(x$model_id))))]
 }
 
 get_id <- function(x, param) {
-  params <- x[,param,drop=FALSE]
-  params <- params[!duplicated(params),,drop=FALSE]
-  params$model_id <- paste("m", gsub(" ", "0", format(seq_len(nrow(params)))), sep = "")
+  params <- x[, param, drop = FALSE]
+  params <- params[!duplicated(params), , drop = FALSE]
+  params$model_id <- paste(
+    "m",
+    gsub(" ", "0", format(seq_len(nrow(params)))),
+    sep = ""
+  )
   rownames(params) <- NULL
   params
 }
 
 bt_eval <- function(rs, metric, maximize, alpha = 0.05) {
-  if (!requireNamespace("BradleyTerry2")) stop("BradleyTerry2 package missing")
+  if (!requireNamespace("BradleyTerry2")) {
+    stop("BradleyTerry2 package missing")
+  }
   se_thresh <- 100
   constant <- qnorm(1 - alpha)
-  rs <- rs[order(rs$Resample, rs$model_id),]
+  rs <- rs[order(rs$Resample, rs$model_id), ]
   rs <- rs[!is.na(rs[, metric]), ]
-  scores <- ddply(rs, .(Resample), get_scores, maximize = maximize, metric = metric)
-  scores <- ddply(scores, .(player1, player2), function(x) c(win1 = sum(x$win1),
-                                                             win2 = sum(x$win2)))
-  if(length(unique(rs$Resample)) >= 5) {
+  scores <- ddply(
+    rs,
+    .(Resample),
+    get_scores,
+    maximize = maximize,
+    metric = metric
+  )
+  scores <- ddply(scores, .(player1, player2), function(x) {
+    c(win1 = sum(x$win1), win2 = sum(x$win2))
+  })
+  if (length(unique(rs$Resample)) >= 5) {
     tmp_scores <- try(skunked(scores), silent = TRUE)
     if (inherits(tmp_scores, "try-error")) scores <- tmp_scores
   }
-  best_mod <- ddply(rs, .(model_id), function(x, metric) mean(x[, metric], na.rm = TRUE), metric = metric)
-  best_mod <- if(maximize)
-    best_mod$model_id[which.max(best_mod$V1)] else
-      best_mod$model_id[which.min(best_mod$V1)]
-  btModel <- BradleyTerry2::BTm(cbind(win1, win2), player1, player2, data = scores, refcat = best_mod)
+  best_mod <- ddply(
+    rs,
+    .(model_id),
+    function(x, metric) mean(x[, metric], na.rm = TRUE),
+    metric = metric
+  )
+  best_mod <- if (maximize) {
+    best_mod$model_id[which.max(best_mod$V1)]
+  } else {
+    best_mod$model_id[which.min(best_mod$V1)]
+  }
+  btModel <- BradleyTerry2::BTm(
+    cbind(win1, win2),
+    player1,
+    player2,
+    data = scores,
+    refcat = best_mod
+  )
   btCoef <- summary(btModel)$coef
   ## Recent versions of the BradleyTerry2 package tag on some dots in the names
   rownames(btCoef) <- gsub("^\\.\\.", "", rownames(btCoef))
-  upperBound <- btCoef[, "Estimate"] + constant*btCoef[, "Std. Error"]
-  if(any(btCoef[, "Std. Error"] > se_thresh)) {
+  upperBound <- btCoef[, "Estimate"] + constant * btCoef[, "Std. Error"]
+  if (any(btCoef[, "Std. Error"] > se_thresh)) {
     ## These players either are uniformly dominated (='dom') or dominating
     dom1 <- btCoef[, "Std. Error"] > se_thresh
-    dom2 <- if(maximize) btCoef[, "Estimate"] <= 0 else btCoef[, "Estimate"] >= 0
+    dom2 <- if (maximize) {
+      btCoef[, "Estimate"] <= 0
+    } else {
+      btCoef[, "Estimate"] >= 0
+    }
     dom <- dom1 & dom2
-  } else dom <- rep(FALSE, length(upperBound))
+  } else {
+    dom <- rep(FALSE, length(upperBound))
+  }
   bound <- upperBound >= 0
   keepers <- names(upperBound)[bound & !dom]
   unique(c(best_mod, keepers))
 }
 
-get_scores <- function(x, maximize = NULL, metric = NULL)
-{
-  if (!requireNamespace("BradleyTerry2")) stop("BradleyTerry2 package missing")
-  delta <- outer(x[,metric], x[,metric], "-")
-  tied <- ifelse(delta == 0, 1, 0)*0.5
+get_scores <- function(x, maximize = NULL, metric = NULL) {
+  if (!requireNamespace("BradleyTerry2")) {
+    stop("BradleyTerry2 package missing")
+  }
+  delta <- outer(x[, metric], x[, metric], "-")
+  tied <- ifelse(delta == 0, 1, 0) * 0.5
   diag(tied) <- 0
-  binary <- if(maximize) ifelse(delta > 0, 1, 0) else ifelse(delta > 0, 0, 1)
+  binary <- if (maximize) ifelse(delta > 0, 1, 0) else ifelse(delta > 0, 0, 1)
   binary <- binary + tied
   diag(binary) <- 0
   rownames(binary) <- colnames(binary) <- x$model_id
@@ -844,15 +1259,22 @@ skunked <- function(scores, verbose = TRUE) {
   p2 <- ddply(scores, .(player2), function(x) sum(x$win2))
   names(p1)[1] <- names(p2)[1] <- "playa"
   by_player <- ddply(rbind(p1, p2), .(playa), function(x) c(wins = sum(x$V1)))
-  if(any(by_player$wins < 1)) {
+  if (any(by_player$wins < 1)) {
     skunked <- as.character(by_player$playa[by_player$wins < 1])
-    if(verbose) cat("o", sum(by_player$wins < 1),
-                    ifelse(sum(by_player$wins < 1) > 1, "models were", "model was"),
-                    "skunked\n")
+    if (verbose) {
+      cat(
+        "o",
+        sum(by_player$wins < 1),
+        ifelse(sum(by_player$wins < 1) > 1, "models were", "model was"),
+        "skunked\n"
+      )
+    }
     scores <- subset(scores, !(player1 %in% skunked))
     scores <- subset(scores, !(player2 %in% skunked))
-    levs <- sort(unique(c(as.character(scores$player1),
-                          as.character(scores$player2))))
+    levs <- sort(unique(c(
+      as.character(scores$player1),
+      as.character(scores$player2)
+    )))
     scores$player1 <- factor(as.character(scores$player1), levels = levs)
     scores$player2 <- factor(as.character(scores$player2), levels = levs)
   }
@@ -862,99 +1284,137 @@ skunked <- function(scores, verbose = TRUE) {
 
 gls_eval <- function(x, metric, maximize, alpha = 0.05) {
   x <- x[!is.na(x[, metric]), ]
-  means <- ddply(x[, c(metric, "model_id")],
-                 .(model_id),
-                 function(x, met) c(mean = mean(x[, met], na.rm = TRUE)),
-                 met = metric)
-  means <- if(maximize) means[order(-means$mean),] else means[order(means$mean),]
+  means <- ddply(
+    x[, c(metric, "model_id")],
+    .(model_id),
+    function(x, met) c(mean = mean(x[, met], na.rm = TRUE)),
+    met = metric
+  )
+  means <- if (maximize) {
+    means[order(-means$mean), ]
+  } else {
+    means[order(means$mean), ]
+  }
   levs <- as.character(means$model_id)
   bl <- levs[1]
   bldat <- subset(x, model_id == bl)[, c("Resample", metric)]
   colnames(bldat)[2] <- ".baseline"
   x2 <- merge(bldat, x[, c("Resample", "model_id", metric)])
-  x2$value <- if(maximize) x2$.baseline - x2[, metric] else x2[, metric] - x2$.baseline
+  x2$value <- if (maximize) {
+    x2$.baseline - x2[, metric]
+  } else {
+    x2[, metric] - x2$.baseline
+  }
   x2 <- subset(x2, model_id != bl)
   x2$model_id <- factor(x2$model_id, levels = levs[-1])
-  if(length(levs) > 2) {
-    gls_fit <- try(gls(value ~ model_id - 1, data = x2,
-                       corCompSymm(form = ~ 1 | Resample),
-                       na.action = na.omit),
-                   silent = TRUE)
-    if(class(gls_fit)[1] != "try-error") {
-      lvl2 <- 1 - (2*alpha) ## convert to one sided
-      ci <- intervals(gls_fit, which = "coef", level = lvl2)$coef[,1]
+  if (length(levs) > 2) {
+    gls_fit <- try(
+      gls(
+        value ~ model_id - 1,
+        data = x2,
+        corCompSymm(form = ~ 1 | Resample),
+        na.action = na.omit
+      ),
+      silent = TRUE
+    )
+    if (class(gls_fit)[1] != "try-error") {
+      lvl2 <- 1 - (2 * alpha) ## convert to one sided
+      ci <- intervals(gls_fit, which = "coef", level = lvl2)$coef[, 1]
       keepers <- ci <= 0
-      if(anyNA(keepers)) keepers[is.na(keepers)] <- TRUE
+      if (anyNA(keepers)) {
+        keepers[is.na(keepers)] <- TRUE
+      }
       keepers <- names(ci)[keepers]
       keepers <- gsub("model_id", "", keepers)
-    } else keepers <- levs
+    } else {
+      keepers <- levs
+    }
   } else {
     ttest <- t.test(x2$value, alternative = "greater")$p.value
-    keepers <- if(!is.na(ttest) && ttest >= alpha) levs[-1] else NULL
+    keepers <- if (!is.na(ttest) && ttest >= alpha) levs[-1] else NULL
   }
   unique(c(bl, keepers))
 }
 
 seq_eval <- function(x, metric, maximize, alpha = 0.05) {
-  means <- ddply(x[, c(metric, "model_id")],
-                 .(model_id),
-                 function(x, met) c(mean = mean(x[, met], na.rm = TRUE)),
-                 met = metric)
-  means <- if(maximize) means[order(-means$mean),] else means[order(means$mean),]
+  means <- ddply(
+    x[, c(metric, "model_id")],
+    .(model_id),
+    function(x, met) c(mean = mean(x[, met], na.rm = TRUE)),
+    met = metric
+  )
+  means <- if (maximize) {
+    means[order(-means$mean), ]
+  } else {
+    means[order(means$mean), ]
+  }
   levs <- as.character(means$model_id)
   bl <- levs[1]
   bldat <- subset(x, model_id == bl)[, c("Resample", metric)]
   colnames(bldat)[2] <- ".baseline"
   x2 <- merge(bldat, x[, c("Resample", "model_id", metric)])
-  x2$value <- if(maximize) x2$.baseline - x2[, metric] else x2[, metric] - x2$.baseline
+  x2$value <- if (maximize) {
+    x2$.baseline - x2[, metric]
+  } else {
+    x2[, metric] - x2$.baseline
+  }
   x2 <- subset(x2, model_id != bl)
   x2$model_id <- factor(x2$model_id, levels = levs[-1])
-  if(length(levs) > 2) {
+  if (length(levs) > 2) {
     fit <- lm(value ~ . - 1, data = x2[, c("model_id", "value")])
     fit <- summary(fit)
     pvals <- pt(coef(fit)[, 3], fit$df[2], lower.tail = FALSE)
     names(pvals) <- gsub("model_id", "", names(pvals))
     keepers <- pvals >= alpha
-    if(anyNA(keepers)) keepers[is.na(keepers)] <- TRUE
+    if (anyNA(keepers)) {
+      keepers[is.na(keepers)] <- TRUE
+    }
     keepers <- names(pvals)[keepers]
     keepers <- gsub("model_id", "", keepers)
   } else {
     ttest <- t.test(x2$value, alternative = "greater")$p.value
-    keepers <- if(!is.na(ttest) && ttest >= alpha) levs[-1] else NULL
+    keepers <- if (!is.na(ttest) && ttest >= alpha) levs[-1] else NULL
   }
   unique(c(bl, keepers))
 }
 
 retrospective <- function(x, B = 5, method = "BT", alpha = 0.05) {
   rs <- x$resample
-  if(!is.factor(rs$Resample)) rs$Resample <- factor(rs$Resample)
+  if (!is.factor(rs$Resample)) {
+    rs$Resample <- factor(rs$Resample)
+  }
   rs <- subset(rs, as.numeric(Resample) <= B)
   current_mods <- get_id(rs, as.character(x$modelInfo$param$parameter))
   #   current_mods <- merge(current_mods, new_loop)
   rs <- merge(rs, current_mods)
 
-  if(method == "BT") {
-    filtered_mods <- try(bt_eval(rs, metric = x$metric, maximize = x$maximize,
-                                 alpha = alpha),
-                         silent = TRUE)
+  if (method == "BT") {
+    filtered_mods <- try(
+      bt_eval(rs, metric = x$metric, maximize = x$maximize, alpha = alpha),
+      silent = TRUE
+    )
   } else {
-    filtered_mods <- try(gls_eval(rs, metric = x$metric, maximize = x$maximize,
-                                  alpha = alpha),
-                         silent = TRUE)
+    filtered_mods <- try(
+      gls_eval(rs, metric = x$metric, maximize = x$maximize, alpha = alpha),
+      silent = TRUE
+    )
   }
 
-
-  list(models = filtered_mods, mods = subset(current_mods, model_id %in% filtered_mods),
-       long = rs, wide = long2wide(rs, x$metric))
+  list(
+    models = filtered_mods,
+    mods = subset(current_mods, model_id %in% filtered_mods),
+    long = rs,
+    wide = long2wide(rs, x$metric)
+  )
 }
 
 cccmat <- function(dat) {
   p <- ncol(dat)
   out <- matrix(1, ncol = p, nrow = p)
-  for(i in 1:p) {
-    for(j in i:p) {
-      if(i > j) {
-        tmp <- ccc(dat[,i], dat[,j])
+  for (i in 1:p) {
+    for (j in i:p) {
+      if (i > j) {
+        tmp <- ccc(dat[, i], dat[, j])
         out[i, j] <- out[j, i] <- tmp
       }
     }
@@ -968,19 +1428,23 @@ ccc <- function(x, y) {
   covm <- cov(cbind(x, y), use = "pairwise.complete.obs")
   mnx <- mean(x, na.rm = TRUE)
   mny <- mean(y, na.rm = TRUE)
-  2*covm[1,2]/(covm[1,1] + covm[2,2] + (mnx - mny)^2)
+  2 * covm[1, 2] / (covm[1, 1] + covm[2, 2] + (mnx - mny)^2)
 }
 
 diffmat <- function(dat) {
   p <- ncol(dat)
   out <- matrix(NA, ncol = p, nrow = p)
-  for(i in 1:p) {
-    for(j in i:p) {
-      if(i < j) {
-        x <- dat[,i]  - dat[,j]
+  for (i in 1:p) {
+    for (j in i:p) {
+      if (i < j) {
+        x <- dat[, i] - dat[, j]
         tmpm <- abs(mean(x, na.rm = TRUE))
         tmps <- sd(x, na.rm = TRUE)
-        out[i, j] <- out[j, i] <- if(tmps < .Machine$double.eps^0.5) 0 else tmpm/tmps
+        out[i, j] <- out[j, i] <- if (tmps < .Machine$double.eps^0.5) {
+          0
+        } else {
+          tmpm / tmps
+        }
       }
     }
   }
@@ -990,15 +1454,24 @@ diffmat <- function(dat) {
 }
 
 
-
-filter_on_diff <- function(dat, metric, cutoff = 0.01, maximize = TRUE, verbose = FALSE) {
+filter_on_diff <- function(
+  dat,
+  metric,
+  cutoff = 0.01,
+  maximize = TRUE,
+  verbose = FALSE
+) {
   x <- long2wide(x = dat, metric = metric)
   mns <- colMeans(x[, -1], na.rm = TRUE)
-  if(!maximize) mns <- -mns
+  if (!maximize) {
+    mns <- -mns
+  }
   x <- diffmat(x[, -1])
   tmp <- x
   diag(tmp) <- Inf
-  if(!any(tmp < cutoff)) return(dat)
+  if (!any(tmp < cutoff)) {
+    return(dat)
+  }
   varnum <- dim(x)[1]
   originalOrder <- 1:varnum
   averageDiff <- function(x) mean(x, na.rm = TRUE)
@@ -1024,29 +1497,35 @@ filter_on_diff <- function(dat, metric, cutoff = 0.01, maximize = TRUE, verbose 
   }
 
   deletecol <- deletecol[deletecol != 0]
-  if(length(deletecol) > 0) {
+  if (length(deletecol) > 0) {
     dumped <- colnames(x)[newOrder[deletecol]]
-    if (verbose)  cat(paste("o", length(deletecol),
-                            ifelse(length(deletecol) > 1, "models of", "model of"),
-                            varnum,
-                            ifelse(length(deletecol) > 1, "were", "was"),
-                            "eliminated due to linear dependencies\n"))
+    if (verbose) {
+      cat(paste(
+        "o",
+        length(deletecol),
+        ifelse(length(deletecol) > 1, "models of", "model of"),
+        varnum,
+        ifelse(length(deletecol) > 1, "were", "was"),
+        "eliminated due to linear dependencies\n"
+      ))
+    }
     dat <- subset(dat, !(model_id %in% dumped))
   }
   dat
 }
 
 
-
 filter_on_corr <- function(dat, metric, cutoff, verbose = FALSE) {
   x <- long2wide(x = dat, metric = metric)
-#   x <- cor(x[, -1], use = "pairwise.complete.obs")
+  #   x <- cor(x[, -1], use = "pairwise.complete.obs")
   x <- cccmat(x[, -1])
   varnum <- dim(x)[1]
-  if (!isTRUE(all.equal(x, t(x))))
+  if (!isTRUE(all.equal(x, t(x)))) {
     stop("correlation matrix is not symmetric")
-  if (varnum == 1)
+  }
+  if (varnum == 1) {
     stop("only one variable given")
+  }
   x <- abs(x)
   originalOrder <- 1:varnum
   averageCorr <- function(x) mean(x, na.rm = TRUE)
@@ -1070,11 +1549,16 @@ filter_on_corr <- function(dat, metric, cutoff, verbose = FALSE) {
     }
   }
   deletecol <- deletecol[deletecol != 0]
-  if(length(deletecol) > 0) {
+  if (length(deletecol) > 0) {
     dumped <- colnames(x)[newOrder[deletecol]]
-    if (verbose)  cat(paste("o", length(deletecol),
-                            ifelse(length(deletecol) > 1, "models were", "model was"),
-                            "eliminated due to linear dependencies\n"))
+    if (verbose) {
+      cat(paste(
+        "o",
+        length(deletecol),
+        ifelse(length(deletecol) > 1, "models were", "model was"),
+        "eliminated due to linear dependencies\n"
+      ))
+    }
     dat <- subset(dat, !(model_id %in% dumped))
   }
   dat

--- a/R/adaptive.R
+++ b/R/adaptive.R
@@ -221,7 +221,9 @@ adaptiveWorkflow <- function(
             rm(tmp)
           }
         }
-        if (testing) print(head(probValues))
+        if (testing) {
+          print(head(probValues))
+        }
       }
 
       ##################################
@@ -348,10 +350,10 @@ adaptiveWorkflow <- function(
     } ## end initial loop over resamples and models
 
   init_resamp <- rbind.fill(init_result[names(init_result) == "resamples"])
-  init_pred <- if (keep_pred) {
-    rbind.fill(init_result[names(init_result) == "pred"])
+  if (keep_pred) {
+    init_pred <- rbind.fill(init_result[names(init_result) == "pred"])
   } else {
-    NULL
+    init_pred <- NULL
   }
   names(init_resamp) <- gsub("^\\.", "", names(init_resamp))
   if (
@@ -555,7 +557,9 @@ adaptiveWorkflow <- function(
                 rm(tmp)
               }
             }
-            if (testing) print(head(probValues))
+            if (testing) {
+              print(head(probValues))
+            }
           }
 
           ##################################
@@ -785,7 +789,9 @@ adaptiveWorkflow <- function(
 
     last_iter <- iter
 
-    if (num_left == 1) break
+    if (num_left == 1) {
+      break
+    }
   }
   ## finish up last resamples
   if (ctrl$adaptive$complete && last_iter < length(ctrl$index)) {
@@ -977,7 +983,9 @@ adaptiveWorkflow <- function(
               rm(tmp)
             }
           }
-          if (testing) print(head(probValues))
+          if (testing) {
+            print(head(probValues))
+          }
         }
 
         ##################################
@@ -1115,10 +1123,10 @@ adaptiveWorkflow <- function(
     init_result <- c(init_result, final_result)
   }
   resamples <- rbind.fill(init_result[names(init_result) == "resamples"])
-  pred <- if (keep_pred) {
-    rbind.fill(init_result[names(init_result) == "pred"])
+  if (keep_pred) {
+    pred <- rbind.fill(init_result[names(init_result) == "pred"])
   } else {
-    NULL
+    pred <- NULL
   }
   names(resamples) <- gsub("^\\.", "", names(resamples))
 
@@ -1198,7 +1206,9 @@ bt_eval <- function(rs, metric, maximize, alpha = 0.05) {
   })
   if (length(unique(rs$Resample)) >= 5) {
     tmp_scores <- try(skunked(scores), silent = TRUE)
-    if (inherits(tmp_scores, "try-error")) scores <- tmp_scores
+    if (inherits(tmp_scores, "try-error")) {
+      scores <- tmp_scores
+    }
   }
   best_mod <- ddply(
     rs,
@@ -1206,10 +1216,10 @@ bt_eval <- function(rs, metric, maximize, alpha = 0.05) {
     function(x, metric) mean(x[, metric], na.rm = TRUE),
     metric = metric
   )
-  best_mod <- if (maximize) {
-    best_mod$model_id[which.max(best_mod$V1)]
+  if (maximize) {
+    best_mod <- best_mod$model_id[which.max(best_mod$V1)]
   } else {
-    best_mod$model_id[which.min(best_mod$V1)]
+    best_mod <- best_mod$model_id[which.min(best_mod$V1)]
   }
   btModel <- BradleyTerry2::BTm(
     cbind(win1, win2),
@@ -1225,10 +1235,10 @@ bt_eval <- function(rs, metric, maximize, alpha = 0.05) {
   if (any(btCoef[, "Std. Error"] > se_thresh)) {
     ## These players either are uniformly dominated (='dom') or dominating
     dom1 <- btCoef[, "Std. Error"] > se_thresh
-    dom2 <- if (maximize) {
-      btCoef[, "Estimate"] <= 0
+    if (maximize) {
+      dom2 <- btCoef[, "Estimate"] <= 0
     } else {
-      btCoef[, "Estimate"] >= 0
+      dom2 <- btCoef[, "Estimate"] >= 0
     }
     dom <- dom1 & dom2
   } else {
@@ -1246,7 +1256,11 @@ get_scores <- function(x, maximize = NULL, metric = NULL) {
   delta <- outer(x[, metric], x[, metric], "-")
   tied <- ifelse(delta == 0, 1, 0) * 0.5
   diag(tied) <- 0
-  binary <- if (maximize) ifelse(delta > 0, 1, 0) else ifelse(delta > 0, 0, 1)
+  if (maximize) {
+    binary <- ifelse(delta > 0, 1, 0)
+  } else {
+    binary <- ifelse(delta > 0, 0, 1)
+  }
   binary <- binary + tied
   diag(binary) <- 0
   rownames(binary) <- colnames(binary) <- x$model_id
@@ -1290,20 +1304,20 @@ gls_eval <- function(x, metric, maximize, alpha = 0.05) {
     function(x, met) c(mean = mean(x[, met], na.rm = TRUE)),
     met = metric
   )
-  means <- if (maximize) {
-    means[order(-means$mean), ]
+  if (maximize) {
+    means <- means[order(-means$mean), ]
   } else {
-    means[order(means$mean), ]
+    means <- means[order(means$mean), ]
   }
   levs <- as.character(means$model_id)
   bl <- levs[1]
   bldat <- subset(x, model_id == bl)[, c("Resample", metric)]
   colnames(bldat)[2] <- ".baseline"
   x2 <- merge(bldat, x[, c("Resample", "model_id", metric)])
-  x2$value <- if (maximize) {
-    x2$.baseline - x2[, metric]
+  if (maximize) {
+    x2$value <- x2$.baseline - x2[, metric]
   } else {
-    x2[, metric] - x2$.baseline
+    x2$value <- x2[, metric] - x2$.baseline
   }
   x2 <- subset(x2, model_id != bl)
   x2$model_id <- factor(x2$model_id, levels = levs[-1])
@@ -1331,7 +1345,11 @@ gls_eval <- function(x, metric, maximize, alpha = 0.05) {
     }
   } else {
     ttest <- t.test(x2$value, alternative = "greater")$p.value
-    keepers <- if (!is.na(ttest) && ttest >= alpha) levs[-1] else NULL
+    if (!is.na(ttest) && ttest >= alpha) {
+      keepers <- levs[-1]
+    } else {
+      keepers <- NULL
+    }
   }
   unique(c(bl, keepers))
 }
@@ -1343,20 +1361,20 @@ seq_eval <- function(x, metric, maximize, alpha = 0.05) {
     function(x, met) c(mean = mean(x[, met], na.rm = TRUE)),
     met = metric
   )
-  means <- if (maximize) {
-    means[order(-means$mean), ]
+  if (maximize) {
+    means <- means[order(-means$mean), ]
   } else {
-    means[order(means$mean), ]
+    means <- means[order(means$mean), ]
   }
   levs <- as.character(means$model_id)
   bl <- levs[1]
   bldat <- subset(x, model_id == bl)[, c("Resample", metric)]
   colnames(bldat)[2] <- ".baseline"
   x2 <- merge(bldat, x[, c("Resample", "model_id", metric)])
-  x2$value <- if (maximize) {
-    x2$.baseline - x2[, metric]
+  if (maximize) {
+    x2$value <- x2$.baseline - x2[, metric]
   } else {
-    x2[, metric] - x2$.baseline
+    x2$value <- x2[, metric] - x2$.baseline
   }
   x2 <- subset(x2, model_id != bl)
   x2$model_id <- factor(x2$model_id, levels = levs[-1])
@@ -1373,7 +1391,11 @@ seq_eval <- function(x, metric, maximize, alpha = 0.05) {
     keepers <- gsub("model_id", "", keepers)
   } else {
     ttest <- t.test(x2$value, alternative = "greater")$p.value
-    keepers <- if (!is.na(ttest) && ttest >= alpha) levs[-1] else NULL
+    if (!is.na(ttest) && ttest >= alpha) {
+      keepers <- levs[-1]
+    } else {
+      keepers <- NULL
+    }
   }
   unique(c(bl, keepers))
 }
@@ -1440,10 +1462,10 @@ diffmat <- function(dat) {
         x <- dat[, i] - dat[, j]
         tmpm <- abs(mean(x, na.rm = TRUE))
         tmps <- sd(x, na.rm = TRUE)
-        out[i, j] <- out[j, i] <- if (tmps < .Machine$double.eps^0.5) {
-          0
+        if (tmps < .Machine$double.eps^0.5) {
+          out[i, j] <- out[j, i] <- 0
         } else {
-          tmpm / tmps
+          out[i, j] <- out[j, i] <- tmpm / tmps
         }
       }
     }

--- a/R/additive.R
+++ b/R/additive.R
@@ -1,44 +1,60 @@
-
-additivePlot <- function(x, data, n = 100, quant = 0, plot = TRUE, ...)
-  {
-    if(inherits(x, "earth"))
-      {
-        data <- data[, predictors(x), drop = FALSE]
-      }
-    seqs <- lapply(data,
-                   function(x, len, q) list(seq = seq(
-                                              quantile(x, na.rm = TRUE, probs = q),
-                                              quantile(x, na.rm = TRUE, probs = 1 - q),
-                                              length.out = len),
-                                            var = ""),
-                   len = n,
-                   q = quant)
-    for(i in seq(along.with = seqs)) seqs[[i]]$var <- colnames(data)[i]
-    meds <- lapply(data,
-                   function(x, len) rep(median(x, na.rm = TRUE), len),
-                   len = n)
-    meds <- as.data.frame(meds, stringsAsFactors = TRUE)
-    predGrid <- lapply(seqs,
-                       function(x, m)
-                       {
-                         m[, x$var] <- x$seq
-                         m$variable <- x$var
-                         m
-                       },
-                       m = meds)
-    predGrid <- do.call("rbind", predGrid)
-    predGrid$predicted <- predict(x, predGrid[, colnames(data), drop = FALSE], ...)
-    predGrid$x <- unlist(lapply(seqs, function(x) x$seq))
-    if(plot)
-      {
-        out <- xyplot(predicted ~ x|variable,
-                      data = predGrid,
-                      between = list(x = 2),
-                      scales = list(x = list(relation = "free")),
-                      as.table = TRUE,
-                      xlab = "",
-                      ylab = "Predicted",
-                      type = "l")
-      } else out <- predGrid
-    out
+additivePlot <- function(x, data, n = 100, quant = 0, plot = TRUE, ...) {
+  if (inherits(x, "earth")) {
+    data <- data[, predictors(x), drop = FALSE]
   }
+  seqs <- lapply(
+    data,
+    function(x, len, q) {
+      list(
+        seq = seq(
+          quantile(x, na.rm = TRUE, probs = q),
+          quantile(x, na.rm = TRUE, probs = 1 - q),
+          length.out = len
+        ),
+        var = ""
+      )
+    },
+    len = n,
+    q = quant
+  )
+  for (i in seq(along.with = seqs)) {
+    seqs[[i]]$var <- colnames(data)[i]
+  }
+  meds <- lapply(
+    data,
+    function(x, len) rep(median(x, na.rm = TRUE), len),
+    len = n
+  )
+  meds <- as.data.frame(meds, stringsAsFactors = TRUE)
+  predGrid <- lapply(
+    seqs,
+    function(x, m) {
+      m[, x$var] <- x$seq
+      m$variable <- x$var
+      m
+    },
+    m = meds
+  )
+  predGrid <- do.call("rbind", predGrid)
+  predGrid$predicted <- predict(
+    x,
+    predGrid[, colnames(data), drop = FALSE],
+    ...
+  )
+  predGrid$x <- unlist(lapply(seqs, function(x) x$seq))
+  if (plot) {
+    out <- xyplot(
+      predicted ~ x | variable,
+      data = predGrid,
+      between = list(x = 2),
+      scales = list(x = list(relation = "free")),
+      as.table = TRUE,
+      xlab = "",
+      ylab = "Predicted",
+      type = "l"
+    )
+  } else {
+    out <- predGrid
+  }
+  out
+}

--- a/R/avNNet.R
+++ b/R/avNNet.R
@@ -47,7 +47,7 @@
 #' data(BloodBrain)
 #' modelFit <- avNNet(bbbDescr, logBBB, size = 5, linout = TRUE, trace = FALSE)
 #' modelFit
-#' 
+#'
 #' predict(modelFit, bbbDescr)
 #' @keywords neural
 #' @aliases avNNet.default predict.avNNet avNNet.formula avNNet

--- a/R/avNNet.R
+++ b/R/avNNet.R
@@ -145,7 +145,11 @@ avNNet.default <- function(
 
   ## to avoid a "no visible binding for global variable 'i'" warning:
   i <- NULL
-  `%op%` <- if (allowParallel) `%dopar%` else `%do%`
+  if (allowParallel) {
+    `%op%` <- `%dopar%`
+  } else {
+    `%op%` <- `%do%`
+  }
   mods <- foreach(
     i = 1:repeats,
     .verbose = FALSE,
@@ -154,7 +158,9 @@ avNNet.default <- function(
   ) %op%
     {
       if (any(names(theDots) == "trace")) {
-        if (theDots$trace) cat("\nFitting Repeat", i, "\n\n")
+        if (theDots$trace) {
+          cat("\nFitting Repeat", i, "\n\n")
+        }
       } else {
         cat("Fitting Repeat", i, "\n\n")
       }
@@ -162,10 +168,10 @@ avNNet.default <- function(
       if (bag) {
         ind <- sample(seq_len(nrow(x)), replace = TRUE)
       }
-      thisMod <- if (is.null(classLev)) {
-        nnet::nnet(x[ind, , drop = FALSE], y[ind], ...)
+      if (is.null(classLev)) {
+        thisMod <- nnet::nnet(x[ind, , drop = FALSE], y[ind], ...)
       } else {
-        nnet::nnet(x[ind, , drop = FALSE], y[ind, ], ...)
+        thisMod <- nnet::nnet(x[ind, , drop = FALSE], y[ind, ], ...)
       }
       thisMod$lev <- classLev
       thisMod
@@ -219,7 +225,11 @@ predict.avNNet <- function(
       for (i in 1:object$repeats) {
         rawTmp <- fitted.values(object$model[[i]])
         rawTmp <- t(apply(rawTmp, 1, function(x) exp(x) / sum(exp(x))))
-        scores <- if (i == 1) rawTmp else scores + rawTmp
+        if (i == 1) {
+          scores <- rawTmp
+        } else {
+          scores <- scores + rawTmp
+        }
       }
       scores <- scores / object$repeats
       classes <- colnames(scores)[apply(scores, 1, which.max)]
@@ -230,7 +240,9 @@ predict.avNNet <- function(
       if (type[1] == "class") {
         out <- (classes)
       }
-      if (type[1] == "prob") out <- t(apply(scores, 1, function(x) x / sum(x)))
+      if (type[1] == "prob") {
+        out <- t(apply(scores, 1, function(x) x / sum(x)))
+      }
     }
   } else {
     if (inherits(object, "avNNet.formula")) {
@@ -272,10 +284,10 @@ predict.avNNet <- function(
       return(apply(out, 1, mean))
     } else {
       for (i in 1:object$repeats) {
-        scores <- if (i == 1) {
-          predict(object$model[[i]], newdata = x)
+        if (i == 1) {
+          scores <- predict(object$model[[i]], newdata = x)
         } else {
-          scores + predict(object$model[[i]], newdata = x)
+          scores <- scores + predict(object$model[[i]], newdata = x)
         }
       }
       scores <- scores / object$repeats
@@ -287,7 +299,9 @@ predict.avNNet <- function(
       if (type[1] == "class") {
         out <- (classes)
       }
-      if (type[1] == "prob") out <- t(apply(scores, 1, function(x) x / sum(x)))
+      if (type[1] == "prob") {
+        out <- t(apply(scores, 1, function(x) x / sum(x)))
+      }
     }
   }
   out

--- a/R/bag.R
+++ b/R/bag.R
@@ -333,7 +333,11 @@ print.bag <- function(x, ...) {
       oobResults <- ddply(oobData, .(key), defaultSummary)
       oobResults$key <- NULL
       oobStat <- apply(oobResults, 2, function(x) {
-        quantile(x, na.rm = TRUE, probs = c(0, 0.025, 0.25, 0.5, 0.75, 0.975, 1))
+        quantile(
+          x,
+          na.rm = TRUE,
+          probs = c(0, 0.025, 0.25, 0.5, 0.75, 0.975, 1)
+        )
       })
       rownames(oobStat) <- paste(
         format(as.numeric(format(gsub("%", "", rownames(oobStat))))),

--- a/R/bag.R
+++ b/R/bag.R
@@ -213,7 +213,11 @@ bagControl <- function(
 
     btSamples <- createResample(y, times = B)
 
-    `%op%` <- if (bagControl$allowParallel) `%dopar%` else `%do%`
+    if (bagControl$allowParallel) {
+      `%op%` <- `%dopar%`
+    } else {
+      `%op%` <- `%do%`
+    }
     btFits <- foreach(
       iter = seq(along.with = btSamples),
       .verbose = FALSE,

--- a/R/bagEarth.R
+++ b/R/bagEarth.R
@@ -98,12 +98,11 @@
       index <- fit$index
       subX <- x[-index, , drop = FALSE]
       subY <- y[-index]
-      predY <-
-        if (is.null(fit$levels)) {
-          predict(fit, subX)
-        } else {
-          predict(fit, subX, type = "class")
-        }
+      if (is.null(fit$levels)) {
+        predY <- predict(fit, subX)
+      } else {
+        predY <- predict(fit, subX, type = "class")
+      }
       postResample(predY, subY)
     }
 
@@ -235,10 +234,10 @@
 "predict.bagEarth" <-
   function(object, newdata = NULL, type = NULL, ...) {
     if (is.null(type)) {
-      type <- if (all(is.na(object$levels))) {
-        "response"
+      if (all(is.na(object$levels))) {
+        type <- "response"
       } else {
-        "class"
+        type <- "class"
       }
     }
     if (!any(type %in% c("response", "class", "prob"))) {

--- a/R/bagEarth.R
+++ b/R/bagEarth.R
@@ -37,7 +37,7 @@
 #' fit1 <- earth(x = trees[, -3], y = trees[, 3])
 #' set.seed(2189)
 #' fit2 <- bagEarth(x = trees[, -3], y = trees[, 3], B = 10)
-#' 
+#'
 #' @keywords regression
 #'
 #' @export
@@ -222,7 +222,7 @@
 #' @keywords regression
 #' @export
 #' @examplesIf !caret:::is_cran_check()
-#' 
+#'
 #' data(trees)
 #' ## out of bag predictions vs just re-predicting the training set
 #' set.seed(655)
@@ -230,7 +230,7 @@
 #' set.seed(655)
 #' fit2 <- bagEarth(Volume ~ ., data = trees, keepX = FALSE)
 #' hist(predict(fit1) - predict(fit2))
-#' 
+#'
 #' @export predict.bagEarth
 "predict.bagEarth" <-
   function(object, newdata = NULL, type = NULL, ...) {
@@ -326,12 +326,12 @@ print.bagEarth <- function(x, ...) {
 #' @keywords manip
 #' @export
 #' @examplesIf !caret:::is_cran_check()
-#' 
+#'
 #' data(trees)
 #' set.seed(9655)
 #' fit <- bagEarth(trees[, -3], trees[, 3])
 #' summary(fit)
-#' 
+#'
 #' @export summary.bagEarth
 "summary.bagEarth" <-
   function(object, ...) {

--- a/R/bagFDA.R
+++ b/R/bagFDA.R
@@ -82,10 +82,10 @@
       if (!is.null(w)) {
         subW <- w[index]
       }
-      fit <- if (is.null(w)) {
-        mda::fda(.outcome ~ ., data = tmp, method = earth::earth, ...)
+      if (is.null(w)) {
+        fit <- mda::fda(.outcome ~ ., data = tmp, method = earth::earth, ...)
       } else {
-        mda::fda(
+        fit <- mda::fda(
           .outcome ~ .,
           data = tmp,
           method = earth::earth,

--- a/R/bagFDA.R
+++ b/R/bagFDA.R
@@ -34,201 +34,266 @@
 #' library(mlbench)
 #' library(earth)
 #' data(Glass)
-#' 
+#'
 #' set.seed(36)
 #' inTrain <- sample(1:dim(Glass)[1], 150)
-#' 
+#'
 #' trainData <- Glass[inTrain, ]
 #' testData <- Glass[-inTrain, ]
-#' 
+#'
 #' set.seed(3577)
 #' baggedFit <- bagFDA(Type ~ ., trainData)
 #' confusionMatrix(
 #'   data = predict(baggedFit, testData[, -10]),
 #'   reference = testData[, 10]
 #' )
-#' 
+#'
 #' @keywords regression
 #'
 #' @export
 "bagFDA" <-
-function(x, ...)
-   UseMethod("bagFDA")
+  function(x, ...) {
+    UseMethod("bagFDA")
+  }
 
 #' @rdname bagFDA
 #' @export
 "bagFDA.default" <-
-function(x, y, weights = NULL, B = 50, keepX = TRUE, ...)
-{
-  requireNamespaceQuietStop("mda")
-  requireNamespaceQuietStop("earth")
-   if(!is.matrix(x)) x <- as.matrix(x)
-   if(!is.vector(y) && !is.factor(y)) y <- as.vector(y)
-   if(!is.vector(y) && !is.factor(y)) y <- factor(y[,1])
-   if(is.null(weights)) weights <- rep(1, dim(x)[1])
-   foo <- function(index, x, y, w, ...)
-   {
-      subX <- x[index,, drop = FALSE]
+  function(x, y, weights = NULL, B = 50, keepX = TRUE, ...) {
+    requireNamespaceQuietStop("mda")
+    requireNamespaceQuietStop("earth")
+    if (!is.matrix(x)) {
+      x <- as.matrix(x)
+    }
+    if (!is.vector(y) && !is.factor(y)) {
+      y <- as.vector(y)
+    }
+    if (!is.vector(y) && !is.factor(y)) {
+      y <- factor(y[, 1])
+    }
+    if (is.null(weights)) {
+      weights <- rep(1, dim(x)[1])
+    }
+    foo <- function(index, x, y, w, ...) {
+      subX <- x[index, , drop = FALSE]
       subY <- y[index]
       tmp <- as.data.frame(subX, stringsAsFactors = FALSE)
       tmp$.outcome <- subY
-      if(!is.null(w)) subW <- w[index]
-      fit <- if(is.null(w))
-        mda::fda(.outcome ~., data = tmp, method = earth::earth, ...) else
-          mda::fda(.outcome ~., data = tmp, method = earth::earth, weights = subW, ...)
+      if (!is.null(w)) {
+        subW <- w[index]
+      }
+      fit <- if (is.null(w)) {
+        mda::fda(.outcome ~ ., data = tmp, method = earth::earth, ...)
+      } else {
+        mda::fda(
+          .outcome ~ .,
+          data = tmp,
+          method = earth::earth,
+          weights = subW,
+          ...
+        )
+      }
       fit$index <- index
       fit
-   }
+    }
 
-   oobFoo <- function(fit, x, y)
-   {
+    oobFoo <- function(fit, x, y) {
       index <- fit$index
-      subX <- x[-index,, drop = FALSE]
+      subX <- x[-index, , drop = FALSE]
       subY <- y[-index]
       predY <- predict(fit, subX)
       postResample(predY, subY)
-   }
+    }
 
-   btSamples <- createResample(y, times = B)
-   btFits <- lapply(btSamples, foo, x = x, y = y, w = weights, ...)
-   oobList <- lapply(btFits, oobFoo, x = x, y = y)
-   oob <- matrix(unlist(oobList), ncol = length(oobList[[1]]), byrow = TRUE)
-   colnames(oob) <- names(oobList[[1]])
-   if(keepX) x <- x else x <- NULL
-   structure(list(fit = btFits, B = B, oob = oob, x = x, levels = levels(y),
-                  weights = !is.null(weights), dots = list(...)), class = "bagFDA")
-}
+    btSamples <- createResample(y, times = B)
+    btFits <- lapply(btSamples, foo, x = x, y = y, w = weights, ...)
+    oobList <- lapply(btFits, oobFoo, x = x, y = y)
+    oob <- matrix(unlist(oobList), ncol = length(oobList[[1]]), byrow = TRUE)
+    colnames(oob) <- names(oobList[[1]])
+    if (keepX) {
+      x <- x
+    } else {
+      x <- NULL
+    }
+    structure(
+      list(
+        fit = btFits,
+        B = B,
+        oob = oob,
+        x = x,
+        levels = levels(y),
+        weights = !is.null(weights),
+        dots = list(...)
+      ),
+      class = "bagFDA"
+    )
+  }
 
 #' @rdname bagFDA
 #' @export
 "bagFDA.formula" <-
-function (formula, data = NULL, B = 50, keepX = TRUE, ..., subset, weights = NULL, na.action = na.omit)
-{
+  function(
+    formula,
+    data = NULL,
+    B = 50,
+    keepX = TRUE,
+    ...,
+    subset,
+    weights = NULL,
+    na.action = na.omit
+  ) {
+    if (!inherits(formula, "formula")) {
+      stop("method is only for formula objects")
+    }
+    m <- match.call(expand.dots = FALSE)
+    mIndex <- match(
+      c("formula", "data", "subset", "weights", "na.action"),
+      names(m),
+      0
+    )
+    m <- m[c(1, mIndex)]
+    m$... <- NULL
+    m$na.action <- na.action
+    m[[1]] <- as.name("model.frame")
+    m <- eval(m, parent.frame())
+    Terms <- attr(m, "terms")
+    attr(Terms, "intercept") <- 0
+    y <- model.response(m)
+    w <- model.weights(m)
+    x <- model.matrix(Terms, m)
+    cons <- attr(x, "contrast")
+    xint <- match("(Intercept)", colnames(x), nomatch = 0)
+    if (xint > 0) {
+      x <- x[, -xint, drop = FALSE]
+    }
 
-   if (!inherits(formula, "formula"))
-     stop("method is only for formula objects")
-   m <- match.call(expand.dots = FALSE)
-   mIndex <- match(c("formula", "data", "subset", "weights", "na.action"), names(m), 0)
-   m <- m[c(1, mIndex)]
-   m$... <- NULL
-   m$na.action <- na.action
-   m[[1]] <- as.name("model.frame")
-   m <- eval(m, parent.frame())
-   Terms <- attr(m, "terms")
-   attr(Terms, "intercept") <- 0
-   y <- model.response(m)
-   w <- model.weights(m)
-   x <- model.matrix(Terms, m)
-   cons <- attr(x, "contrast")
-   xint <- match("(Intercept)", colnames(x), nomatch = 0)
-   if (xint > 0)  x <- x[, -xint, drop = FALSE]
-
-   out <- bagFDA.default(x = x, y = y, weights = weights, B = B, keepX = keepX, ...)
-   out
-}
+    out <- bagFDA.default(
+      x = x,
+      y = y,
+      weights = weights,
+      B = B,
+      keepX = keepX,
+      ...
+    )
+    out
+  }
 
 #' @rdname bagFDA
 #' @export
 "print.bagFDA" <-
-function (x, ...)
-{
-    if(!is.null(x$x))cat("Data:\n   # variables:\t", dim(x$x)[2], "\n   # samples:\t", dim(x$x)[1], "\n")
+  function(x, ...) {
+    if (!is.null(x$x)) {
+      cat(
+        "Data:\n   # variables:\t",
+        dim(x$x)[2],
+        "\n   # samples:\t",
+        dim(x$x)[1],
+        "\n"
+      )
+    }
     cat(
       "\nModel:",
-      "\n   B:        \t", x$B,
-      "\n   dimension:\t", x$fit[[1]]$dimension,
-      "\n")
-    if(x$weights) cat("case weights used\n")
+      "\n   B:        \t",
+      x$B,
+      "\n   dimension:\t",
+      x$fit[[1]]$dimension,
+      "\n"
+    )
+    if (x$weights) {
+      cat("case weights used\n")
+    }
 
     cat("\n")
     invisible(x)
-}
-
-
+  }
 
 
 #' @rdname predict.bagEarth
 #' @export
 "predict.bagFDA" <-
-function(object, newdata = NULL, type = "class", ...)
-{
-  requireNamespaceQuietStop("mda")
-  requireNamespaceQuietStop("earth")
-   getTrainPred <- function(x)
-     {
-       oobIndex <- seq_len(nrow(x$fit$fitted.values))
-       oobIndex <- oobIndex[!(oobIndex %in% unique(x$index))]
-       tmp <- predict(x, type = "posterior")[oobIndex,,drop = FALSE]
-       rownames(tmp) <- seq_len(nrow(tmp))
-       out <- data.frame(pred = tmp,
-                         sample = oobIndex,
-                         check.rows = FALSE)
-       colnames(out)[seq_len(ncol(tmp))] <- names(x$prior)
-       out
-     }
+  function(object, newdata = NULL, type = "class", ...) {
+    requireNamespaceQuietStop("mda")
+    requireNamespaceQuietStop("earth")
+    getTrainPred <- function(x) {
+      oobIndex <- seq_len(nrow(x$fit$fitted.values))
+      oobIndex <- oobIndex[!(oobIndex %in% unique(x$index))]
+      tmp <- predict(x, type = "posterior")[oobIndex, , drop = FALSE]
+      rownames(tmp) <- seq_len(nrow(tmp))
+      out <- data.frame(pred = tmp, sample = oobIndex, check.rows = FALSE)
+      colnames(out)[seq_len(ncol(tmp))] <- names(x$prior)
+      out
+    }
 
-   if(is.null(newdata) && !is.null(object$x)) newdata <- object$x
+    if (is.null(newdata) && !is.null(object$x)) {
+      newdata <- object$x
+    }
 
-   if(is.null(newdata))
-     {
-       pred <- lapply(object$fit, getTrainPred)
+    if (is.null(newdata)) {
+      pred <- lapply(object$fit, getTrainPred)
     } else {
-       pred <- lapply(object$fit,
-                      function(x, y)
-                      {
-                        tmp <- predict(x, newdata = y, type = "posterior")
-                        nms <- colnames(tmp)
-                        tmp <- as.data.frame(tmp, stringsAsFactors = FALSE)
-                        names(tmp) <- nms
-                        tmp$sample <- seq_len(nrow(tmp))
-                        tmp
-                      },
-                      y = newdata)
-     }
-   pred <- rbind.fill(pred)
-   out <- ddply(pred, .(sample),
-                function(x) colMeans(x[,seq(along.with = object$levels)], na.rm = TRUE))
-   out <- out[,-1,drop = FALSE]
-   rownames(out) <- rownames(newdata)
-   predClass <- object$levels[apply(out, 1, which.max)]
-   predClass <- factor(predClass, levels = object$levels)
-   switch(type, class = predClass, probs = out, posterior = out)
-}
+      pred <- lapply(
+        object$fit,
+        function(x, y) {
+          tmp <- predict(x, newdata = y, type = "posterior")
+          nms <- colnames(tmp)
+          tmp <- as.data.frame(tmp, stringsAsFactors = FALSE)
+          names(tmp) <- nms
+          tmp$sample <- seq_len(nrow(tmp))
+          tmp
+        },
+        y = newdata
+      )
+    }
+    pred <- rbind.fill(pred)
+    out <- ddply(pred, .(sample), function(x) {
+      colMeans(x[, seq(along.with = object$levels)], na.rm = TRUE)
+    })
+    out <- out[, -1, drop = FALSE]
+    rownames(out) <- rownames(newdata)
+    predClass <- object$levels[apply(out, 1, which.max)]
+    predClass <- factor(predClass, levels = object$levels)
+    switch(type, class = predClass, probs = out, posterior = out)
+  }
 
 #' @rdname summary.bagEarth
 #' @export
 "summary.bagFDA" <-
-function(object, ...)
-{
+  function(object, ...) {
+    oobStat <- apply(object$oob, 2, function(x) {
+      quantile(x, probs = c(0, 0.025, 0.5, 0.975, 1))
+    })
 
-   oobStat <- apply(object$oob, 2, function(x) quantile(x, probs = c(0, 0.025, 0.5, 0.975, 1)))
-
-   numTerms <- unlist(lapply(object$fit, function(x) length(x$fit$selected.terms)))
-   numVar <- unlist(lapply(
+    numTerms <- unlist(lapply(object$fit, function(x) {
+      length(x$fit$selected.terms)
+    }))
+    numVar <- unlist(lapply(
       object$fit,
-      function(x)
-      {
-         sum(
-            apply(
-               x$fit$dirs,
-               2,
-               function(u) any(u != 0)))
-      }))
-   modelInfo <- cbind(numTerms, numVar)
-   colnames(modelInfo) <- c("Num Terms", "Num Variables")
-   out <- list(modelInfo = modelInfo, oobStat = oobStat)
-   class(out) <- "summary.bagFDA"
-   out
-}
+      function(x) {
+        sum(
+          apply(
+            x$fit$dirs,
+            2,
+            function(u) any(u != 0)
+          )
+        )
+      }
+    ))
+    modelInfo <- cbind(numTerms, numVar)
+    colnames(modelInfo) <- c("Num Terms", "Num Variables")
+    out <- list(modelInfo = modelInfo, oobStat = oobStat)
+    class(out) <- "summary.bagFDA"
+    out
+  }
 
 #' @export
 "print.summary.bagFDA" <-
-function(x, digits = max(3, getOption("digits") - 3), ...)
-{
-   oobStat <- apply(x$oob, 2, function(x) quantile(x, probs = c(0, 0.025, 0.25, 0.5, 0.75, 0.975, 1)))
-   cat("Out of bag statistics:\n\n")
-   print(x$oobStat, digits = digits)
-   cat("\nModel Selection Statistics:\n\n")
-   print(summary(x$modelInfo))
-   cat("\n")
-}
+  function(x, digits = max(3, getOption("digits") - 3), ...) {
+    oobStat <- apply(x$oob, 2, function(x) {
+      quantile(x, probs = c(0, 0.025, 0.25, 0.5, 0.75, 0.975, 1))
+    })
+    cat("Out of bag statistics:\n\n")
+    print(x$oobStat, digits = digits)
+    cat("\nModel Selection Statistics:\n\n")
+    print(summary(x$modelInfo))
+    cat("\n")
+  }

--- a/R/basic2x2Stats.R
+++ b/R/basic2x2Stats.R
@@ -1,10 +1,14 @@
-basic2x2Stats <- function(x, y, pos, neg)
-{
-   out <- vector(length = 4, mode = "numeric")
-   out[1] <- sensitivity(x, y, pos)
-   out[2] <- specificity(x, y, neg)
-   out[3] <- posPredValue(x, y, pos)
-   out[4] <- negPredValue(x, y, neg)  
-   names(out) <- c("Sensitivity", "Specificity", "Pos Pred Value", "Neg Pred Value")
-   out
+basic2x2Stats <- function(x, y, pos, neg) {
+  out <- vector(length = 4, mode = "numeric")
+  out[1] <- sensitivity(x, y, pos)
+  out[2] <- specificity(x, y, neg)
+  out[3] <- posPredValue(x, y, pos)
+  out[4] <- negPredValue(x, y, neg)
+  names(out) <- c(
+    "Sensitivity",
+    "Specificity",
+    "Pos Pred Value",
+    "Neg Pred Value"
+  )
+  out
 }

--- a/R/calibration.R
+++ b/R/calibration.R
@@ -151,10 +151,10 @@ calibration.formula <- function(
   probNames <- strsplit(form$right.name, " + ", fixed = TRUE)[[1]]
 
   calibData <- data.frame(calibClassVar = form$left, calibProbVar = form$right)
-  calibData$calibModelVar <- if (length(probNames) > 1) {
-    form$condition[[length(form$condition)]]
+  if (length(probNames) > 1) {
+    calibData$calibModelVar <- form$condition[[length(form$condition)]]
   } else {
-    probNames
+    calibData$calibModelVar <- probNames
   }
 
   if (length(form$condition) > 0 && any(names(form$condition) != "")) {

--- a/R/calibration.R
+++ b/R/calibration.R
@@ -81,33 +81,33 @@
 #' @seealso [lattice::xyplot()], [lattice::trellis.par.set()]
 #'
 #' @examplesIf !caret:::is_cran_check()
-#' 
+#'
 #' data(mdrr)
 #' mdrrDescr <- mdrrDescr[, -nearZeroVar(mdrrDescr)]
 #' mdrrDescr <- mdrrDescr[, -findCorrelation(cor(mdrrDescr), .5)]
-#' 
+#'
 #' inTrain <- createDataPartition(mdrrClass)
 #' trainX <- mdrrDescr[inTrain[[1]], ]
 #' trainY <- mdrrClass[inTrain[[1]]]
 #' testX <- mdrrDescr[-inTrain[[1]], ]
 #' testY <- mdrrClass[-inTrain[[1]]]
-#' 
+#'
 #' library(MASS)
-#' 
+#'
 #' ldaFit <- lda(trainX, trainY)
-#' 
+#'
 #' testProbs <- data.frame(
 #'   obs = testY,
 #'   lda = predict(ldaFit, testX)$posterior[, 1]
 #' )
-#' 
+#'
 #' calibration(obs ~ lda, data = testProbs)
-#' 
+#'
 #' calPlotData <- calibration(obs ~ lda, data = testProbs)
 #' calPlotData
-#' 
+#'
 #' xyplot(calPlotData, auto.key = list(columns = 2))
-#' 
+#'
 #' @keywords hplot
 #'
 #' @export

--- a/R/caretTheme.R
+++ b/R/caretTheme.R
@@ -1,5 +1,6 @@
 #' @export
-caretTheme <- function() 
+# fmt: skip
+caretTheme <- function()
    list(
       plot.polygon = list(alpha = 1, col = "aliceblue", border = "black",
          lty = 1, lwd = 1),
@@ -66,4 +67,3 @@ caretTheme <- function()
            "#9E0142", "#3288BD", "#F46D43", "#5E4FA2", "#66C2A5", "black", 
            "#9E0142", "#3288BD", "#F46D43", "#5E4FA2", "#66C2A5", "black", 
            "#9E0142", "#3288BD", "#F46D43", "#5E4FA2", "#66C2A5", "black")))
-         

--- a/R/classDist.R
+++ b/R/classDist.R
@@ -53,118 +53,130 @@
 #'
 #' @examples
 #' trainSet <- sample(1:150, 100)
-#' 
+#'
 #' distData <- classDist(iris[trainSet, 1:4], iris$Species[trainSet])
-#' 
+#'
 #' newDist <- predict(distData, iris[-trainSet, 1:4])
-#' 
+#'
 #' splom(newDist, groups = iris$Species[-trainSet])
-#' 
+#'
 #' @keywords manip
 #' @export
-classDist <- function (x, ...)  UseMethod("classDist")
+classDist <- function(x, ...) UseMethod("classDist")
 
 #' @rdname classDist
 #' @export
-classDist.default <- function(x, y, groups = 5,
-                              pca = FALSE,
-                              keep = NULL,
-                              ...)
-{
-  if(is.numeric(y))
-    {
-      y <- cut(y,
-               unique(quantile(y, probs = seq(0, 1, length.out = groups + 1))),
-               include.lowest = TRUE)
-      classLabels <- paste(round((1:groups)/groups*100, 2))
-      y <- factor(y)
-      cuts <- levels(y)
-    } else {
-      classLabels <- levels(y)
-      cuts <- NULL
-    }
+classDist.default <- function(x, y, groups = 5, pca = FALSE, keep = NULL, ...) {
+  if (is.numeric(y)) {
+    y <- cut(
+      y,
+      unique(quantile(y, probs = seq(0, 1, length.out = groups + 1))),
+      include.lowest = TRUE
+    )
+    classLabels <- paste(round((1:groups) / groups * 100, 2))
+    y <- factor(y)
+    cuts <- levels(y)
+  } else {
+    classLabels <- levels(y)
+    cuts <- NULL
+  }
 
   p <- ncol(x)
 
-  if(pca)
-    {
-      pca <- prcomp(x, center = TRUE, scale. = TRUE,
-                    tol = sqrt(.Machine$double.eps))
-      keep <- min(keep, ncol(pca$rotation))
-      if(!is.null(keep)) pca$rotation <- pca$rotation[, 1:keep, drop = FALSE]
-      x <- as.data.frame(predict(pca, newdata = x), stringsAsFactors = FALSE)
-    } else pca <- NULL
+  if (pca) {
+    pca <- prcomp(
+      x,
+      center = TRUE,
+      scale. = TRUE,
+      tol = sqrt(.Machine$double.eps)
+    )
+    keep <- min(keep, ncol(pca$rotation))
+    if (!is.null(keep)) {
+      pca$rotation <- pca$rotation[, 1:keep, drop = FALSE]
+    }
+    x <- as.data.frame(predict(pca, newdata = x), stringsAsFactors = FALSE)
+  } else {
+    pca <- NULL
+  }
 
   x <- split(x, y)
 
-  getStats <- function(u)
-    {
-      if(nrow(u) < ncol(u))
-        stop("there must be more rows than columns for this class")
-      A <- try(cov(u), silent = TRUE)
-      if(inherits(A, "try-error"))
-        stop("Cannot compute the covariance matrix")
-      A <- try(solve(A), silent = TRUE)
-      if(inherits(A, "try-error"))
-        stop("Cannot invert the covariance matrix")
-      list(means = colMeans(u, na.rm = TRUE),
-           A = A)
+  getStats <- function(u) {
+    if (nrow(u) < ncol(u)) {
+      stop("there must be more rows than columns for this class")
     }
+    A <- try(cov(u), silent = TRUE)
+    if (inherits(A, "try-error")) {
+      stop("Cannot compute the covariance matrix")
+    }
+    A <- try(solve(A), silent = TRUE)
+    if (inherits(A, "try-error")) {
+      stop("Cannot invert the covariance matrix")
+    }
+    list(means = colMeans(u, na.rm = TRUE), A = A)
+  }
   structure(
-            list(values = lapply(x, getStats),
-                 classes = classLabels,
-                 cuts = cuts,
-                 pca = pca,
-                 call = match.call(),
-                 p = p,
-                 n = unlist(lapply(x, nrow))),
-            class = "classDist")
+    list(
+      values = lapply(x, getStats),
+      classes = classLabels,
+      cuts = cuts,
+      pca = pca,
+      call = match.call(),
+      p = p,
+      n = unlist(lapply(x, nrow))
+    ),
+    class = "classDist"
+  )
 }
 
 #' @export
-print.classDist <- function(x, ...)
-  {
-    printCall(x$call)
+print.classDist <- function(x, ...) {
+  printCall(x$call)
 
-    if(!is.null(x$cuts))
-      {
-        cat("Classes based on", length(x$cuts) - 1,
-            "cuts of the data\n")
-        paste(x$cuts, collapse = " ")
-        cat("\n")
-      }
-
-    if(!is.null(x$pca)) cat("PCA applied,",
-                            ncol(x$pca$rotation),
-                            "components retained\n\n")
-    cat("# predictors variables:", x$p, "\n")
-    cat("# samples:",
-        paste(
-              paste(x$n,
-                    ifelse(is.null(x$cuts), " (", " "),
-                    names(x$n),
-                    ifelse(is.null(x$cuts), ")", ""),
-                    sep = ""),
-              collapse = ", "),
-        "\n")
-    invisible(x)
+  if (!is.null(x$cuts)) {
+    cat("Classes based on", length(x$cuts) - 1, "cuts of the data\n")
+    paste(x$cuts, collapse = " ")
+    cat("\n")
   }
+
+  if (!is.null(x$pca)) {
+    cat("PCA applied,", ncol(x$pca$rotation), "components retained\n\n")
+  }
+  cat("# predictors variables:", x$p, "\n")
+  cat(
+    "# samples:",
+    paste(
+      paste(
+        x$n,
+        ifelse(is.null(x$cuts), " (", " "),
+        names(x$n),
+        ifelse(is.null(x$cuts), ")", ""),
+        sep = ""
+      ),
+      collapse = ", "
+    ),
+    "\n"
+  )
+  invisible(x)
+}
 
 #' @rdname classDist
 #' @export
-predict.classDist <- function(object, newdata, trans = log, ...)
-{
-  if(!is.null(object$pca))
-    {
-      newdata <- predict(object$pca, newdata = newdata)
-    }
+predict.classDist <- function(object, newdata, trans = log, ...) {
+  if (!is.null(object$pca)) {
+    newdata <- predict(object$pca, newdata = newdata)
+  }
 
-  pred <- function(a, x) mahalanobis(x, center = a$means, cov = a$A, inverted = TRUE)
+  pred <- function(a, x) {
+    mahalanobis(x, center = a$means, cov = a$A, inverted = TRUE)
+  }
 
   out <- lapply(object$values, pred, x = newdata)
   out <- do.call("cbind", out)
   colnames(out) <- paste("dist.", object$classes, sep = "")
 
-  if(!is.null(trans)) out <- apply(out, 2, trans)
+  if (!is.null(trans)) {
+    out <- apply(out, 2, trans)
+  }
   out
 }

--- a/R/classLevels.R
+++ b/R/classLevels.R
@@ -1,62 +1,30 @@
-
 #' @export
 levels.train <- function(x, ...) {
-  if(any(names(x) == "levels")) {
+  if (any(names(x) == "levels")) {
     out <- x$levels
     attributes(out) <- NULL
   } else {
-    if(x$modelType == "Classification") {
-      if(!isS4(x$finalModel) && !is.null(x$finalModel$obsLevels))
+    if (x$modelType == "Classification") {
+      if (!isS4(x$finalModel) && !is.null(x$finalModel$obsLevels)) {
         return(x$finalModel$obsLevels)
-      if(is.null(x$modelInfo)) {
+      }
+      if (is.null(x$modelInfo)) {
         code <- getModelInfo(x$method, regex = FALSE)[[1]]
-      } else code <- x$modelInfo
-      if(!is.null(code$levels)){
+      } else {
+        code <- x$modelInfo
+      }
+      if (!is.null(code$levels)) {
         checkInstall(code$library)
-        for(i in seq(along.with = code$library))
+        for (i in seq(along.with = code$library)) {
           do.call("requireNamespaceQuietStop", list(package = code$library[i]))
+        }
         out <- code$levels(x$finalModel, ...)
-      } else out <- NULL
-    } else out <- NULL
+      } else {
+        out <- NULL
+      }
+    } else {
+      out <- NULL
+    }
   }
   out
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/R/common_code.R
+++ b/R/common_code.R
@@ -67,7 +67,13 @@ same_args <- function(a, b) {
   TRUE
 }
 
-getOper <- function(x) if (x) `%dopar%` else `%do%`
+getOper <- function(x) {
+  if (x) {
+    `%dopar%`
+  } else {
+    `%do%`
+  }
+}
 
 jack_sim <- function(a, b) {
   if (is.matrix(a) && nrow(a) > 1) {
@@ -116,10 +122,10 @@ change_text <- function(old, new, p, show_diff = TRUE) {
   size_diff <- length(new) - length(old)
   if (show_diff) {
     if (abs(size_diff) >= 0) {
-      num_text <- if (size_diff >= 0) {
-        paste0(length(old), "+", size_diff)
+      if (size_diff >= 0) {
+        num_text <- paste0(length(old), "+", size_diff)
       } else {
-        paste0(length(old), size_diff)
+        num_text <- paste0(length(old), size_diff)
       }
     } else {
       num_text <- paste(length(old))

--- a/R/common_code.R
+++ b/R/common_code.R
@@ -2,15 +2,25 @@ get_fitness_differences <- function(pnames, subsets, fitness, label) {
   signs <- lapply(subsets, index2vec, vars = length(pnames))
   signs <- do.call("rbind", signs)
   colnames(signs) <- pnames
-  nzv <- apply(signs, 2, function(x) min(table(factor(x, levels = paste(0:1)))) > 1)
-  if(all(!nzv)) return(NULL)
+  nzv <- apply(signs, 2, function(x) {
+    min(table(factor(x, levels = paste(0:1)))) > 1
+  })
+  if (all(!nzv)) {
+    return(NULL)
+  }
   signs <- signs[, nzv, drop = FALSE]
-  if(!is.matrix(fitness)) fitness <- as.matrix(fitness)
+  if (!is.matrix(fitness)) {
+    fitness <- as.matrix(fitness)
+  }
   snr <- function(x, y) {
-    apply(y, 2,
-          function(outcome, ind)
-            t.test(outcome[ind == 1], outcome[ind == 0])$statistic,
-          ind = x)
+    apply(
+      y,
+      2,
+      function(outcome, ind) {
+        t.test(outcome[ind == 1], outcome[ind == 0])$statistic
+      },
+      ind = x
+    )
   }
   melt(apply(signs, 2, snr, y = fitness))
 }
@@ -22,19 +32,25 @@ process_diffs <- function(x, pnames) {
   }
   x <- x[!is_null_res]
   x <- do.call("rbind", x)
-  mean_diffs <- ddply(x, c("Var1", "Var2"),
-                      function(x) c(mean = mean(x$value, na.rm = TRUE)))
+  mean_diffs <- ddply(x, c("Var1", "Var2"), function(x) {
+    c(mean = mean(x$value, na.rm = TRUE))
+  })
 
-  mean_diffs <- reshape(mean_diffs, direction = "wide",
-                        v.names = "mean",
-                        idvar = "Var2",
-                        timevar = "Var1")
+  mean_diffs <- reshape(
+    mean_diffs,
+    direction = "wide",
+    v.names = "mean",
+    idvar = "Var2",
+    timevar = "Var1"
+  )
   names(mean_diffs) <- gsub("mean\\.", "", names(mean_diffs))
   names(mean_diffs)[1] <- "Variable"
   included <- pnames %in% as.character(mean_diffs$Variable)
-  if(any(!included)) {
+  if (any(!included)) {
     extras <- data.frame(Variable = pnames[!included])
-    for(i in 2:ncol(mean_diffs)) extras[, names(mean_diffs)[i]] <- NA_real_
+    for (i in 2:ncol(mean_diffs)) {
+      extras[, names(mean_diffs)[i]] <- NA_real_
+    }
     mean_diffs <- rbind(mean_diffs, extras)
   }
   mean_diffs
@@ -42,19 +58,28 @@ process_diffs <- function(x, pnames) {
 
 
 same_args <- function(a, b) {
-  if(length(a) != length(b)) return(FALSE)
-  if(!isTRUE(all.equal(sort(a), sort(b)))) return(FALSE)
+  if (length(a) != length(b)) {
+    return(FALSE)
+  }
+  if (!isTRUE(all.equal(sort(a), sort(b)))) {
+    return(FALSE)
+  }
   TRUE
 }
 
-getOper <- function(x) if(x)  `%dopar%` else  `%do%`
+getOper <- function(x) if (x) `%dopar%` else `%do%`
 
 jack_sim <- function(a, b) {
-  if(is.matrix(a) && nrow(a) > 1) a <- a[1,,drop=FALSE]
-  if(is.matrix(a) && nrow(b) > 1) b <- b[1,,drop=FALSE]
-  sum(a ==1 & b ==1)/(sum(a == 1 & b == 0)+sum(a == 0 & b == 1)+sum(a ==1 & b ==1))*100
+  if (is.matrix(a) && nrow(a) > 1) {
+    a <- a[1, , drop = FALSE]
+  }
+  if (is.matrix(a) && nrow(b) > 1) {
+    b <- b[1, , drop = FALSE]
+  }
+  sum(a == 1 & b == 1) /
+    (sum(a == 1 & b == 0) + sum(a == 0 & b == 1) + sum(a == 1 & b == 1)) *
+    100
 }
-
 
 
 #' Convert indicies to a binary vector
@@ -69,16 +94,18 @@ jack_sim <- function(a, b) {
 #' @return a numeric vector
 #' @author Max Kuhn
 #' @examples
-#' 
+#'
 #' index2vec(x = 1:2, vars = 5)
 #' index2vec(x = 1:2, vars = 5, sign = TRUE)
-#' 
+#'
 #' @export index2vec
 
 index2vec <- function(x, vars, sign = FALSE) {
   bin <- rep(0, vars)
   bin[x] <- 1
-  if(sign) bin <- ifelse(bin == 0, -1, 1)
+  if (sign) {
+    bin <- ifelse(bin == 0, -1, 1)
+  }
   bin
 }
 
@@ -87,10 +114,16 @@ change_text <- function(old, new, p, show_diff = TRUE) {
   a <- index2vec(new, p)
   b <- index2vec(old, p)
   size_diff <- length(new) - length(old)
-  if(show_diff) {
-    if(abs(size_diff) >= 0) {
-      num_text <- if(size_diff >= 0) paste0(length(old), "+", size_diff) else paste0(length(old), size_diff)
-    } else num_text <- paste(length(old))
+  if (show_diff) {
+    if (abs(size_diff) >= 0) {
+      num_text <- if (size_diff >= 0) {
+        paste0(length(old), "+", size_diff)
+      } else {
+        paste0(length(old), size_diff)
+      }
+    } else {
+      num_text <- paste(length(old))
+    }
   } else {
     old_len <- length(old)
     new_len <- length(new)
@@ -103,7 +136,7 @@ change_text <- function(old, new, p, show_diff = TRUE) {
 
 #' @export
 predictors.gafs <- function(x, ...) {
- x$best_vars
+  x$best_vars
 }
 
 #' @export

--- a/R/confusionMatrix.R
+++ b/R/confusionMatrix.R
@@ -98,10 +98,10 @@
 #' @family performance
 #' @keywords utilities
 #' @examples
-#' 
+#'
 #' ###################
 #' ## 2 class example
-#' 
+#'
 #' lvs <- c("normal", "abnormal")
 #' truth <- factor(rep(lvs, times = c(86, 258)), levels = rev(lvs))
 #' pred <- factor(
@@ -111,85 +111,109 @@
 #'   ),
 #'   levels = rev(lvs)
 #' )
-#' 
+#'
 #' xtab <- table(pred, truth)
-#' 
+#'
 #' confusionMatrix(xtab)
 #' confusionMatrix(pred, truth)
 #' confusionMatrix(xtab, prevalence = 0.25)
-#' 
+#'
 #' ###################
 #' ## 3 class example
-#' 
+#'
 #' confusionMatrix(iris$Species, sample(iris$Species))
-#' 
+#'
 #' newPrior <- c(.05, .8, .15)
 #' names(newPrior) <- levels(iris$Species)
-#' 
+#'
 #' confusionMatrix(iris$Species, sample(iris$Species))
-#' 
+#'
 #' @export confusionMatrix
 confusionMatrix <-
-  function(data, ...){
+  function(data, ...) {
     UseMethod("confusionMatrix")
   }
 
 #' @rdname confusionMatrix
 #' @export
-confusionMatrix.default <- function(data, reference,
-                                    positive = NULL,
-                                    dnn = c("Prediction", "Reference"),
-                                    prevalence = NULL,
-                                    mode = "sens_spec",
-                                    ...) {
-  if(!(mode %in% c("sens_spec", "prec_recall", "everything")))
+confusionMatrix.default <- function(
+  data,
+  reference,
+  positive = NULL,
+  dnn = c("Prediction", "Reference"),
+  prevalence = NULL,
+  mode = "sens_spec",
+  ...
+) {
+  if (!(mode %in% c("sens_spec", "prec_recall", "everything"))) {
     stop("`mode` should be either 'sens_spec', 'prec_recall', or 'everything'")
-  if(!is.factor(data) || !is.factor(reference)) {
-    stop("`data` and `reference` should be factors with the same levels.", call. = FALSE)
   }
-  if(!is.character(positive) && !is.null(positive)) stop("positive argument must be character")
+  if (!is.factor(data) || !is.factor(reference)) {
+    stop(
+      "`data` and `reference` should be factors with the same levels.",
+      call. = FALSE
+    )
+  }
+  if (!is.character(positive) && !is.null(positive)) {
+    stop("positive argument must be character")
+  }
 
-  if(length(levels(data)) > length(levels(reference)))
+  if (length(levels(data)) > length(levels(reference))) {
     stop("the data cannot have more levels than the reference")
+  }
 
-  if(!any(levels(data) %in% levels(reference))){
+  if (!any(levels(data) %in% levels(reference))) {
     stop("The data must contain some levels that overlap the reference.")
   }
 
-  if(!all(levels(data) %in% levels(reference))){
+  if (!all(levels(data) %in% levels(reference))) {
     badLevel <- levels(data)[!levels(data) %in% levels(reference)]
-    if(sum(table(data)[badLevel]) > 0){
+    if (sum(table(data)[badLevel]) > 0) {
       stop("The data contain levels not found in the data.")
-    } else{
-      warning("The data contains levels not found in the data, but they are empty and will be dropped.")
+    } else {
+      warning(
+        "The data contains levels not found in the data, but they are empty and will be dropped."
+      )
       data <- factor(as.character(data))
     }
   }
 
-  if(any(levels(reference) != levels(data))) {
-    warning("Levels are not in the same order for reference and data. Refactoring data to match.")
+  if (any(levels(reference) != levels(data))) {
+    warning(
+      "Levels are not in the same order for reference and data. Refactoring data to match."
+    )
     data <- as.character(data)
     data <- factor(data, levels = levels(reference))
   }
   classLevels <- levels(data)
   numLevels <- length(classLevels)
-  if(numLevels < 2)
+  if (numLevels < 2) {
     stop("there must be at least 2 factors levels in the data")
+  }
 
-  if(numLevels == 2 && is.null(positive))  positive <- levels(reference)[1]
+  if (numLevels == 2 && is.null(positive)) {
+    positive <- levels(reference)[1]
+  }
 
   classTable <- table(data, reference, dnn = dnn, ...)
 
-  getFromNamespace("confusionMatrix.table", "caret")(classTable, positive, prevalence = prevalence, mode = mode)
+  getFromNamespace("confusionMatrix.table", "caret")(
+    classTable,
+    positive,
+    prevalence = prevalence,
+    mode = mode
+  )
 }
 
 #' @rdname confusionMatrix
 #' @export
-confusionMatrix.matrix <- function(data,
-                                   positive = NULL,
-                                   prevalence = NULL,
-                                   mode = "sens_spec",
-                                   ...) {
+confusionMatrix.matrix <- function(
+  data,
+  positive = NULL,
+  prevalence = NULL,
+  mode = "sens_spec",
+  ...
+) {
   if (length(unique(dim(data))) != 1) {
     stop("matrix must have equal dimensions")
   }
@@ -199,116 +223,181 @@ confusionMatrix.matrix <- function(data,
 
 #' @rdname confusionMatrix
 #' @export
-confusionMatrix.table <- function(data, positive = NULL,
-                                  prevalence = NULL, mode = "sens_spec", ...){
-  if(!(mode %in% c("sens_spec", "prec_recall", "everything")))
+confusionMatrix.table <- function(
+  data,
+  positive = NULL,
+  prevalence = NULL,
+  mode = "sens_spec",
+  ...
+) {
+  if (!(mode %in% c("sens_spec", "prec_recall", "everything"))) {
     stop("`mode` should be either 'sens_spec', 'prec_recall', or 'everything'")
-  if(length(dim(data)) != 2) stop("the table must have two dimensions")
-  if(!all.equal(nrow(data), ncol(data))) stop("the table must nrow = ncol")
-  if(!isTRUE(all.equal(rownames(data), colnames(data)))) stop("the table must the same classes in the same order")
-  if(!is.character(positive) && !is.null(positive)) stop("positive argument must be character")
+  }
+  if (length(dim(data)) != 2) {
+    stop("the table must have two dimensions")
+  }
+  if (!all.equal(nrow(data), ncol(data))) {
+    stop("the table must nrow = ncol")
+  }
+  if (!isTRUE(all.equal(rownames(data), colnames(data)))) {
+    stop("the table must the same classes in the same order")
+  }
+  if (!is.character(positive) && !is.null(positive)) {
+    stop("positive argument must be character")
+  }
 
   classLevels <- rownames(data)
   numLevels <- length(classLevels)
-  if(numLevels < 2)
+  if (numLevels < 2) {
     stop("there must be at least 2 factors levels in the data")
+  }
 
-  if(numLevels == 2 && is.null(positive))  positive <- rownames(data)[1]
+  if (numLevels == 2 && is.null(positive)) {
+    positive <- rownames(data)[1]
+  }
 
-
-  if(numLevels == 2 & !is.null(prevalence) && length(prevalence) != 1)
+  if (numLevels == 2 & !is.null(prevalence) && length(prevalence) != 1) {
     stop("with two levels, one prevalence probability must be specified")
+  }
 
-  if(numLevels > 2 & !is.null(prevalence) && length(prevalence) != numLevels)
-    stop("the number of prevalence probability must be the same as the number of levels")
+  if (numLevels > 2 & !is.null(prevalence) && length(prevalence) != numLevels) {
+    stop(
+      "the number of prevalence probability must be the same as the number of levels"
+    )
+  }
 
-  if(numLevels > 2 & !is.null(prevalence) && is.null(names(prevalence)))
+  if (numLevels > 2 & !is.null(prevalence) && is.null(names(prevalence))) {
     stop("with >2 classes, the prevalence vector must have names")
+  }
 
   propCI <- function(x) {
     res <- try(binom.test(sum(diag(x)), sum(x))$conf.int, silent = TRUE)
-    if(inherits(res, "try-error"))
+    if (inherits(res, "try-error")) {
       res <- rep(NA, 2)
+    }
     res
   }
 
-  propTest <- function(x){
+  propTest <- function(x) {
     res <- try(
-      binom.test(sum(diag(x)),
-                 sum(x),
-                 p = max(apply(x, 2, sum)/sum(x)),
-                 alternative = "greater"),
-      silent = TRUE)
-    res <- if(inherits(res, "try-error"))
+      binom.test(
+        sum(diag(x)),
+        sum(x),
+        p = max(apply(x, 2, sum) / sum(x)),
+        alternative = "greater"
+      ),
+      silent = TRUE
+    )
+    res <- if (inherits(res, "try-error")) {
       c("null.value.probability of success" = NA, p.value = NA)
-    else
+    } else {
       res <- unlist(res[c("null.value", "p.value")])
+    }
     res
   }
 
-  overall <- c(unlist(e1071::classAgreement(data))[c("diag", "kappa")],
-               propCI(data),
-               propTest(data),
-               mcnemar.test(data)$p.value)
+  overall <- c(
+    unlist(e1071::classAgreement(data))[c("diag", "kappa")],
+    propCI(data),
+    propTest(data),
+    mcnemar.test(data)$p.value
+  )
 
-  names(overall) <- c("Accuracy", "Kappa", "AccuracyLower", "AccuracyUpper", "AccuracyNull", "AccuracyPValue", "McnemarPValue")
+  names(overall) <- c(
+    "Accuracy",
+    "Kappa",
+    "AccuracyLower",
+    "AccuracyUpper",
+    "AccuracyNull",
+    "AccuracyPValue",
+    "McnemarPValue"
+  )
 
-  if(numLevels == 2) {
-    if(is.null(prevalence)) prevalence <- sum(data[, positive])/sum(data)
+  if (numLevels == 2) {
+    if (is.null(prevalence)) {
+      prevalence <- sum(data[, positive]) / sum(data)
+    }
     negative <- classLevels[!(classLevels %in% positive)]
-    tableStats <- c(sensitivity.table(data, positive),
-                    specificity.table(data, negative),
-                    posPredValue.table(data, positive, prevalence = prevalence),
-                    negPredValue.table(data, negative, prevalence = prevalence),
-                    precision.table(data, relevant = positive),
-                    recall.table(data, relevant = positive),
-                    F_meas.table(data, relevant = positive),
-                    prevalence,
-                    sum(data[positive, positive])/sum(data),
-                    sum(data[positive, ])/sum(data))
-    names(tableStats) <- c("Sensitivity", "Specificity",
-                           "Pos Pred Value", "Neg Pred Value",
-                           "Precision", "Recall", "F1",
-                           "Prevalence", "Detection Rate",
-                           "Detection Prevalence")
-    tableStats["Balanced Accuracy"] <- (tableStats["Sensitivity"]+tableStats["Specificity"])/2
-
+    tableStats <- c(
+      sensitivity.table(data, positive),
+      specificity.table(data, negative),
+      posPredValue.table(data, positive, prevalence = prevalence),
+      negPredValue.table(data, negative, prevalence = prevalence),
+      precision.table(data, relevant = positive),
+      recall.table(data, relevant = positive),
+      F_meas.table(data, relevant = positive),
+      prevalence,
+      sum(data[positive, positive]) / sum(data),
+      sum(data[positive, ]) / sum(data)
+    )
+    names(tableStats) <- c(
+      "Sensitivity",
+      "Specificity",
+      "Pos Pred Value",
+      "Neg Pred Value",
+      "Precision",
+      "Recall",
+      "F1",
+      "Prevalence",
+      "Detection Rate",
+      "Detection Prevalence"
+    )
+    tableStats["Balanced Accuracy"] <- (tableStats["Sensitivity"] +
+      tableStats["Specificity"]) /
+      2
   } else {
-
     tableStats <- matrix(NA, nrow = length(classLevels), ncol = 11)
 
-    for(i in seq(along.with = classLevels)) {
+    for (i in seq(along.with = classLevels)) {
       pos <- classLevels[i]
       neg <- classLevels[!(classLevels %in% classLevels[i])]
-      prev <- if(is.null(prevalence)) sum(data[, pos])/sum(data) else prevalence[pos]
-      tableStats[i,] <- c(sensitivity.table(data, pos),
-                          specificity.table(data, neg),
-                          posPredValue.table(data, pos, prevalence = prev),
-                          negPredValue.table(data, neg, prevalence = prev),
-                          precision.table(data, relevant = pos),
-                          recall.table(data, relevant = pos),
-                          F_meas.table(data, relevant = pos),
-                          prev,
-                          sum(data[pos, pos])/sum(data),
-                          sum(data[pos, ])/sum(data), NA)
-      tableStats[i,11] <- (tableStats[i,1] + tableStats[i,2])/2
+      prev <- if (is.null(prevalence)) {
+        sum(data[, pos]) / sum(data)
+      } else {
+        prevalence[pos]
+      }
+      tableStats[i, ] <- c(
+        sensitivity.table(data, pos),
+        specificity.table(data, neg),
+        posPredValue.table(data, pos, prevalence = prev),
+        negPredValue.table(data, neg, prevalence = prev),
+        precision.table(data, relevant = pos),
+        recall.table(data, relevant = pos),
+        F_meas.table(data, relevant = pos),
+        prev,
+        sum(data[pos, pos]) / sum(data),
+        sum(data[pos, ]) / sum(data),
+        NA
+      )
+      tableStats[i, 11] <- (tableStats[i, 1] + tableStats[i, 2]) / 2
     }
     rownames(tableStats) <- paste("Class:", classLevels)
-    colnames(tableStats) <- c("Sensitivity", "Specificity",
-                              "Pos Pred Value", "Neg Pred Value",
-                              "Precision", "Recall", "F1",
-                              "Prevalence", "Detection Rate",
-                              "Detection Prevalence", "Balanced Accuracy")
+    colnames(tableStats) <- c(
+      "Sensitivity",
+      "Specificity",
+      "Pos Pred Value",
+      "Neg Pred Value",
+      "Precision",
+      "Recall",
+      "F1",
+      "Prevalence",
+      "Detection Rate",
+      "Detection Prevalence",
+      "Balanced Accuracy"
+    )
   }
 
   structure(
-    list(positive = positive,
-         table = data,
-         overall = overall,
-         byClass = tableStats,
-         mode = mode,
-         dots = list(...)),
-    class = "confusionMatrix")
+    list(
+      positive = positive,
+      table = data,
+      overall = overall,
+      byClass = tableStats,
+      mode = mode,
+      dots = list(...)
+    ),
+    class = "confusionMatrix"
+  )
 }
 
 #' Confusion matrix as a table
@@ -331,7 +420,7 @@ confusionMatrix.table <- function(data, positive = NULL,
 #' @examples
 #' ###################
 #' ## 2 class example
-#' 
+#'
 #' lvs <- c("normal", "abnormal")
 #' truth <- factor(rep(lvs, times = c(86, 258)), levels = rev(lvs))
 #' pred <- factor(
@@ -341,35 +430,40 @@ confusionMatrix.table <- function(data, positive = NULL,
 #'   ),
 #'   levels = rev(lvs)
 #' )
-#' 
+#'
 #' xtab <- table(pred, truth)
-#' 
+#'
 #' results <- confusionMatrix(xtab)
 #' as.table(results)
 #' as.matrix(results)
 #' as.matrix(results, what = "overall")
 #' as.matrix(results, what = "classes")
-#' 
+#'
 #' ###################
 #' ## 3 class example
-#' 
+#'
 #' xtab <- confusionMatrix(iris$Species, sample(iris$Species))
 #' as.matrix(xtab)
-#' 
+#'
 #' @keywords utilities
 #'
 #' @export
-as.matrix.confusionMatrix <- function(x, what = "xtabs", ...){
-  if(!(what %in% c("xtabs", "overall", "classes")))
+as.matrix.confusionMatrix <- function(x, what = "xtabs", ...) {
+  if (!(what %in% c("xtabs", "overall", "classes"))) {
     stop("what must be either xtabs, overall or classes")
-  out <- switch(what,
-                xtabs = matrix(as.vector(x$table),
-                               nrow = length(colnames(x$table)),
-                               dimnames = list(rownames(x$table), colnames(x$table))),
-                overall = as.matrix(x$overall),
-                classes = as.matrix(x$byClass))
-  if(what == "classes"){
-    if(length(colnames(x$table)) > 2){
+  }
+  out <- switch(
+    what,
+    xtabs = matrix(
+      as.vector(x$table),
+      nrow = length(colnames(x$table)),
+      dimnames = list(rownames(x$table), colnames(x$table))
+    ),
+    overall = as.matrix(x$overall),
+    classes = as.matrix(x$byClass)
+  )
+  if (what == "classes") {
+    if (length(colnames(x$table)) > 2) {
       out <- t(out)
       colnames(out) <- gsub("Class: ", "", colnames(out), fixed = TRUE)
     }
@@ -379,54 +473,74 @@ as.matrix.confusionMatrix <- function(x, what = "xtabs", ...){
 
 sbf_resampledCM <- function(x) {
   lev <- x$obsLevels
-  if("pred" %in% names(x) && !is.null(x$pred)) {
+  if ("pred" %in% names(x) && !is.null(x$pred)) {
     resampledCM <- do.call("rbind", x$pred[names(x$pred) == "predictions"])
-    resampledCM <- ddply(resampledCM, .(Resample), function(y) flatTable(pred  = y$pred, obs = y$obs))
-  } else stop(paste("When there are 50+ classes, the function does not automatically pre-compute the",
-                    "resampled confusion matrices. You can get them when the option",
-                    "`saveDetails = TRUE`."))
+    resampledCM <- ddply(resampledCM, .(Resample), function(y) {
+      flatTable(pred = y$pred, obs = y$obs)
+    })
+  } else {
+    stop(paste(
+      "When there are 50+ classes, the function does not automatically pre-compute the",
+      "resampled confusion matrices. You can get them when the option",
+      "`saveDetails = TRUE`."
+    ))
+  }
   resampledCM
 }
 rfe_resampledCM <- function(x) {
   lev <- x$obsLevels
-  if("resample" %in% names(x) &&
-     !is.null(x$resample) &&
-     sum(grepl("\\.cell[1-9]", names(x$resample))) > 3) {
+  if (
+    "resample" %in%
+      names(x) &&
+      !is.null(x$resample) &&
+      sum(grepl("\\.cell[1-9]", names(x$resample))) > 3
+  ) {
     resampledCM <- subset(x$resample, Variables == x$optsize)
-    resampledCM <- resampledCM[,grepl("\\.cell[1-9]", names(resampledCM))]
+    resampledCM <- resampledCM[, grepl("\\.cell[1-9]", names(resampledCM))]
   } else {
-    if(!is.null(x$pred)) {
-      resampledCM <- ddply(x$pred, .(Resample), function(y) flatTable(pred  = y$pred, obs = y$obs))
+    if (!is.null(x$pred)) {
+      resampledCM <- ddply(x$pred, .(Resample), function(y) {
+        flatTable(pred = y$pred, obs = y$obs)
+      })
     } else {
-      if(length(lev) > 50)
-        stop(paste("When there are 50+ classes, `the function does not automatically pre-compute the",
-                   "resampled confusion matrices. You can get them when the object",
-                   "has a `pred` element."))
+      if (length(lev) > 50) {
+        stop(paste(
+          "When there are 50+ classes, `the function does not automatically pre-compute the",
+          "resampled confusion matrices. You can get them when the object",
+          "has a `pred` element."
+        ))
+      }
     }
   }
   resampledCM
 }
 train_resampledCM <- function(x) {
-  if(x$modelType == "Regression")
+  if (x$modelType == "Regression") {
     stop("confusion matrices are only valid for classification models")
+  }
 
   lev <- levels(x)
 
   ## For problems with large numbers of classes, `train`, `rfe`, and `sbf` do not pre-compute the
   ## the resampled matrices. If the predictions have been saved, we can get them from there.
 
-  if("resampledCM" %in% names(x) && !is.null(x$resampledCM)) {
+  if ("resampledCM" %in% names(x) && !is.null(x$resampledCM)) {
     ## get only best tune
     names(x$bestTune) <- gsub("^\\.", "", names(x$bestTune))
     resampledCM <- merge(x$bestTune, x$resampledCM)
   } else {
-    if(!is.null(x$pred)) {
-      resampledCM <- ddply(merge(x$pred, x$bestTune), .(Resample), function(y) flatTable(pred  = y$pred, obs = y$obs))
+    if (!is.null(x$pred)) {
+      resampledCM <- ddply(merge(x$pred, x$bestTune), .(Resample), function(y) {
+        flatTable(pred = y$pred, obs = y$obs)
+      })
     } else {
-      if(length(lev) > 50)
-        stop(paste("When there are 50+ classes, `train` does not automatically pre-compute the",
-                   "resampled confusion matrices. You can get them from this function",
-                   "using a value of `savePredictions` other than FALSE."))
+      if (length(lev) > 50) {
+        stop(paste(
+          "When there are 50+ classes, `train` does not automatically pre-compute the",
+          "resampled confusion matrices. You can get them from this function",
+          "using a value of `savePredictions` other than FALSE."
+        ))
+      }
     }
   }
   resampledCM
@@ -434,8 +548,7 @@ train_resampledCM <- function(x) {
 
 
 #' @export
-as.table.confusionMatrix <- function(x, ...)  x$table
-
+as.table.confusionMatrix <- function(x, ...) x$table
 
 
 #' Estimate a Resampled Confusion Matrix
@@ -474,11 +587,11 @@ as.table.confusionMatrix <- function(x, ...)  x$table
 #' @keywords utilities
 #' @export
 #' @examples
-#' 
+#'
 #' data(iris)
 #' TrainData <- iris[, 1:4]
 #' TrainClasses <- iris[, 5]
-#' 
+#'
 #' knnFit <- train(
 #'   TrainData,
 #'   TrainClasses,
@@ -490,26 +603,37 @@ as.table.confusionMatrix <- function(x, ...)  x$table
 #' confusionMatrix(knnFit)
 #' confusionMatrix(knnFit, "average")
 #' confusionMatrix(knnFit, "none")
-#' 
+#'
 #' @export confusionMatrix.train
-confusionMatrix.train <- function(data, norm = "overall", dnn = c("Prediction", "Reference"), ...){
-  if(data$control$method %in% c("oob", "LOOCV", "none"))
-    stop("cannot compute confusion matrices for leave-one-out, out-of-bag resampling, or no resampling")
+confusionMatrix.train <- function(
+  data,
+  norm = "overall",
+  dnn = c("Prediction", "Reference"),
+  ...
+) {
+  if (data$control$method %in% c("oob", "LOOCV", "none")) {
+    stop(
+      "cannot compute confusion matrices for leave-one-out, out-of-bag resampling, or no resampling"
+    )
+  }
 
   if (inherits(data, "train")) {
-    if(data$modelType == "Regression")
+    if (data$modelType == "Regression") {
       stop("confusion matrices are only valid for classification models")
+    }
     lev <- levels(data)
     ## For problems with large numbers of classes, `train`, `rfe`, and `sbf` do not pre-compute the
     ## the resampled matrices. If the predictions have been saved, we can get them from there.
     resampledCM <- train_resampledCM(data)
   } else {
     lev <- data$obsLevels
-    if (inherits(data, "rfe")) resampledCM <- rfe_resampledCM(data)
+    if (inherits(data, "rfe")) {
+      resampledCM <- rfe_resampledCM(data)
+    }
     if (inherits(data, "sbf")) resampledCM <- sbf_resampledCM(data)
   }
 
-  if(!is.null(data$control$index)) {
+  if (!is.null(data$control$index)) {
     resampleN <- unlist(lapply(data$control$index, length))
     numResamp <- length(resampleN)
     resampText <- resampName(data)
@@ -518,25 +642,32 @@ confusionMatrix.train <- function(data, norm = "overall", dnn = c("Prediction", 
     numResamp <- 0
   }
 
-  counts <- as.matrix(resampledCM[ , grep("^\\.?cell", colnames(resampledCM))])
+  counts <- as.matrix(resampledCM[, grep("^\\.?cell", colnames(resampledCM))])
 
   ## normalize?
   norm <- match.arg(norm, c("none", "overall", "average"))
 
-  if(norm == "none") counts <- matrix(apply(counts, 2, sum), nrow = length(lev))
-  else counts <- matrix(apply(counts, 2, mean), nrow = length(lev))
+  if (norm == "none") {
+    counts <- matrix(apply(counts, 2, sum), nrow = length(lev))
+  } else {
+    counts <- matrix(apply(counts, 2, mean), nrow = length(lev))
+  }
 
-  if(norm == "overall") counts <- counts / sum(counts) * 100
+  if (norm == "overall") {
+    counts <- counts / sum(counts) * 100
+  }
 
   ## names
   rownames(counts) <- colnames(counts) <- lev
   names(dimnames(counts)) <- dnn
 
   ## out
-  out <- list(table = as.table(counts),
-              norm = norm,
-              B = length(data$control$index),
-              text = paste(resampText, "Confusion Matrix"))
+  out <- list(
+    table = as.table(counts),
+    norm = norm,
+    B = length(data$control$index),
+    text = paste(resampText, "Confusion Matrix")
+  )
   class(out) <- paste0("confusionMatrix.", class(data))
   out
 }
@@ -548,20 +679,26 @@ confusionMatrix.rfe <- confusionMatrix.train
 confusionMatrix.sbf <- confusionMatrix.train
 
 #' @export
-print.confusionMatrix.train <- function(x, digits = 1, ...){
+print.confusionMatrix.train <- function(x, digits = 1, ...) {
   cat(x$text, "\n")
-  normText <- switch(x$norm,
-                     none = "\n(entries are un-normalized aggregated counts)\n",
-                     average = "\n(entries are average cell counts across resamples)\n",
-                     overall = "\n(entries are percentual average cell counts across resamples)\n",
-                     "")
+  normText <- switch(
+    x$norm,
+    none = "\n(entries are un-normalized aggregated counts)\n",
+    average = "\n(entries are average cell counts across resamples)\n",
+    overall = "\n(entries are percentual average cell counts across resamples)\n",
+    ""
+  )
   cat(normText, "\n")
-  if(x$norm == "none" && x$B == 1) {
+  if (x$norm == "none" && x$B == 1) {
     print(getFromNamespace("confusionMatrix.table", "caret")(x$table))
   } else {
     print(round(x$table, digits))
 
-    out <- cbind("Accuracy (average)", ":", formatC(sum(diag(x$table) / sum(x$table))))
+    out <- cbind(
+      "Accuracy (average)",
+      ":",
+      formatC(sum(diag(x$table) / sum(x$table)))
+    )
 
     dimnames(out) <- list(rep("", nrow(out)), rep("", ncol(out)))
     print(out, quote = FALSE)
@@ -576,50 +713,89 @@ print.confusionMatrix.rfe <- print.confusionMatrix.train
 #' @export
 print.confusionMatrix.sbf <- print.confusionMatrix.train
 
-resampName <- function(x, numbers = TRUE){
-  if(!("control" %in% names(x))) return("")
-  if(numbers) {
+resampName <- function(x, numbers = TRUE) {
+  if (!("control" %in% names(x))) {
+    return("")
+  }
+  if (numbers) {
     resampleN <- unlist(lapply(x$control$index, length))
     numResamp <- length(resampleN)
-    out <- switch(tolower(x$control$method),
-                  none = "None",
-                  apparent = "Apparent",
-                  custom = paste("Custom Resampling (", numResamp, " reps)", sep = ""),
-                  timeslice = paste("Rolling Forecasting Origin Resampling (",
-                                    x$control$horizon, " held-out with",
-                                    ifelse(x$control$fixedWindow, " a ", " no "),
-                                    "fixed window)", sep = ""),
-                  oob = "Out of Bag Resampling",
-                  boot =, optimism_boot =, boot_all =,
-                  boot632 = paste("Bootstrapped (", numResamp, " reps)", sep = ""),
-                  cv = paste("Cross-Validated (", x$control$number, " fold)", sep = ""),
-                  repeatedcv = paste("Cross-Validated (", x$control$number, " fold, repeated ",
-                                     x$control$repeats, " times)", sep = ""),
-                  lgocv = paste("Repeated Train/Test Splits Estimated (", numResamp, " reps, ",
-                                round(x$control$p*100, 1), "%)", sep = ""),
-                  loocv = "Leave-One-Out Cross-Validation",
-                  adaptive_boot = paste("Adaptively Bootstrapped (", numResamp, " reps)", sep = ""),
-                  adaptive_cv = paste("Adaptively Cross-Validated (", x$control$number, " fold, repeated ",
-                                      x$control$repeats, " times)", sep = ""),
-                  adaptive_lgocv = paste("Adaptive Repeated Train/Test Splits Estimated (", numResamp, " reps, ",
-                                         round(x$control$p, 2), "%)", sep = "")
+    out <- switch(
+      tolower(x$control$method),
+      none = "None",
+      apparent = "Apparent",
+      custom = paste("Custom Resampling (", numResamp, " reps)", sep = ""),
+      timeslice = paste(
+        "Rolling Forecasting Origin Resampling (",
+        x$control$horizon,
+        " held-out with",
+        ifelse(x$control$fixedWindow, " a ", " no "),
+        "fixed window)",
+        sep = ""
+      ),
+      oob = "Out of Bag Resampling",
+      boot = ,
+      optimism_boot = ,
+      boot_all = ,
+      boot632 = paste("Bootstrapped (", numResamp, " reps)", sep = ""),
+      cv = paste("Cross-Validated (", x$control$number, " fold)", sep = ""),
+      repeatedcv = paste(
+        "Cross-Validated (",
+        x$control$number,
+        " fold, repeated ",
+        x$control$repeats,
+        " times)",
+        sep = ""
+      ),
+      lgocv = paste(
+        "Repeated Train/Test Splits Estimated (",
+        numResamp,
+        " reps, ",
+        round(x$control$p * 100, 1),
+        "%)",
+        sep = ""
+      ),
+      loocv = "Leave-One-Out Cross-Validation",
+      adaptive_boot = paste(
+        "Adaptively Bootstrapped (",
+        numResamp,
+        " reps)",
+        sep = ""
+      ),
+      adaptive_cv = paste(
+        "Adaptively Cross-Validated (",
+        x$control$number,
+        " fold, repeated ",
+        x$control$repeats,
+        " times)",
+        sep = ""
+      ),
+      adaptive_lgocv = paste(
+        "Adaptive Repeated Train/Test Splits Estimated (",
+        numResamp,
+        " reps, ",
+        round(x$control$p, 2),
+        "%)",
+        sep = ""
+      )
     )
   } else {
-    out <- switch(tolower(x$control$method),
-                  none = "None",
-                  apparent = "(Apparent)",
-                  custom = "Custom Resampling",
-                  timeslice = "Rolling Forecasting Origin Resampling",
-                  oob = "Out of Bag Resampling",
-                  boot = "(Bootstrap)",
-                  optimism_boot = "(Optimism Bootstrap)",
-                  boot_all = "(Bootstrap All)",
-                  boot632 = "(Bootstrap 632 Rule)",
-                  cv = "(Cross-Validation)",
-                  repeatedcv = "(Repeated Cross-Validation)",
-                  loocv = "Leave-One-Out Cross-Validation",
-                  lgocv = "(Repeated Train/Test Splits)")
-
+    out <- switch(
+      tolower(x$control$method),
+      none = "None",
+      apparent = "(Apparent)",
+      custom = "Custom Resampling",
+      timeslice = "Rolling Forecasting Origin Resampling",
+      oob = "Out of Bag Resampling",
+      boot = "(Bootstrap)",
+      optimism_boot = "(Optimism Bootstrap)",
+      boot_all = "(Bootstrap All)",
+      boot632 = "(Bootstrap 632 Rule)",
+      cv = "(Cross-Validation)",
+      repeatedcv = "(Repeated Cross-Validation)",
+      loocv = "Leave-One-Out Cross-Validation",
+      lgocv = "(Repeated Train/Test Splits)"
+    )
   }
   out
 }
@@ -642,47 +818,62 @@ resampName <- function(x, numbers = TRUE){
 #' @keywords utilities
 #' @export
 
-print.confusionMatrix <- function(x, mode = x$mode, digits = max(3, getOption("digits") - 3), printStats = TRUE, ...){
-  if(is.null(mode)) mode <- "sens_spec"
-  if(!(mode %in% c("sens_spec", "prec_recall", "everything")))
+print.confusionMatrix <- function(
+  x,
+  mode = x$mode,
+  digits = max(3, getOption("digits") - 3),
+  printStats = TRUE,
+  ...
+) {
+  if (is.null(mode)) {
+    mode <- "sens_spec"
+  }
+  if (!(mode %in% c("sens_spec", "prec_recall", "everything"))) {
     stop("`mode` should be either 'sens_spec', 'prec_recall', or 'everything'")
+  }
   cat("Confusion Matrix and Statistics\n\n")
   print(x$table, ...)
 
-  if(printStats) {
+  if (printStats) {
     tmp <- round(x$overall, digits = digits)
     pIndex <- grep("PValue", names(x$overall))
     tmp[pIndex] <- format.pval(x$overall[pIndex], digits = digits)
     overall <- tmp
 
-    accCI <- paste("(",
-                   paste(
-                     overall[ c("AccuracyLower", "AccuracyUpper")],
-                     collapse = ", "),
-                   ")",
-                   sep = "")
+    accCI <- paste(
+      "(",
+      paste(
+        overall[c("AccuracyLower", "AccuracyUpper")],
+        collapse = ", "
+      ),
+      ")",
+      sep = ""
+    )
 
-    overallText <- c(paste(overall["Accuracy"]),
-                     accCI,
-                     paste(overall[c("AccuracyNull", "AccuracyPValue")]),
-                     "",
-                     paste(overall["Kappa"]),
-                     "",
-                     paste(overall["McnemarPValue"]))
+    overallText <- c(
+      paste(overall["Accuracy"]),
+      accCI,
+      paste(overall[c("AccuracyNull", "AccuracyPValue")]),
+      "",
+      paste(overall["Kappa"]),
+      "",
+      paste(overall["McnemarPValue"])
+    )
 
-    overallNames <- c("Accuracy", "95% CI",
-                      "No Information Rate",
-                      "P-Value [Acc > NIR]",
-                      "",
-                      "Kappa",
-                      "",
-                      "Mcnemar's Test P-Value")
+    overallNames <- c(
+      "Accuracy",
+      "95% CI",
+      "No Information Rate",
+      "P-Value [Acc > NIR]",
+      "",
+      "Kappa",
+      "",
+      "Mcnemar's Test P-Value"
+    )
 
-    if(dim(x$table)[1] > 2){
+    if (dim(x$table)[1] > 2) {
       cat("\nOverall Statistics\n")
-      overallNames <- ifelse(overallNames == "",
-                             "",
-                             paste(overallNames, ":"))
+      overallNames <- ifelse(overallNames == "", "", paste(overallNames, ":"))
       out <- cbind(format(overallNames, justify = "right"), overallText)
       colnames(out) <- rep("", ncol(out))
       rownames(out) <- rep("", nrow(out))
@@ -690,23 +881,36 @@ print.confusionMatrix <- function(x, mode = x$mode, digits = max(3, getOption("d
       print(out, quote = FALSE)
 
       cat("\nStatistics by Class:\n\n")
-      if(mode == "prec_recall")
-        x$byClass <- x$byClass[,!grepl("(Sensitivity)|(Specificity)|(Pos Pred Value)|(Neg Pred Value)",
-                                     colnames(x$byClass))]
-      if(mode == "sens_spec")
-        x$byClass <- x$byClass[,!grepl("(Precision)|(Recall)|(F1)", colnames(x$byClass))]
+      if (mode == "prec_recall") {
+        x$byClass <- x$byClass[,
+          !grepl(
+            "(Sensitivity)|(Specificity)|(Pos Pred Value)|(Neg Pred Value)",
+            colnames(x$byClass)
+          )
+        ]
+      }
+      if (mode == "sens_spec") {
+        x$byClass <- x$byClass[,
+          !grepl("(Precision)|(Recall)|(F1)", colnames(x$byClass))
+        ]
+      }
       print(t(x$byClass), digits = digits)
-
     } else {
-      if(mode == "prec_recall")
-        x$byClass <- x$byClass[!grepl("(Sensitivity)|(Specificity)|(Pos Pred Value)|(Neg Pred Value)",
-                                       names(x$byClass))]
-      if(mode == "sens_spec")
-        x$byClass <- x$byClass[!grepl("(Precision)|(Recall)|(F1)", names(x$byClass))]
+      if (mode == "prec_recall") {
+        x$byClass <- x$byClass[
+          !grepl(
+            "(Sensitivity)|(Specificity)|(Pos Pred Value)|(Neg Pred Value)",
+            names(x$byClass)
+          )
+        ]
+      }
+      if (mode == "sens_spec") {
+        x$byClass <- x$byClass[
+          !grepl("(Precision)|(Recall)|(F1)", names(x$byClass))
+        ]
+      }
 
-      overallText <- c(overallText,
-                       "",
-                       format(x$byClass, digits = digits))
+      overallText <- c(overallText, "", format(x$byClass, digits = digits))
       overallNames <- c(overallNames, "", names(x$byClass))
       overallNames <- ifelse(overallNames == "", "", paste(overallNames, ":"))
 

--- a/R/confusionMatrix.R
+++ b/R/confusionMatrix.R
@@ -288,8 +288,8 @@ confusionMatrix.table <- function(
       ),
       silent = TRUE
     )
-    res <- if (inherits(res, "try-error")) {
-      c("null.value.probability of success" = NA, p.value = NA)
+    if (inherits(res, "try-error")) {
+      res <- c("null.value.probability of success" = NA, p.value = NA)
     } else {
       res <- unlist(res[c("null.value", "p.value")])
     }
@@ -351,10 +351,10 @@ confusionMatrix.table <- function(
     for (i in seq(along.with = classLevels)) {
       pos <- classLevels[i]
       neg <- classLevels[!(classLevels %in% classLevels[i])]
-      prev <- if (is.null(prevalence)) {
-        sum(data[, pos]) / sum(data)
+      if (is.null(prevalence)) {
+        prev <- sum(data[, pos]) / sum(data)
       } else {
-        prevalence[pos]
+        prev <- prevalence[pos]
       }
       tableStats[i, ] <- c(
         sensitivity.table(data, pos),
@@ -630,7 +630,9 @@ confusionMatrix.train <- function(
     if (inherits(data, "rfe")) {
       resampledCM <- rfe_resampledCM(data)
     }
-    if (inherits(data, "sbf")) resampledCM <- sbf_resampledCM(data)
+    if (inherits(data, "sbf")) {
+      resampledCM <- sbf_resampledCM(data)
+    }
   }
 
   if (!is.null(data$control$index)) {

--- a/R/createDataPartition.R
+++ b/R/createDataPartition.R
@@ -279,7 +279,11 @@ createMultiFolds <- function(y, k = 10, times = 5) {
       prettyNums[i],
       sep = ""
     )
-    out <- if (i == 1) tmp else c(out, tmp)
+    if (i == 1) {
+      out <- tmp
+    } else {
+      out <- c(out, tmp)
+    }
   }
   out
 }
@@ -395,12 +399,11 @@ make_resamples <- function(ctrl_obj, outcome) {
   ## Create holdout indices
   if (is.null(ctrl_obj$indexOut) && ctrl_obj$method != "oob") {
     if (tolower(ctrl_obj$method) != "timeslice") {
-      y_index <-
-        if (inherits(outcome, "Surv")) {
-          seq_len(nrow(outcome))
-        } else {
-          seq(along.with = outcome)
-        }
+      if (inherits(outcome, "Surv")) {
+        y_index <- seq_len(nrow(outcome))
+      } else {
+        y_index <- seq(along.with = outcome)
+      }
       ctrl_obj$indexOut <-
         lapply(ctrl_obj$index, function(training) {
           setdiff(y_index, training)

--- a/R/createDataPartition.R
+++ b/R/createDataPartition.R
@@ -70,70 +70,88 @@
 #' @family resampling
 #' @keywords utilities
 #' @examples
-#' 
+#'
 #' data(oil)
 #' createDataPartition(oilType, 2)
-#' 
+#'
 #' x <- rgamma(50, 3, .5)
 #' inA <- createDataPartition(x, list = FALSE)
-#' 
+#'
 #' plot(density(x[inA]))
 #' rug(x[inA])
-#' 
+#'
 #' points(density(x[-inA]), type = "l", col = 4)
 #' rug(x[-inA], col = 4)
-#' 
+#'
 #' createResample(oilType, 2)
-#' 
+#'
 #' createFolds(oilType, 10)
 #' createFolds(oilType, 5, FALSE)
-#' 
+#'
 #' createFolds(rnorm(21))
-#' 
+#'
 #' createTimeSlices(1:9, 5, 1, fixedWindow = FALSE)
 #' createTimeSlices(1:9, 5, 1, fixedWindow = TRUE)
 #' createTimeSlices(1:9, 5, 3, fixedWindow = TRUE)
 #' createTimeSlices(1:9, 5, 3, fixedWindow = FALSE)
-#' 
+#'
 #' createTimeSlices(1:15, 5, 3)
 #' createTimeSlices(1:15, 5, 3, skip = 2)
 #' createTimeSlices(1:15, 5, 3, skip = 3)
-#' 
+#'
 #' set.seed(131)
 #' groups <- sort(sample(letters[1:4], size = 20, replace = TRUE))
 #' table(groups)
 #' folds <- groupKFold(groups)
 #' lapply(folds, function(x, y) table(y[x]), y = groups)
 #' @export createDataPartition
-createDataPartition <- function (y, times = 1, p = 0.5, list = TRUE, groups = min(5, length(y))){
-  if(inherits(y, "Surv")) y <- y[,"time"]
+createDataPartition <- function(
+  y,
+  times = 1,
+  p = 0.5,
+  list = TRUE,
+  groups = min(5, length(y))
+) {
+  if (inherits(y, "Surv")) {
+    y <- y[, "time"]
+  }
   out <- vector(mode = "list", times)
 
-  if(length(y) < 2) stop("y must have at least 2 data points")
+  if (length(y) < 2) {
+    stop("y must have at least 2 data points")
+  }
 
-  if(groups < 2) groups <- 2
+  if (groups < 2) {
+    groups <- 2
+  }
 
-  if(is.numeric(y)) {
-    y <- cut(y,
-             unique(quantile(y, probs = seq(0, 1, length.out = groups))),
-             include.lowest = TRUE)
+  if (is.numeric(y)) {
+    y <- cut(
+      y,
+      unique(quantile(y, probs = seq(0, 1, length.out = groups))),
+      include.lowest = TRUE
+    )
   } else {
     xtab <- table(y)
-    if(any(xtab == 0)) {
-      warning(paste("Some classes have no records (",
-                    paste(names(xtab)[xtab  == 0], sep = "", collapse = ", "),
-                    ") and these will be ignored"))
+    if (any(xtab == 0)) {
+      warning(paste(
+        "Some classes have no records (",
+        paste(names(xtab)[xtab == 0], sep = "", collapse = ", "),
+        ") and these will be ignored"
+      ))
       y <- factor(as.character(y))
     }
-    if(any(xtab == 1)) {
-      warning(paste("Some classes have a single record (",
-                    paste(names(xtab)[xtab  == 1], sep = "", collapse = ", "),
-                    ") and these will be selected for the sample"))
+    if (any(xtab == 1)) {
+      warning(paste(
+        "Some classes have a single record (",
+        paste(names(xtab)[xtab == 1], sep = "", collapse = ", "),
+        ") and these will be selected for the sample"
+      ))
     }
   }
 
   subsample <- function(dat, p) {
-    if(nrow(dat) == 1) {
+    if (nrow(dat) == 1) {
       out <- dat$index
     } else {
       num <- ceiling(nrow(dat) * p)
@@ -143,8 +161,12 @@ createDataPartition <- function (y, times = 1, p = 0.5, list = TRUE, groups = mi
   }
 
   for (j in 1:times) {
-    tmp <- dlply(data.frame(y = y, index = seq(along.with = y)),
-                 .(y), subsample, p = p)
+    tmp <- dlply(
+      data.frame(y = y, index = seq(along.with = y)),
+      .(y),
+      subsample,
+      p = p
+    )
     tmp <- sort(as.vector(unlist(tmp)))
     out[[j]] <- tmp
   }
@@ -163,8 +185,10 @@ createDataPartition <- function (y, times = 1, p = 0.5, list = TRUE, groups = mi
 #' @export
 "createFolds" <-
   function(y, k = 10, list = TRUE, returnTrain = FALSE) {
-    if(inherits(y, "Surv")) y <- y[,"time"]
-    if(is.numeric(y)) {
+    if (inherits(y, "Surv")) {
+      y <- y[, "time"]
+    }
+    if (is.numeric(y)) {
       ## Group the numeric data based on their magnitudes
       ## and sample within those groups.
 
@@ -175,14 +199,18 @@ createDataPartition <- function (y, times = 1, p = 0.5, list = TRUE, groups = mi
       ## At most, we will use quantiles. If the sample
       ## is too small, we just do regular unstratified
       ## CV
-      cuts <- floor(length(y)/k)
-      if(cuts < 2) cuts <- 2
-      if(cuts > 5) cuts <- 5
+      cuts <- floor(length(y) / k)
+      if (cuts < 2) {
+        cuts <- 2
+      }
+      if (cuts > 5) {
+        cuts <- 5
+      }
       breaks <- unique(quantile(y, probs = seq(0, 1, length.out = cuts)))
       y <- cut(y, breaks, include.lowest = TRUE)
     }
 
-    if(k < length(y)) {
+    if (k < length(y)) {
       ## reset levels so that the possible levels and
       ## the levels in the vector are the same
       y <- factor(as.character(y))
@@ -192,48 +220,66 @@ createDataPartition <- function (y, times = 1, p = 0.5, list = TRUE, groups = mi
       ## For each class, balance the fold allocation as far
       ## as possible, then resample the remainder.
       ## The final assignment of folds is also randomized.
-      for(i in seq_along(numInClass)) {
+      for (i in seq_along(numInClass)) {
         ## create a vector of integers from 1:k as many times as possible without
         ## going over the number of samples in the class. Note that if the number
         ## of samples in a class is less than k, nothing is produced here.
         min_reps <- numInClass[i] %/% k
-        if(min_reps > 0) {
+        if (min_reps > 0) {
           spares <- numInClass[i] %% k
           seqVector <- rep(1:k, min_reps)
           ## add enough random integers to get  length(seqVector) == numInClass[i]
-          if(spares > 0) seqVector <- c(seqVector, sample(1:k, spares))
+          if (spares > 0) {
+            seqVector <- c(seqVector, sample(1:k, spares))
+          }
           ## shuffle the integers for fold assignment and assign to this classes's data
           foldVector[which(y == names(numInClass)[i])] <- sample(seqVector)
         } else {
           ## Here there are less records in the class than unique folds so
           ## randomly sprinkle them into folds.
-          foldVector[which(y == names(numInClass)[i])] <- sample(1:k, size = numInClass[i])
+          foldVector[which(y == names(numInClass)[i])] <- sample(
+            1:k,
+            size = numInClass[i]
+          )
         }
       }
-    } else foldVector <- seq(along.with = y)
+    } else {
+      foldVector <- seq(along.with = y)
+    }
 
-    if(list) {
+    if (list) {
       out <- split(seq(along.with = y), foldVector)
-      names(out) <- paste("Fold", gsub(" ", "0", format(seq(along.with = out))), sep = "")
-      if(returnTrain) out <- lapply(out, function(data, y) y[-data], y = seq(along.with = y))
-    } else out <- foldVector
+      names(out) <- paste(
+        "Fold",
+        gsub(" ", "0", format(seq(along.with = out))),
+        sep = ""
+      )
+      if (returnTrain) {
+        out <- lapply(out, function(data, y) y[-data], y = seq(along.with = y))
+      }
+    } else {
+      out <- foldVector
+    }
     out
   }
 
 #' @rdname createDataPartition
 #' @export
 createMultiFolds <- function(y, k = 10, times = 5) {
-  if(inherits(y, "Surv")) y <- y[,"time"]
+  if (inherits(y, "Surv")) {
+    y <- y[, "time"]
+  }
   prettyNums <- paste("Rep", gsub(" ", "0", format(1:times)), sep = "")
-  for(i in 1:times) {
+  for (i in 1:times) {
     tmp <- createFolds(y, k = k, list = TRUE, returnTrain = TRUE)
-    names(tmp) <- paste("Fold",
-                        gsub(" ", "0", format(seq(along.with = tmp))),
-                        ".",
-                        prettyNums[i],
-                        sep = "")
-    out <- if(i == 1) tmp else c(out, tmp)
-
+    names(tmp) <- paste(
+      "Fold",
+      gsub(" ", "0", format(seq(along.with = tmp))),
+      ".",
+      prettyNums[i],
+      sep = ""
+    )
+    out <- if (i == 1) tmp else c(out, tmp)
   }
   out
 }
@@ -241,7 +287,13 @@ createMultiFolds <- function(y, k = 10, times = 5) {
 ## From Tony Cooper <tonyc@iconz.co.nz> on 1/9/13
 #' @rdname createDataPartition
 #' @export
-createTimeSlices <- function(y, initialWindow, horizon = 1, fixedWindow = TRUE, skip = 0) {
+createTimeSlices <- function(
+  y,
+  initialWindow,
+  horizon = 1,
+  fixedWindow = TRUE,
+  skip = 0
+) {
   ## initialwindow = initial number of consecutive values in each training set sample
   ## horizon = number of consecutive values in test set sample
   ## fixedwindow = FALSE if we use the maximum possible length for the training set
@@ -256,7 +308,7 @@ createTimeSlices <- function(y, initialWindow, horizon = 1, fixedWindow = TRUE, 
   }
 
   train <- mapply(seq, starts, stops, SIMPLIFY = FALSE)
-  test <- mapply(seq, stops+1, stops+horizon, SIMPLIFY = FALSE)
+  test <- mapply(seq, stops + 1, stops + horizon, SIMPLIFY = FALSE)
   nums <- gsub(" ", "0", format(stops))
   names(train) <- paste("Training", nums, sep = "")
   names(test) <- paste("Testing", nums, sep = "")
@@ -284,53 +336,76 @@ groupKFold <- function(group, k = length(unique(group))) {
 
 make_resamples <- function(ctrl_obj, outcome) {
   n <- length(outcome)
-  if(is.null(ctrl_obj$index)) {
-    if(ctrl_obj$method == "custom")
-      stop("'custom' resampling is appropriate when the `trControl` argument `index` is used", call. = FALSE)
+  if (is.null(ctrl_obj$index)) {
+    if (ctrl_obj$method == "custom") {
+      stop(
+        "'custom' resampling is appropriate when the `trControl` argument `index` is used",
+        call. = FALSE
+      )
+    }
     ctrl_obj$index <-
-      switch(tolower(ctrl_obj$method),
-             oob = NULL,
-             none = list(seq(along.with = outcome)),
-             apparent = list(all = seq(along.with = outcome)),
-             alt_cv =, cv = createFolds(outcome, ctrl_obj$number, returnTrain = TRUE),
-             repeatedcv =, adaptive_cv = createMultiFolds(outcome, ctrl_obj$number, ctrl_obj$repeats),
-             loocv = createFolds(outcome, n, returnTrain = TRUE),
-             boot =, boot632 =, optimism_boot =, boot_all =,
-             adaptive_boot = createResample(outcome, ctrl_obj$number),
-             test = createDataPartition(outcome, 1, ctrl_obj$p),
-             adaptive_lgocv =, lgocv = createDataPartition(outcome, ctrl_obj$number, ctrl_obj$p),
-             timeslice = createTimeSlices(seq(along.with = outcome),
-                                          initialWindow = ctrl_obj$initialWindow,
-                                          horizon = ctrl_obj$horizon,
-                                          fixedWindow = ctrl_obj$fixedWindow,
-                                          skip = ctrl_obj$skip)$train,
-             stop("Not a recognized resampling method.", call. = FALSE))
+      switch(
+        tolower(ctrl_obj$method),
+        oob = NULL,
+        none = list(seq(along.with = outcome)),
+        apparent = list(all = seq(along.with = outcome)),
+        alt_cv = ,
+        cv = createFolds(outcome, ctrl_obj$number, returnTrain = TRUE),
+        repeatedcv = ,
+        adaptive_cv = createMultiFolds(
+          outcome,
+          ctrl_obj$number,
+          ctrl_obj$repeats
+        ),
+        loocv = createFolds(outcome, n, returnTrain = TRUE),
+        boot = ,
+        boot632 = ,
+        optimism_boot = ,
+        boot_all = ,
+        adaptive_boot = createResample(outcome, ctrl_obj$number),
+        test = createDataPartition(outcome, 1, ctrl_obj$p),
+        adaptive_lgocv = ,
+        lgocv = createDataPartition(outcome, ctrl_obj$number, ctrl_obj$p),
+        timeslice = createTimeSlices(
+          seq(along.with = outcome),
+          initialWindow = ctrl_obj$initialWindow,
+          horizon = ctrl_obj$horizon,
+          fixedWindow = ctrl_obj$fixedWindow,
+          skip = ctrl_obj$skip
+        )$train,
+        stop("Not a recognized resampling method.", call. = FALSE)
+      )
   } else {
     index_types <- unlist(lapply(ctrl_obj$index, is.integer))
-    if(!isTRUE(all(index_types)))
+    if (!isTRUE(all(index_types))) {
       stop("`index` should be lists of integers.", call. = FALSE)
-    if(!is.null(ctrl_obj$indexOut)) {
+    }
+    if (!is.null(ctrl_obj$indexOut)) {
       index_types <- unlist(lapply(ctrl_obj$indexOut, is.integer))
-      if(!isTRUE(all(index_types)))
+      if (!isTRUE(all(index_types))) {
         stop("`indexOut` should be lists of integers.", call. = FALSE)
+      }
     }
   }
 
-  if(ctrl_obj$method == "apparent")
+  if (ctrl_obj$method == "apparent") {
     ctrl_obj$indexOut <- list(all = seq(along.with = outcome))
+  }
 
   ## Create holdout indices
-  if(is.null(ctrl_obj$indexOut) && ctrl_obj$method != "oob"){
-    if(tolower(ctrl_obj$method) != "timeslice") {
+  if (is.null(ctrl_obj$indexOut) && ctrl_obj$method != "oob") {
+    if (tolower(ctrl_obj$method) != "timeslice") {
       y_index <-
-        if (inherits(outcome, "Surv"))
+        if (inherits(outcome, "Surv")) {
           seq_len(nrow(outcome))
-      else
-        seq(along.with = outcome)
+        } else {
+          seq(along.with = outcome)
+        }
       ctrl_obj$indexOut <-
-        lapply(ctrl_obj$index, function(training)
-          setdiff(y_index, training))
-      if(ctrl_obj$method %in% c("optimism_boot", "boot_all")) {
+        lapply(ctrl_obj$index, function(training) {
+          setdiff(y_index, training)
+        })
+      if (ctrl_obj$method %in% c("optimism_boot", "boot_all")) {
         ctrl_obj$indexExtra <- lapply(ctrl_obj$index, function(training) {
           list(origIndex = y_index, bootIndex = training)
         })
@@ -338,22 +413,24 @@ make_resamples <- function(ctrl_obj, outcome) {
       names(ctrl_obj$indexOut) <- prettySeq(ctrl_obj$indexOut)
     } else {
       ctrl_obj$indexOut <-
-        createTimeSlices(seq(along.with = outcome),
-                         initialWindow = ctrl_obj$initialWindow,
-                         horizon = ctrl_obj$horizon,
-                         fixedWindow = ctrl_obj$fixedWindow,
-                         skip = ctrl_obj$skip)$test
+        createTimeSlices(
+          seq(along.with = outcome),
+          initialWindow = ctrl_obj$initialWindow,
+          horizon = ctrl_obj$horizon,
+          fixedWindow = ctrl_obj$fixedWindow,
+          skip = ctrl_obj$skip
+        )$test
     }
   }
 
-  if(ctrl_obj$method != "oob" && is.null(ctrl_obj$index))
+  if (ctrl_obj$method != "oob" && is.null(ctrl_obj$index)) {
     names(ctrl_obj$index) <- prettySeq(ctrl_obj$index)
-  if(ctrl_obj$method != "oob" && is.null(names(ctrl_obj$index)))
-    names(ctrl_obj$index)    <- prettySeq(ctrl_obj$index)
-  if(ctrl_obj$method != "oob" && is.null(names(ctrl_obj$indexOut)))
+  }
+  if (ctrl_obj$method != "oob" && is.null(names(ctrl_obj$index))) {
+    names(ctrl_obj$index) <- prettySeq(ctrl_obj$index)
+  }
+  if (ctrl_obj$method != "oob" && is.null(names(ctrl_obj$indexOut))) {
     names(ctrl_obj$indexOut) <- prettySeq(ctrl_obj$indexOut)
+  }
   ctrl_obj
 }
-
-
-

--- a/R/createModel.R
+++ b/R/createModel.R
@@ -82,7 +82,11 @@
         ))
   ) {
     modelFit$xNames <- colnames(x)
-    modelFit$problemType <- if (is.factor(y)) "Classification" else "Regression"
+    if (is.factor(y)) {
+      modelFit$problemType <- "Classification"
+    } else {
+      modelFit$problemType <- "Regression"
+    }
     modelFit$tuneValue <- tuneValue
     modelFit$obsLevels <- obsLevels
     modelFit$param <- list(...)

--- a/R/createModel.R
+++ b/R/createModel.R
@@ -9,23 +9,37 @@
 #'
 #' @export
 #' @keywords internal
-"createModel" <-function(x, y, wts, method, tuneValue, obsLevels, pp = NULL, last = FALSE, sampling = NULL, classProbs, ...) {
-
+"createModel" <- function(
+  x,
+  y,
+  wts,
+  method,
+  tuneValue,
+  obsLevels,
+  pp = NULL,
+  last = FALSE,
+  sampling = NULL,
+  classProbs,
+  ...
+) {
   ## To get of warnings "some row.names duplicated: " when resampling with replacement
-  if(is.data.frame(x) || is.matrix(x)) 
+  if (is.data.frame(x) || is.matrix(x)) {
     rownames(x) <- make.names(rownames(x), unique = TRUE)
+  }
 
-  if(!is.null(sampling) && sampling$first) {
+  if (!is.null(sampling) && sampling$first) {
     tmp <- sampling$func(x, y)
     x <- tmp$x
     y <- tmp$y
     rm(tmp)
   }
 
-  if(!is.null(pp$options)) {
+  if (!is.null(pp$options)) {
     pp$method <- pp$options
     pp$options <- NULL
-    if("ica" %in% pp$method) pp$n.comp <- pp$ICAcomp
+    if ("ica" %in% pp$method) {
+      pp$n.comp <- pp$ICAcomp
+    }
     pp$ICAcomp <- NULL
     pp$x <- x
     pp$outcome <- y
@@ -33,28 +47,42 @@
     ppObj$call <- "scrubed"
     x <- predict(ppObj, x)
     rm(pp)
-  } else ppObj <- NULL
+  } else {
+    ppObj <- NULL
+  }
 
-  if(!is.null(sampling) && !sampling$first) {
+  if (!is.null(sampling) && !sampling$first) {
     tmp <- sampling$func(x, y)
     x <- tmp$x
     y <- tmp$y
     rm(tmp)
   }
 
-  modelFit <- method$fit(x = x,
-                         y = y, wts = wts,
-                         param  = tuneValue, lev = obsLevels,
-                         last = last,
-                         classProbs = classProbs, ...)
+  modelFit <- method$fit(
+    x = x,
+    y = y,
+    wts = wts,
+    param = tuneValue,
+    lev = obsLevels,
+    last = last,
+    classProbs = classProbs,
+    ...
+  )
   ## for models using S4 classes, you can't easily append data, so
   ## exclude these and we'll use other methods to get this information
-  if(is.null(method$label)) method$label <- ""
-  if(!isS4(modelFit) &&
-       !(method$label %in% c("Ensemble Partial Least Squares Regression",
-                             "Ensemble Partial Least Squares Regression with Feature Selection"))) {
+  if (is.null(method$label)) {
+    method$label <- ""
+  }
+  if (
+    !isS4(modelFit) &&
+      !(method$label %in%
+        c(
+          "Ensemble Partial Least Squares Regression",
+          "Ensemble Partial Least Squares Regression with Feature Selection"
+        ))
+  ) {
     modelFit$xNames <- colnames(x)
-    modelFit$problemType <- if(is.factor(y)) "Classification" else "Regression"
+    modelFit$problemType <- if (is.factor(y)) "Classification" else "Regression"
     modelFit$tuneValue <- tuneValue
     modelFit$obsLevels <- obsLevels
     modelFit$param <- list(...)

--- a/R/createResample.R
+++ b/R/createResample.R
@@ -1,12 +1,13 @@
-
 #' @rdname createDataPartition
 #' @export
 createResample <- function(y, times = 10, list = TRUE) {
-  if (inherits(y, "Surv"))
+  if (inherits(y, "Surv")) {
     y <- y[, "time"]
+  }
   trainIndex <- matrix(0, ncol = times, nrow = length(y))
   out <- apply(
-    trainIndex, 2,
+    trainIndex,
+    2,
     function(data) {
       index <- seq(along.with = data)
       out <-
@@ -15,7 +16,7 @@ createResample <- function(y, times = 10, list = TRUE) {
     }
   )
 
-  if (list)  {
+  if (list) {
     out <- as.data.frame(out, stringsAsFactors = TRUE)
     attributes(out) <- NULL
     names(out) <- prettySeq(out)

--- a/R/diag.R
+++ b/R/diag.R
@@ -19,7 +19,7 @@
 ## a fast version of diag(n, .) / sparse-Diagonal() + dimnames
 ## Originally .Diag in stats:contrast.R
 
-.RDiag <- function (nms, sparse) {
+.RDiag <- function(nms, sparse) {
   n <- as.integer(length(nms))
   d <- c(n, n)
   dn <- list(nms, nms)

--- a/R/dotplot.varImp.train.R
+++ b/R/dotplot.varImp.train.R
@@ -11,51 +11,53 @@
 #' @seealso [varImp()], [lattice::dotplot()]
 #' @keywords hplot
 #' @examples
-#' 
+#'
 #' data(iris)
 #' TrainData <- iris[, 1:4]
 #' TrainClasses <- iris[, 5]
-#' 
+#'
 #' knnFit <- train(TrainData, TrainClasses, "knn")
-#' 
+#'
 #' knnImp <- varImp(knnFit)
-#' 
+#'
 #' dotPlot(knnImp)
-#' 
+#'
 #' @export dotPlot
-dotPlot <- function (x, top = min(20, dim(x$importance)[1]), ...) 
-{
-   varSubset <- sortImp(x, top)
-   plotObj <- stack(varSubset)
+dotPlot <- function(x, top = min(20, dim(x$importance)[1]), ...) {
+  varSubset <- sortImp(x, top)
+  plotObj <- stack(varSubset)
 
-   if(dim(varSubset)[2] == 1)
-   {
-      plotObj <- varSubset
-      names(plotObj) <- "values"
-      plotObj$ind <- "Overall"
-   } else plotObj <- stack(varSubset)
-   
-   plotObj$Var <- rep(rownames(varSubset), dim(varSubset)[2])
-   plotObj$Var <- factor(plotObj$Var, levels = rev(rownames(varSubset)))
-   if(dim(varSubset)[2] < 3)
-   {
-      if(dim(varSubset)[2] > 1) plotObj <- plotObj[plotObj$ind == levels(plotObj$ind)[1],]
-      out <- dotplot(
-         Var ~ values, 
-         data = plotObj, 
-         as.table = TRUE, 
-         xlab = "Importance",
-         ...)   
-   
-   } else {
-      out <- dotplot(
-         Var ~ values, 
-         data = plotObj, 
-         groups = plotObj$ind, 
-         auto.key = list(columns = min(3, length(levels(plotObj$ind)))), 
-         as.table = TRUE, 
-         xlab = "Importance",
-         ...)   
-   }
-   out
+  if (dim(varSubset)[2] == 1) {
+    plotObj <- varSubset
+    names(plotObj) <- "values"
+    plotObj$ind <- "Overall"
+  } else {
+    plotObj <- stack(varSubset)
+  }
+
+  plotObj$Var <- rep(rownames(varSubset), dim(varSubset)[2])
+  plotObj$Var <- factor(plotObj$Var, levels = rev(rownames(varSubset)))
+  if (dim(varSubset)[2] < 3) {
+    if (dim(varSubset)[2] > 1) {
+      plotObj <- plotObj[plotObj$ind == levels(plotObj$ind)[1], ]
+    }
+    out <- dotplot(
+      Var ~ values,
+      data = plotObj,
+      as.table = TRUE,
+      xlab = "Importance",
+      ...
+    )
+  } else {
+    out <- dotplot(
+      Var ~ values,
+      data = plotObj,
+      groups = plotObj$ind,
+      auto.key = list(columns = min(3, length(levels(plotObj$ind)))),
+      as.table = TRUE,
+      xlab = "Importance",
+      ...
+    )
+  }
+  out
 }

--- a/R/dummyVar.R
+++ b/R/dummyVar.R
@@ -99,7 +99,7 @@
 #'   day = c("Mon", "Mon", "Mon", "Wed", "Wed", "Fri", "Sat", "Sat", "Fri"),
 #'   stringsAsFactors = TRUE
 #' )
-#' 
+#'
 #' levels(when$time) <- list(
 #'   morning = "morning",
 #'   afternoon = "afternoon",
@@ -114,27 +114,27 @@
 #'   Sat = "Sat",
 #'   Sun = "Sun"
 #' )
-#' 
+#'
 #' ## Default behavior:
 #' model.matrix(~day, when)
-#' 
+#'
 #' mainEffects <- dummyVars(~ day + time, data = when)
 #' mainEffects
 #' predict(mainEffects, when[1:3, ])
-#' 
+#'
 #' when2 <- when
 #' when2[1, 1] <- NA
 #' predict(mainEffects, when2[1:3, ])
 #' predict(mainEffects, when2[1:3, ], na.action = na.omit)
-#' 
+#'
 #' interactionModel <- dummyVars(~ day + time + day:time, data = when, sep = ".")
 #' predict(interactionModel, when[1:3, ])
-#' 
+#'
 #' noNames <- dummyVars(~ day + time + day:time, data = when, levelsOnly = TRUE)
 #' predict(noNames, when)
-#' 
+#'
 #' head(class2ind(iris$Species))
-#' 
+#'
 #' two_levels <- factor(rep(letters[1:2], each = 5))
 #' class2ind(two_levels)
 #' class2ind(two_levels, drop2nd = TRUE)

--- a/R/expoTrans.R
+++ b/R/expoTrans.R
@@ -122,7 +122,11 @@ predict.expoTrans <- function(object, newdata, ...) {
 
 
 manly <- function(x, lambda) {
-  if (lambda == 0) x else (exp(lambda * x) - 1) / lambda
+  if (lambda == 0) {
+    x
+  } else {
+    (exp(lambda * x) - 1) / lambda
+  }
 }
 
 manlyLik <- function(lambda, x, neg = FALSE) {
@@ -135,5 +139,9 @@ manlyLik <- function(lambda, x, neg = FALSE) {
   if (!is.finite(out) || is.na(out)) {
     out <- .Machine$double.xmax
   }
-  if (neg) -out else out
+  if (neg) {
+    -out
+  } else {
+    out
+  }
 }

--- a/R/expoTrans.R
+++ b/R/expoTrans.R
@@ -1,58 +1,96 @@
-
 #' @export
 expoTrans <- function(y, ...) UseMethod("expoTrans")
 
 #' @export
-expoTrans.default <- function(y, na.rm  = TRUE, init = 0, lim = c(-4, 4), method = "Brent", numUnique = 3, ...)
-{
+expoTrans.default <- function(
+  y,
+  na.rm = TRUE,
+  init = 0,
+  lim = c(-4, 4),
+  method = "Brent",
+  numUnique = 3,
+  ...
+) {
   requireNamespaceQuietStop("e1071")
-  if(anyNA(y) && !na.rm) stop("missing data found")
+  if (anyNA(y) && !na.rm) {
+    stop("missing data found")
+  }
   call <- match.call()
-  rat <- max(y, na.rm = TRUE)/min(y, na.rm = TRUE)
-  if(length(unique(y[!is.na(y)])) >= numUnique)
-  {
-    results <- optim(init, manlyLik, x = y[!is.na(y)], neg = TRUE, method = method,
-                     lower = lim[1], upper = lim[2])
+  rat <- max(y, na.rm = TRUE) / min(y, na.rm = TRUE)
+  if (length(unique(y[!is.na(y)])) >= numUnique) {
+    results <- optim(
+      init,
+      manlyLik,
+      x = y[!is.na(y)],
+      neg = TRUE,
+      method = method,
+      lower = lim[1],
+      upper = lim[2]
+    )
     out <- list(lambda = results$par, est = manly(y, results$par))
-    if(length(unique(out$est)) == 1 || results$convergence > 0)
+    if (length(unique(out$est)) == 1 || results$convergence > 0) {
       out <- list(lambda = NA, est = y)
-  } else out <- list(lambda = NA, est = y)
+    }
+  } else {
+    out <- list(lambda = NA, est = y)
+  }
   out$n <- sum(!is.na(y))
   out$skewness <- e1071::skewness(y, na.rm = TRUE)
   out$summary <- summary(y)
-  out$ratio <- max(y, na.rm = TRUE)/min(y, na.rm = TRUE)
+  out$ratio <- max(y, na.rm = TRUE) / min(y, na.rm = TRUE)
   out$class <- class
   class(out) <- "expoTrans"
   out
 }
 
 #' @export
-expoTrans.numeric <- function(y, na.rm  = TRUE, init = 0, lim = c(-4, 4), method = "Brent", numUnique = 3, ...)
-{
+expoTrans.numeric <- function(
+  y,
+  na.rm = TRUE,
+  init = 0,
+  lim = c(-4, 4),
+  method = "Brent",
+  numUnique = 3,
+  ...
+) {
   requireNamespaceQuietStop("e1071")
-  if(anyNA(y) && !na.rm) stop("missing data found")
+  if (anyNA(y) && !na.rm) {
+    stop("missing data found")
+  }
   call <- match.call()
-  rat <- max(y, na.rm = TRUE)/min(y, na.rm = TRUE)
-  if(length(unique(y[!is.na(y)])) >= numUnique)
-  {
-    results <- optim(init, manlyLik, x = y[!is.na(y)], neg = TRUE, method = method,
-                     lower = lim[1], upper = lim[2])
+  rat <- max(y, na.rm = TRUE) / min(y, na.rm = TRUE)
+  if (length(unique(y[!is.na(y)])) >= numUnique) {
+    results <- optim(
+      init,
+      manlyLik,
+      x = y[!is.na(y)],
+      neg = TRUE,
+      method = method,
+      lower = lim[1],
+      upper = lim[2]
+    )
     out <- list(lambda = results$par, est = manly(y, results$par))
-    if(length(unique(out$est)) == 1 || results$convergence > 0)
+    if (length(unique(out$est)) == 1 || results$convergence > 0) {
       out <- list(lambda = NA, est = y)
-  } else out <- list(lambda = NA, est = y)
+    }
+  } else {
+    out <- list(lambda = NA, est = y)
+  }
   out$n <- sum(!is.na(y))
   out$skewness <- e1071::skewness(y, na.rm = TRUE)
   out$summary <- summary(y)
-  out$ratio <- max(y, na.rm = TRUE)/min(y, na.rm = TRUE)
+  out$ratio <- max(y, na.rm = TRUE) / min(y, na.rm = TRUE)
   out$class <- class
   class(out) <- "expoTrans"
   out
 }
 
 #' @export
-print.expoTrans <- function(x, digits = max(3L, getOption("digits") - 3L), ...)
-{
+print.expoTrans <- function(
+  x,
+  digits = max(3L, getOption("digits") - 3L),
+  ...
+) {
   cat("Exponential Transformation\n\n")
 
   cat(x$n, "data points used to estimate Lambda\n\n")
@@ -60,37 +98,42 @@ print.expoTrans <- function(x, digits = max(3L, getOption("digits") - 3L), ...)
   print(x$summary)
   cat("\nLargest/Smallest:", signif(x$ratio, digits), "\n")
   cat("Sample Skewness:", signif(x$skewness, digits), "\n")
-  if(!is.na(x$lambda))
-  {
+  if (!is.na(x$lambda)) {
     cat("\nEstimated Lambda:", signif(x$lambda, digits), "\n")
-  } else cat("\nLambda could not be estimated; no transformation is applied\n")
+  } else {
+    cat("\nLambda could not be estimated; no transformation is applied\n")
+  }
   cat("\n")
   invisible(x)
 }
 
 #' @export
-predict.expoTrans <- function(object, newdata, ...)
-{
-  if(!is.vector(newdata) || !is.numeric(newdata)) stop("newdata should be a numeric vector")
-  if(is.na(object$lambda))
-  {
+predict.expoTrans <- function(object, newdata, ...) {
+  if (!is.vector(newdata) || !is.numeric(newdata)) {
+    stop("newdata should be a numeric vector")
+  }
+  if (is.na(object$lambda)) {
     out <- newdata
-  } else out <- manly(newdata, object$lambda)
+  } else {
+    out <- manly(newdata, object$lambda)
+  }
   out
 }
 
 
-manly <- function(x, lambda)
-  if(lambda == 0) x else (exp(lambda*x) - 1)/lambda
+manly <- function(x, lambda) {
+  if (lambda == 0) x else (exp(lambda * x) - 1) / lambda
+}
 
-manlyLik <- function(lambda, x, neg = FALSE)
-{
+manlyLik <- function(lambda, x, neg = FALSE) {
   y <- manly(x, lambda)
   v <- var(y, na.rm = TRUE)
-  L1 <- lambda * sum(x, na.rm= TRUE)
-  L2 <- 0.5 * sum(y - mean(y, na.rm = TRUE))/v
-  L3 <- sum(!is.na(x)) * log(sqrt(2*pi)*sqrt(v))
+  L1 <- lambda * sum(x, na.rm = TRUE)
+  L2 <- 0.5 * sum(y - mean(y, na.rm = TRUE)) / v
+  L3 <- sum(!is.na(x)) * log(sqrt(2 * pi) * sqrt(v))
   out <- L1 - L2 - L3
-  if(!is.finite(out) || is.na(out)) out <- .Machine$double.xmax
-  if(neg) -out else out
+  if (!is.finite(out) || is.na(out)) {
+    out <- .Machine$double.xmax
+  }
+  if (neg) -out else out
 }

--- a/R/extractPrediction.R
+++ b/R/extractPrediction.R
@@ -1,183 +1,229 @@
 #' @rdname predict.train
 #' @export
-extractPrediction <- function(models, 
-                              testX = NULL, 
-                              testY = NULL, 
-                              unkX = NULL, 
-                              unkOnly = !is.null(unkX) & is.null(testX), 
-                              verbose = FALSE)
-{
-  
+extractPrediction <- function(
+  models,
+  testX = NULL,
+  testY = NULL,
+  unkX = NULL,
+  unkOnly = !is.null(unkX) & is.null(testX),
+  verbose = FALSE
+) {
   objectNames <- names(models)
-  if(is.null(objectNames)) objectNames <- paste("Object", seq_along(models), sep = "")
-  
-  if(!unkOnly) {
-    trainX <- models[[1]]$trainingData[,!(colnames(models[[1]]$trainingData) %in% ".outcome"), drop = FALSE]
-    trainY <- models[[1]]$trainingData$.outcome  
+  if (is.null(objectNames)) {
+    objectNames <- paste("Object", seq_along(models), sep = "")
+  }
+
+  if (!unkOnly) {
+    trainX <- models[[1]]$trainingData[,
+      !(colnames(models[[1]]$trainingData) %in% ".outcome"),
+      drop = FALSE
+    ]
+    trainY <- models[[1]]$trainingData$.outcome
   }
   obsLevels <- levels(models[[1]])
-  
-  if(verbose)
-  {
+
+  if (verbose) {
     cat("Number of training samples:", length(trainY), "\n")
     cat("Number of test samples:    ", length(testY), "\n\n")
   }
-  
+
   pred <- obs <- modelName <- dataType <- objName <- NULL
-  if(!is.null(testX))
-  {
+  if (!is.null(testX)) {
     #if(!is.data.frame(testX)) testX <- as.data.frame(testX)
     hasNa <- apply(testX, 1, function(data) anyNA(data))
-    if(verbose) cat("There were ", sum(hasNa), "rows with missing values\n\n")
+    if (verbose) cat("There were ", sum(hasNa), "rows with missing values\n\n")
   }
-  
-  for(i in seq(along.with = models))
-  {
-    if(!unkOnly)
-    {
-      tempTrainPred <- predictionFunction(models[[i]]$modelInfo,
-                                          models[[i]]$finalModel, 
-                                          trainX, 
-                                          models[[i]]$preProcess)
-      
-      if(verbose) cat(models[[i]]$method, ":", length(tempTrainPred), "training predictions were added\n")         
-      
-      if(models[[i]]$modelType == "Classification")
-      {
+
+  for (i in seq(along.with = models)) {
+    if (!unkOnly) {
+      tempTrainPred <- predictionFunction(
+        models[[i]]$modelInfo,
+        models[[i]]$finalModel,
+        trainX,
+        models[[i]]$preProcess
+      )
+
+      if (verbose) {
+        cat(
+          models[[i]]$method,
+          ":",
+          length(tempTrainPred),
+          "training predictions were added\n"
+        )
+      }
+
+      if (models[[i]]$modelType == "Classification") {
         pred <- c(pred, as.character(tempTrainPred))
         obs <- c(obs, as.character(trainY))
       } else {
-        tempTrainPred <- trimPredictions(mod_type = models[[i]]$modelType,
-                                         bounds =  models[[i]]$control$predictionBounds,
-                                         limits =  models[[i]]$yLimit,
-                                         pred = tempTrainPred)
+        tempTrainPred <- trimPredictions(
+          mod_type = models[[i]]$modelType,
+          bounds = models[[i]]$control$predictionBounds,
+          limits = models[[i]]$yLimit,
+          pred = tempTrainPred
+        )
         pred <- c(pred, tempTrainPred)
-        obs <- c(obs, trainY)      
+        obs <- c(obs, trainY)
       }
-      
+
       modelName <- c(modelName, rep(models[[i]]$method, length(tempTrainPred)))
       objName <- c(objName, rep(objectNames[[i]], length(tempTrainPred)))
       dataType <- c(dataType, rep("Training", length(tempTrainPred)))
-      
-      if(!is.null(testX) && !is.null(testY))
-      {
-        if(any(colnames(testX) == ".outcome")) 
+
+      if (!is.null(testX) && !is.null(testY)) {
+        if (any(colnames(testX) == ".outcome")) {
           testX <- testX[, colnames(testX) != ".outcome", drop = FALSE]
-        
-        tempTestPred <- predictionFunction(models[[i]]$modelInfo,
-                                           models[[i]]$finalModel, 
-                                           testX, 
-                                           models[[i]]$preProcess)              
-        
-        if(verbose) cat(models[[i]]$method, ":", length(tempTestPred), "test predictions were added\n")         
-        
-        if(models[[i]]$modelType == "Classification")
-        {
-          pred <- c(pred, as.character(tempTestPred))
-          obs <- c(obs, as.character(testY))    
-        } else {
-          tempTestPred <- trimPredictions(mod_type = models[[i]]$modelType,
-                                          bounds =  models[[i]]$control$predictionBounds,
-                                          limits =  models[[i]]$yLimit,
-                                          pred = tempTestPred)
-          pred <- c(pred, tempTestPred)   
-          obs <- c(obs, testY) 
         }
-        
+
+        tempTestPred <- predictionFunction(
+          models[[i]]$modelInfo,
+          models[[i]]$finalModel,
+          testX,
+          models[[i]]$preProcess
+        )
+
+        if (verbose) {
+          cat(
+            models[[i]]$method,
+            ":",
+            length(tempTestPred),
+            "test predictions were added\n"
+          )
+        }
+
+        if (models[[i]]$modelType == "Classification") {
+          pred <- c(pred, as.character(tempTestPred))
+          obs <- c(obs, as.character(testY))
+        } else {
+          tempTestPred <- trimPredictions(
+            mod_type = models[[i]]$modelType,
+            bounds = models[[i]]$control$predictionBounds,
+            limits = models[[i]]$yLimit,
+            pred = tempTestPred
+          )
+          pred <- c(pred, tempTestPred)
+          obs <- c(obs, testY)
+        }
+
         modelName <- c(modelName, rep(models[[i]]$method, length(tempTestPred)))
-        objName <- c(objName, rep(objectNames[[i]], length(tempTestPred)))         
-        dataType <- c(dataType, rep("Test", length(tempTestPred)))   
-        
+        objName <- c(objName, rep(objectNames[[i]], length(tempTestPred)))
+        dataType <- c(dataType, rep("Test", length(tempTestPred)))
       }
-      if(verbose) cat("\n")
+      if (verbose) cat("\n")
     }
-    if(!is.null(unkX))
-    {
-      if(any(colnames(unkX) == ".outcome")) 
+    if (!is.null(unkX)) {
+      if (any(colnames(unkX) == ".outcome")) {
         unkX <- unkX[, colnames(unkX) != ".outcome", drop = FALSE]
-      tempUnkPred <- predictionFunction(models[[i]]$modelInfo,
-                                        models[[i]]$finalModel, 
-                                        unkX, 
-                                        models[[i]]$preProcess)     
-      
-      if(verbose) cat(models[[i]]$method, ":", length(tempUnkPred), "unknown predictions were added\n")         
-      
-      if(models[[i]]$modelType == "Classification")
-      {
-        pred <- c(pred, as.character(tempUnkPred))
-        obs <- c(obs, rep("", length(tempUnkPred)))    
-      } else {
-        tempUnkPred <- trimPredictions(mod_type = models[[i]]$modelType,
-                                       bounds =  models[[i]]$control$predictionBounds,
-                                       limits =  models[[i]]$yLimit,
-                                       pred = tempUnkPred)
-        pred <- c(pred, tempUnkPred)   
-        obs <- c(obs, rep(NA, length(tempUnkPred)))    
       }
-      
+      tempUnkPred <- predictionFunction(
+        models[[i]]$modelInfo,
+        models[[i]]$finalModel,
+        unkX,
+        models[[i]]$preProcess
+      )
+
+      if (verbose) {
+        cat(
+          models[[i]]$method,
+          ":",
+          length(tempUnkPred),
+          "unknown predictions were added\n"
+        )
+      }
+
+      if (models[[i]]$modelType == "Classification") {
+        pred <- c(pred, as.character(tempUnkPred))
+        obs <- c(obs, rep("", length(tempUnkPred)))
+      } else {
+        tempUnkPred <- trimPredictions(
+          mod_type = models[[i]]$modelType,
+          bounds = models[[i]]$control$predictionBounds,
+          limits = models[[i]]$yLimit,
+          pred = tempUnkPred
+        )
+        pred <- c(pred, tempUnkPred)
+        obs <- c(obs, rep(NA, length(tempUnkPred)))
+      }
+
       modelName <- c(modelName, rep(models[[i]]$method, length(tempUnkPred)))
-      objName <- c(objName, rep(objectNames[[i]], length(tempUnkPred)))             
-      dataType <- c(dataType, rep("Unknown", length(tempUnkPred)))   
-      
+      objName <- c(objName, rep(objectNames[[i]], length(tempUnkPred)))
+      dataType <- c(dataType, rep("Unknown", length(tempUnkPred)))
     }
-    if(verbose) cat("\n")      
+    if (verbose) cat("\n")
   }
-  if(models[[1]]$modelType == "Classification")
-  {   
+  if (models[[1]]$modelType == "Classification") {
     pred <- factor(pred, levels = obsLevels)
     obs <- factor(obs, levels = obsLevels)
   }
-  
-  data.frame(obs = obs,
-             pred = pred,
-             model = modelName,
-             dataType = dataType,
-             object = objName)
+
+  data.frame(
+    obs = obs,
+    pred = pred,
+    model = modelName,
+    dataType = dataType,
+    object = objName
+  )
 }
 
 
 trimPredictions <- function(pred, mod_type, bounds, limits) {
-  if(mod_type == "Regression" && is.logical(bounds) && any(bounds)) {
-    if(bounds[1]) pred <- ifelse(pred < limits[1], limits[1], pred)
-    if(bounds[2]) pred <- ifelse(pred > limits[2], limits[2], pred)         
+  if (mod_type == "Regression" && is.logical(bounds) && any(bounds)) {
+    if (bounds[1]) {
+      pred <- ifelse(pred < limits[1], limits[1], pred)
+    }
+    if (bounds[2]) pred <- ifelse(pred > limits[2], limits[2], pred)
   }
-  if(mod_type == "Regression" && is.numeric(bounds) && any(!is.na(bounds))) {
-    if(!is.na(bounds[1])) pred <- ifelse(pred < bounds[1], bounds[1], pred)
-    if(!is.na(bounds[2])) pred <- ifelse(pred > bounds[2], bounds[2], pred)
+  if (mod_type == "Regression" && is.numeric(bounds) && any(!is.na(bounds))) {
+    if (!is.na(bounds[1])) {
+      pred <- ifelse(pred < bounds[1], bounds[1], pred)
+    }
+    if (!is.na(bounds[2])) pred <- ifelse(pred > bounds[2], bounds[2], pred)
   }
   pred
 }
 
 ## This is used in workflows
 trim_values <- function(preds, ctrl, is_num) {
-  if(is_num) {
-    if(is.logical(ctrl$predictionBounds) && any(ctrl$predictionBounds)) {
-      if(is.list(preds)) {
-        preds <- lapply(preds, trimPredictions,
-                        mod_type = "Regression",
-                        bounds = ctrl$predictionBounds,
-                        limits = ctrl$yLimits)
+  if (is_num) {
+    if (is.logical(ctrl$predictionBounds) && any(ctrl$predictionBounds)) {
+      if (is.list(preds)) {
+        preds <- lapply(
+          preds,
+          trimPredictions,
+          mod_type = "Regression",
+          bounds = ctrl$predictionBounds,
+          limits = ctrl$yLimits
+        )
       } else {
-        preds <- trimPredictions(mod_type = "Regression",
-                                 bounds =  ctrl$predictionBounds,
-                                 limits =  ctrl$yLimit,
-                                 pred = preds)
+        preds <- trimPredictions(
+          mod_type = "Regression",
+          bounds = ctrl$predictionBounds,
+          limits = ctrl$yLimit,
+          pred = preds
+        )
       }
     } else {
-      if(is.numeric(ctrl$predictionBounds) && any(!is.na(ctrl$predictionBounds))) {
-        if(is.list(preds)) {
-          preds <- lapply(preds, trimPredictions,
-                          mod_type = "Regression",
-                          bounds = ctrl$predictionBounds,
-                          limits = ctrl$yLimits)
+      if (
+        is.numeric(ctrl$predictionBounds) && any(!is.na(ctrl$predictionBounds))
+      ) {
+        if (is.list(preds)) {
+          preds <- lapply(
+            preds,
+            trimPredictions,
+            mod_type = "Regression",
+            bounds = ctrl$predictionBounds,
+            limits = ctrl$yLimits
+          )
         } else {
-          preds <- trimPredictions(mod_type = "Regression",
-                                   bounds =  ctrl$predictionBounds,
-                                   limits =  ctrl$yLimit,
-                                   pred = preds)
+          preds <- trimPredictions(
+            mod_type = "Regression",
+            bounds = ctrl$predictionBounds,
+            limits = ctrl$yLimit,
+            pred = preds
+          )
         }
       }
-    } 
+    }
   }
   preds
 }

--- a/R/extractPrediction.R
+++ b/R/extractPrediction.R
@@ -31,7 +31,9 @@ extractPrediction <- function(
   if (!is.null(testX)) {
     #if(!is.data.frame(testX)) testX <- as.data.frame(testX)
     hasNa <- apply(testX, 1, function(data) anyNA(data))
-    if (verbose) cat("There were ", sum(hasNa), "rows with missing values\n\n")
+    if (verbose) {
+      cat("There were ", sum(hasNa), "rows with missing values\n\n")
+    }
   }
 
   for (i in seq(along.with = models)) {
@@ -109,7 +111,9 @@ extractPrediction <- function(
         objName <- c(objName, rep(objectNames[[i]], length(tempTestPred)))
         dataType <- c(dataType, rep("Test", length(tempTestPred)))
       }
-      if (verbose) cat("\n")
+      if (verbose) {
+        cat("\n")
+      }
     }
     if (!is.null(unkX)) {
       if (any(colnames(unkX) == ".outcome")) {
@@ -149,7 +153,9 @@ extractPrediction <- function(
       objName <- c(objName, rep(objectNames[[i]], length(tempUnkPred)))
       dataType <- c(dataType, rep("Unknown", length(tempUnkPred)))
     }
-    if (verbose) cat("\n")
+    if (verbose) {
+      cat("\n")
+    }
   }
   if (models[[1]]$modelType == "Classification") {
     pred <- factor(pred, levels = obsLevels)
@@ -171,13 +177,17 @@ trimPredictions <- function(pred, mod_type, bounds, limits) {
     if (bounds[1]) {
       pred <- ifelse(pred < limits[1], limits[1], pred)
     }
-    if (bounds[2]) pred <- ifelse(pred > limits[2], limits[2], pred)
+    if (bounds[2]) {
+      pred <- ifelse(pred > limits[2], limits[2], pred)
+    }
   }
   if (mod_type == "Regression" && is.numeric(bounds) && any(!is.na(bounds))) {
     if (!is.na(bounds[1])) {
       pred <- ifelse(pred < bounds[1], bounds[1], pred)
     }
-    if (!is.na(bounds[2])) pred <- ifelse(pred > bounds[2], bounds[2], pred)
+    if (!is.na(bounds[2])) {
+      pred <- ifelse(pred > bounds[2], bounds[2], pred)
+    }
   }
   pred
 }

--- a/R/extractProb.R
+++ b/R/extractProb.R
@@ -70,10 +70,10 @@ extractProb <- function(
       }
       flush.console()
 
-      predProb <- if (is.null(predProb)) {
-        tempTrainProb
+      if (is.null(predProb)) {
+        predProb <- tempTrainProb
       } else {
-        rbind(predProb, tempTrainProb)
+        predProb <- rbind(predProb, tempTrainProb)
       }
       predClass <- c(predClass, as.character(tempTrainPred))
       obs <- c(obs, as.character(trainY))
@@ -108,10 +108,10 @@ extractProb <- function(
           )
         }
 
-        predProb <- if (is.null(predProb)) {
-          tempTestProb
+        if (is.null(predProb)) {
+          predProb <- tempTestProb
         } else {
-          rbind(predProb, tempTestProb)
+          predProb <- rbind(predProb, tempTestProb)
         }
         predClass <- c(predClass, as.character(tempTestPred))
         obs <- c(obs, as.character(testY))
@@ -148,10 +148,10 @@ extractProb <- function(
         )
       }
 
-      predProb <- if (is.null(predProb)) {
-        tempUnkProb
+      if (is.null(predProb)) {
+        predProb <- tempUnkProb
       } else {
-        rbind(predProb, tempUnkProb)
+        predProb <- rbind(predProb, tempUnkProb)
       }
       predClass <- c(predClass, as.character(tempUnkPred))
       obs <- c(obs, rep(NA, length(tempUnkPred)))
@@ -159,7 +159,9 @@ extractProb <- function(
       objName <- c(objName, rep(objectNames[[i]], length(tempUnkPred)))
       dataType <- c(dataType, rep("Unknown", length(tempUnkPred)))
     }
-    if (verbose) cat("\n")
+    if (verbose) {
+      cat("\n")
+    }
   }
 
   predClass <- factor(predClass, levels = obsLevels)

--- a/R/extractProb.R
+++ b/R/extractProb.R
@@ -1,57 +1,80 @@
- ## TODO use foreach to parallelize
+## TODO use foreach to parallelize
 #' @rdname predict.train
 #' @export
-extractProb <- function(models,
-                        testX = NULL,
-                        testY = NULL,
-                        unkX = NULL,
-                        unkOnly = !is.null(unkX) & is.null(testX),
-                        verbose = FALSE)
-{
-
+extractProb <- function(
+  models,
+  testX = NULL,
+  testY = NULL,
+  unkX = NULL,
+  unkOnly = !is.null(unkX) & is.null(testX),
+  verbose = FALSE
+) {
   objectNames <- names(models)
-  if(is.null(objectNames)) objectNames <- paste("Object", seq_along(models), sep = "")
+  if (is.null(objectNames)) {
+    objectNames <- paste("Object", seq_along(models), sep = "")
+  }
 
-
-  if(any(unlist(lapply(models, function(x) is.null(x$modelInfo$prob)))))
+  if (any(unlist(lapply(models, function(x) is.null(x$modelInfo$prob))))) {
     stop("only classification models that produce probabilities are allowed")
+  }
 
   obsLevels <- levels(models[[1]])
 
-  if(!unkOnly) {
-    trainX <- models[[1]]$trainingData[,!(colnames(models[[1]]$trainingData) %in% ".outcome"), drop = FALSE]
+  if (!unkOnly) {
+    trainX <- models[[1]]$trainingData[,
+      !(colnames(models[[1]]$trainingData) %in% ".outcome"),
+      drop = FALSE
+    ]
     trainY <- models[[1]]$trainingData$.outcome
   }
-  if(verbose)
-  {
+  if (verbose) {
     cat("Number of training samples:", length(trainY), "\n")
     cat("Number of test samples:    ", length(testY), "\n\n")
   }
 
-
   predProb <- predClass <- obs <- modelName <- dataType <- objName <- NULL
-  if(!is.null(testX))
-  {
-    if(!is.data.frame(testX)) testX <- as.data.frame(testX, stringsAsFactors = TRUE)
+  if (!is.null(testX)) {
+    if (!is.data.frame(testX)) {
+      testX <- as.data.frame(testX, stringsAsFactors = TRUE)
+    }
     hasNa <- apply(testX, 1, function(data) anyNA(data))
-    if(verbose) cat("There were ", sum(hasNa), "rows with missing values\n\n"); flush.console()
+    if (verbose) {
+      cat("There were ", sum(hasNa), "rows with missing values\n\n")
+    }
+    flush.console()
   }
 
-  for(i in seq(along.with = models))
-  {
-    if(verbose) cat("starting ", models[[i]]$method, "\n"); flush.console()
-    if(!unkOnly) {
-      tempTrainProb <- probFunction(models[[i]]$modelInfo,
-                                    models[[i]]$finalModel,
-                                    trainX,
-                                    models[[i]]$preProcess)
+  for (i in seq(along.with = models)) {
+    if (verbose) {
+      cat("starting ", models[[i]]$method, "\n")
+    }
+    flush.console()
+    if (!unkOnly) {
+      tempTrainProb <- probFunction(
+        models[[i]]$modelInfo,
+        models[[i]]$finalModel,
+        trainX,
+        models[[i]]$preProcess
+      )
       tempTrainPred <- apply(tempTrainProb, 1, which.max)
       tempTrainPred <- colnames(tempTrainProb)[tempTrainPred]
       tempTrainPred <- factor(tempTrainPred, levels = obsLevels)
 
-      if(verbose) cat(models[[i]]$method, ":", length(tempTrainPred), "training predictions were added\n"); flush.console()
+      if (verbose) {
+        cat(
+          models[[i]]$method,
+          ":",
+          length(tempTrainPred),
+          "training predictions were added\n"
+        )
+      }
+      flush.console()
 
-      predProb <- if(is.null(predProb)) tempTrainProb else rbind(predProb, tempTrainProb)
+      predProb <- if (is.null(predProb)) {
+        tempTrainProb
+      } else {
+        rbind(predProb, tempTrainProb)
+      }
       predClass <- c(predClass, as.character(tempTrainPred))
       obs <- c(obs, as.character(trainY))
       modelName <- c(modelName, rep(models[[i]]$method, length(tempTrainPred)))
@@ -59,57 +82,84 @@ extractProb <- function(models,
       dataType <- c(dataType, rep("Training", length(tempTrainPred)))
 
       # Test Data
-      if(!is.null(testX) && !is.null(testY)) {
-        if(!is.data.frame(testX)) testX <- as.data.frame(testX, stringsAsFactors = TRUE)
+      if (!is.null(testX) && !is.null(testY)) {
+        if (!is.data.frame(testX)) {
+          testX <- as.data.frame(testX, stringsAsFactors = TRUE)
+        }
         tempX <- testX
         tempY <- testY
         tempX$.outcome <- NULL
-        tempTestProb <- probFunction(models[[i]]$modelInfo,
-                                     models[[i]]$finalModel,
-                                     tempX,
-                                     models[[i]]$preProcess)
+        tempTestProb <- probFunction(
+          models[[i]]$modelInfo,
+          models[[i]]$finalModel,
+          tempX,
+          models[[i]]$preProcess
+        )
         tempTestPred <- apply(tempTestProb, 1, which.max)
         tempTestPred <- colnames(tempTestProb)[tempTestPred]
         tempTestPred <- factor(tempTestPred, levels = obsLevels)
 
-        if(verbose) cat(models[[i]]$method, ":", length(tempTestPred), "test predictions were added\n")
+        if (verbose) {
+          cat(
+            models[[i]]$method,
+            ":",
+            length(tempTestPred),
+            "test predictions were added\n"
+          )
+        }
 
-        predProb <- if(is.null(predProb)) tempTestProb else rbind(predProb, tempTestProb)
+        predProb <- if (is.null(predProb)) {
+          tempTestProb
+        } else {
+          rbind(predProb, tempTestProb)
+        }
         predClass <- c(predClass, as.character(tempTestPred))
         obs <- c(obs, as.character(testY))
         modelName <- c(modelName, rep(models[[i]]$method, length(tempTestPred)))
         objName <- c(objName, rep(objectNames[[i]], length(tempTestPred)))
         dataType <- c(dataType, rep("Test", length(tempTestPred)))
       }
-
     }
 
     # Unknown Data
-    if(!is.null(unkX))
-    {
-      if(!is.data.frame(unkX)) unkX <- as.data.frame(unkX, stringsAsFactors = TRUE)
+    if (!is.null(unkX)) {
+      if (!is.data.frame(unkX)) {
+        unkX <- as.data.frame(unkX, stringsAsFactors = TRUE)
+      }
       tempX <- unkX
       tempX$.outcome <- NULL
 
-      tempUnkProb <- probFunction(models[[i]]$modelInfo,
-                                  models[[i]]$finalModel,
-                                  tempX,
-                                  models[[i]]$preProcess)
+      tempUnkProb <- probFunction(
+        models[[i]]$modelInfo,
+        models[[i]]$finalModel,
+        tempX,
+        models[[i]]$preProcess
+      )
       tempUnkPred <- apply(tempUnkProb, 1, which.max)
       tempUnkPred <- colnames(tempUnkProb)[tempUnkPred]
       tempUnkPred <- factor(tempUnkPred, levels = obsLevels)
 
-      if(verbose) cat(models[[i]]$method, ":", length(tempUnkPred), "unknown predictions were added\n")
+      if (verbose) {
+        cat(
+          models[[i]]$method,
+          ":",
+          length(tempUnkPred),
+          "unknown predictions were added\n"
+        )
+      }
 
-      predProb <- if(is.null(predProb)) tempUnkProb else rbind(predProb, tempUnkProb)
+      predProb <- if (is.null(predProb)) {
+        tempUnkProb
+      } else {
+        rbind(predProb, tempUnkProb)
+      }
       predClass <- c(predClass, as.character(tempUnkPred))
       obs <- c(obs, rep(NA, length(tempUnkPred)))
       modelName <- c(modelName, rep(models[[i]]$method, length(tempUnkPred)))
       objName <- c(objName, rep(objectNames[[i]], length(tempUnkPred)))
       dataType <- c(dataType, rep("Unknown", length(tempUnkPred)))
-
     }
-    if(verbose) cat("\n")
+    if (verbose) cat("\n")
   }
 
   predClass <- factor(predClass, levels = obsLevels)

--- a/R/featurePlot.R
+++ b/R/featurePlot.R
@@ -17,74 +17,119 @@
 #' @author Max Kuhn
 #' @keywords hplot
 #' @examples
-#' 
+#'
 #' x <- matrix(rnorm(50 * 5), ncol = 5)
 #' y <- factor(rep(c("A", "B"), 25))
-#' 
+#'
 #' trellis.par.set(theme = col.whitebg(), warn = FALSE)
 #' featurePlot(x, y, "ellipse")
 #' featurePlot(x, y, "strip", jitter = TRUE)
 #' featurePlot(x, y, "box")
 #' featurePlot(x, y, "pairs")
-#' 
+#'
 #' @export featurePlot
 "featurePlot" <-
-function(x, y,
-   plot = if(is.factor(y)) "strip" else "scatter",
-   labels = c("Feature", ""), ...)
-{
-   if(!is.data.frame(x))  x <- as.data.frame(x, stringsAsFactors = TRUE)
-   numFeat <- dim(x)[2]
+  function(
+    x,
+    y,
+    plot = if (is.factor(y)) "strip" else "scatter",
+    labels = c("Feature", ""),
+    ...
+  ) {
+    if (!is.data.frame(x)) {
+      x <- as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    numFeat <- dim(x)[2]
 
-   if(plot != "pairs")
-   {
+    if (plot != "pairs") {
       stackX <- stack(x)
       stackX$.y <- rep(y, numFeat)
-   } else {
-      if(!is.factor(y))
-      {
-         x <- data.frame(cbind(x, y))
+    } else {
+      if (!is.factor(y)) {
+        x <- data.frame(cbind(x, y))
       }
-   }
+    }
 
-   if(is.factor(y))
-   {
-      featPlot <- switch(tolower(plot),
-         strip = stripplot(values ~ .y|ind, stackX,
-            xlab = labels[1], ylab = labels[2], ...),
-         box =, boxplot = bwplot(values ~ .y|ind, stackX,
-            xlab = labels[1], ylab = labels[2], ...),
-         density = densityplot(~values |ind, stackX,
-            groups = stackX$.y,
-            xlab = labels[1], ylab = labels[2], ...),
-         pairs = splom(~x, groups = y, ...),
-         ellipse =  splom(~x, groups = y,
-            panel = function(x, y, groups, subscripts, ...)
-            {
-               requireNamespaceQuietStop("ellipse")
-               lineInfo <-  trellis.par.get("superpose.line")
-               pointInfo <-  trellis.par.get("superpose.symbol")
-               uniqueGroups <- sort(unique(groups))
-               for (i in seq(along.with=uniqueGroups))
-               {
-                  id <- which(groups[subscripts] == uniqueGroups[i])
-                  panel.xyplot(x[id], y[id], pch = pointInfo$pch[i],
-                      col = pointInfo$col[i], cex = pointInfo$cex[i], ...)
-                  groupVar<-var(cbind(x[id],y[id]))
-                  groupMean<-cbind(mean(x[id]),mean(y[id]))
-                  groupEllipse<-ellipse::ellipse(groupVar, centre = groupMean, level = 0.95)
-                  panel.xyplot(groupEllipse[,1], groupEllipse[,2], type="l", col = lineInfo$col[i], lty = lineInfo$lty[i], ...)
-               }
-            },
-         ...)
+    if (is.factor(y)) {
+      featPlot <- switch(
+        tolower(plot),
+        strip = stripplot(
+          values ~ .y | ind,
+          stackX,
+          xlab = labels[1],
+          ylab = labels[2],
+          ...
+        ),
+        box = ,
+        boxplot = bwplot(
+          values ~ .y | ind,
+          stackX,
+          xlab = labels[1],
+          ylab = labels[2],
+          ...
+        ),
+        density = densityplot(
+          ~ values | ind,
+          stackX,
+          groups = stackX$.y,
+          xlab = labels[1],
+          ylab = labels[2],
+          ...
+        ),
+        pairs = splom(~x, groups = y, ...),
+        ellipse = splom(
+          ~x,
+          groups = y,
+          panel = function(x, y, groups, subscripts, ...) {
+            requireNamespaceQuietStop("ellipse")
+            lineInfo <- trellis.par.get("superpose.line")
+            pointInfo <- trellis.par.get("superpose.symbol")
+            uniqueGroups <- sort(unique(groups))
+            for (i in seq(along.with = uniqueGroups)) {
+              id <- which(groups[subscripts] == uniqueGroups[i])
+              panel.xyplot(
+                x[id],
+                y[id],
+                pch = pointInfo$pch[i],
+                col = pointInfo$col[i],
+                cex = pointInfo$cex[i],
+                ...
+              )
+              groupVar <- var(cbind(x[id], y[id]))
+              groupMean <- cbind(mean(x[id]), mean(y[id]))
+              groupEllipse <- ellipse::ellipse(
+                groupVar,
+                centre = groupMean,
+                level = 0.95
+              )
+              panel.xyplot(
+                groupEllipse[, 1],
+                groupEllipse[, 2],
+                type = "l",
+                col = lineInfo$col[i],
+                lty = lineInfo$lty[i],
+                ...
+              )
+            }
+          },
+          ...
+        )
       )
-   } else {
-      featPlot <- switch(tolower(plot),
-         scatter =, xyplot = xyplot(.y ~ values|ind, stackX,
-            scales = list( x = list(relation = "free")),
-            xlab = labels[1], ylab = labels[2], ...),
-         pairs = splom(~x,  ...))
-   }
+    } else {
+      featPlot <- switch(
+        tolower(plot),
+        scatter = ,
+        xyplot = xyplot(
+          .y ~ values | ind,
+          stackX,
+          scales = list(x = list(relation = "free")),
+          xlab = labels[1],
+          ylab = labels[2],
+          ...
+        ),
+        pairs = splom(~x, ...)
+      )
+    }
 
-   featPlot
-}
+    featPlot
+  }

--- a/R/filterVarImp.R
+++ b/R/filterVarImp.R
@@ -117,7 +117,9 @@ filterVarImp <- function(x, y, nonpara = FALSE, ...) {
         if (inherits(regMod, "try-error") || any(is.nan(regMod$residuals))) {
           try(regMod <- lm(y ~ x, ...))
         }
-        if (inherits(regMod, "try-error")) return(NA)
+        if (inherits(regMod, "try-error")) {
+          return(NA)
+        }
       }
 
       pR2 <- 1 - (sum(resid(regMod)^2) / meanMod)
@@ -127,7 +129,11 @@ filterVarImp <- function(x, y, nonpara = FALSE, ...) {
       pR2
     }
 
-    testFunc <- if (nonpara) nonparaFoo else paraFoo
+    if (nonpara) {
+      testFunc <- nonparaFoo
+    } else {
+      testFunc <- paraFoo
+    }
 
     outStat <- apply(x, 2, testFunc, y = y)
     outStat <- data.frame(Overall = outStat)

--- a/R/filterVarImp.R
+++ b/R/filterVarImp.R
@@ -1,14 +1,12 @@
-
-rocPerCol <- function(dat, cls){
+rocPerCol <- function(dat, cls) {
   roc_auc <- auc(cls, dat)
   max(roc_auc, 1 - roc_auc)
 }
 
-asNumeric <- function(data){
+asNumeric <- function(data) {
   fc <- sapply(data, is.factor)
   modifyList(data, lapply(data[, fc], as.numeric))
 }
-
 
 
 #' Calculation of filter-based variable importance
@@ -48,12 +46,12 @@ asNumeric <- function(data){
 #' @author Max Kuhn
 #' @keywords models
 #' @examples
-#' 
+#'
 #' data(mdrr)
 #' filterVarImp(mdrrDescr[, 1:5], mdrrClass)
-#' 
+#'
 #' data(BloodBrain)
-#' 
+#'
 #' filterVarImp(bbbDescr[, 1:5], logBBB, nonpara = FALSE)
 #' apply(
 #'   bbbDescr[, 1:5],
@@ -61,75 +59,78 @@ asNumeric <- function(data){
 #'   function(x, y) summary(lm(y ~ x))$coefficients[2, 3],
 #'   y = logBBB
 #' )
-#' 
+#'
 #' filterVarImp(bbbDescr[, 1:5], logBBB, nonpara = TRUE)
-#' 
+#'
 #' @export filterVarImp
-filterVarImp <- function(x, y, nonpara = FALSE, ...){
+filterVarImp <- function(x, y, nonpara = FALSE, ...) {
   # converting factors to numeric
   notNumber <- sapply(x, function(x) !is.numeric(x))
   x = asNumeric(x)
 
-  if(is.factor(y)){
-      classLevels <- levels(y)
-      k <- length(classLevels)
+  if (is.factor(y)) {
+    classLevels <- levels(y)
+    k <- length(classLevels)
 
-      if(k > 2){
+    if (k > 2) {
+      Combs <- combn(classLevels, 2)
+      CombsN <- combn(1:k, 2)
 
-        Combs <- combn(classLevels, 2)
-        CombsN <- combn(1:k, 2)
+      lStat <- lapply(seq_len(ncol(Combs)), FUN = function(cc) {
+        yLevs <- as.character(y) %in% Combs[, cc]
+        tmpX <- x[yLevs, ]
+        tmpY <- as.numeric(y[yLevs] == Combs[, cc][2])
+        apply(tmpX, 2, rocPerCol, cls = tmpY)
+      })
+      Stat = do.call("cbind", lStat)
 
-          lStat <- lapply(seq_len(ncol(Combs)), FUN = function(cc){
-            yLevs <- as.character(y) %in% Combs[,cc]
-            tmpX <- x[yLevs,]
-            tmpY <- as.numeric(y[yLevs] == Combs[,cc][2])
-            apply(tmpX, 2, rocPerCol, cls = tmpY)
-          })
-          Stat = do.call("cbind", lStat)
+      loutStat <- lapply(1:k, function(j) {
+        apply(Stat[, CombsN[, j]], 1, max)
+      })
 
-          loutStat <- lapply(1:k, function(j){
-            apply(Stat[,CombsN[,j]], 1, max)
-          })
-
-          outStat = do.call("cbind", loutStat)
-
-        } else {
-          tmp <- apply(x, 2, rocPerCol, cls = y)
-          outStat <- cbind(tmp, tmp)
-        }
-
-      outStat <- as.data.frame(outStat, stringsAsFactors = FALSE)
-      colnames(outStat) <- classLevels
-      rownames(outStat) <- dimnames(x)[[2]]
-      outStat <- data.frame(outStat)
+      outStat = do.call("cbind", loutStat)
     } else {
-
-      paraFoo <- function(data, y) abs(coef(summary(lm(y ~ data, na.action = na.omit)))[2, "t value"])
-      nonparaFoo <- function(x, y, ...)
-        {
-          meanMod <- sum((y - mean(y, rm.na = TRUE))^2)
-          nzv <- nearZeroVar(x, saveMetrics = TRUE)
-
-          if(nzv$zeroVar) return(NA)
-          if(nzv$percentUnique < 20)
-            {
-              regMod <- lm(y~x, na.action = na.omit, ...)
-            } else {
-              regMod <- try(loess(y~x, na.action = na.omit, ...), silent = TRUE)
-
-              if(inherits(regMod, "try-error") || any(is.nan(regMod$residuals))) try(regMod <- lm(y~x, ...))
-              if(inherits(regMod, "try-error")) return(NA)
-            }
-
-          pR2 <- 1 - (sum(resid(regMod)^2)/meanMod)
-          if(pR2 < 0) pR2 <- 0
-          pR2
-        }
-
-      testFunc <- if(nonpara) nonparaFoo else paraFoo
-
-      outStat <- apply(x, 2, testFunc, y = y)
-      outStat <- data.frame(Overall = outStat)
+      tmp <- apply(x, 2, rocPerCol, cls = y)
+      outStat <- cbind(tmp, tmp)
     }
+
+    outStat <- as.data.frame(outStat, stringsAsFactors = FALSE)
+    colnames(outStat) <- classLevels
+    rownames(outStat) <- dimnames(x)[[2]]
+    outStat <- data.frame(outStat)
+  } else {
+    paraFoo <- function(data, y) {
+      abs(coef(summary(lm(y ~ data, na.action = na.omit)))[2, "t value"])
+    }
+    nonparaFoo <- function(x, y, ...) {
+      meanMod <- sum((y - mean(y, rm.na = TRUE))^2)
+      nzv <- nearZeroVar(x, saveMetrics = TRUE)
+
+      if (nzv$zeroVar) {
+        return(NA)
+      }
+      if (nzv$percentUnique < 20) {
+        regMod <- lm(y ~ x, na.action = na.omit, ...)
+      } else {
+        regMod <- try(loess(y ~ x, na.action = na.omit, ...), silent = TRUE)
+
+        if (inherits(regMod, "try-error") || any(is.nan(regMod$residuals))) {
+          try(regMod <- lm(y ~ x, ...))
+        }
+        if (inherits(regMod, "try-error")) return(NA)
+      }
+
+      pR2 <- 1 - (sum(resid(regMod)^2) / meanMod)
+      if (pR2 < 0) {
+        pR2 <- 0
+      }
+      pR2
+    }
+
+    testFunc <- if (nonpara) nonparaFoo else paraFoo
+
+    outStat <- apply(x, 2, testFunc, y = y)
+    outStat <- data.frame(Overall = outStat)
+  }
   outStat
 }

--- a/R/findCorrelation.R
+++ b/R/findCorrelation.R
@@ -103,12 +103,16 @@ findCorrelation_exact <- function(x, cutoff = 0.90, verbose = FALSE) {
             deletecol[i] <- TRUE
             x2[i, ] <- NA
             x2[, i] <- NA
-            if (verbose) cat(" so flagging column", newOrder[i], "\n")
+            if (verbose) {
+              cat(" so flagging column", newOrder[i], "\n")
+            }
           } else {
             deletecol[j] <- TRUE
             x2[j, ] <- NA
             x2[, j] <- NA
-            if (verbose) cat(" so flagging column", newOrder[j], "\n")
+            if (verbose) {
+              cat(" so flagging column", newOrder[j], "\n")
+            }
           }
         }
       }
@@ -212,10 +216,10 @@ findCorrelation <- function(
   if (names && is.null(colnames(x))) {
     stop("'x' must have column names when `names = TRUE`")
   }
-  out <- if (exact) {
-    findCorrelation_exact(x = x, cutoff = cutoff, verbose = verbose)
+  if (exact) {
+    out <- findCorrelation_exact(x = x, cutoff = cutoff, verbose = verbose)
   } else {
-    findCorrelation_fast(x = x, cutoff = cutoff, verbose = verbose)
+    out <- findCorrelation_fast(x = x, cutoff = cutoff, verbose = verbose)
   }
   out
   if (names) {

--- a/R/findCorrelation.R
+++ b/R/findCorrelation.R
@@ -150,7 +150,7 @@ findCorrelation_exact <- function(x, cutoff = 0.90, verbose = FALSE) {
 #' @family preprocessing
 #' @keywords manip
 #' @examples
-#' 
+#'
 #' R1 <- structure(
 #'   c(
 #'     1,
@@ -183,24 +183,24 @@ findCorrelation_exact <- function(x, cutoff = 0.90, verbose = FALSE) {
 #' )
 #' colnames(R1) <- rownames(R1) <- paste0("x", 1:ncol(R1))
 #' R1
-#' 
+#'
 #' findCorrelation(R1, cutoff = .6, exact = FALSE)
 #' findCorrelation(R1, cutoff = .6, exact = TRUE)
 #' findCorrelation(R1, cutoff = .6, exact = TRUE, names = FALSE)
-#' 
+#'
 #' R2 <- diag(rep(1, 5))
 #' R2[2, 3] <- R2[3, 2] <- .7
 #' R2[5, 3] <- R2[3, 5] <- -.7
 #' R2[4, 1] <- R2[1, 4] <- -.67
-#' 
+#'
 #' corrDF <- expand.grid(row = 1:5, col = 1:5)
 #' corrDF$correlation <- as.vector(R2)
 #' levelplot(correlation ~ row + col, corrDF)
-#' 
+#'
 #' findCorrelation(R2, cutoff = .65, verbose = TRUE)
-#' 
+#'
 #' findCorrelation(R2, cutoff = .99, verbose = TRUE)
-#' 
+#'
 #' @export findCorrelation
 findCorrelation <- function(
   x,

--- a/R/findLinearCombos.R
+++ b/R/findLinearCombos.R
@@ -2,61 +2,55 @@
 enumLC <- function(object, ...) UseMethod("enumLC")
 
 #' @export
-enumLC.default <- function(object, ...)
-{
-   # there doesn't seem to be a reasonable default, so
-   # we'll throw an error
-   stop(paste('enumLC does not support ', class(object), 'objects'))
+enumLC.default <- function(object, ...) {
+  # there doesn't seem to be a reasonable default, so
+  # we'll throw an error
+  stop(paste('enumLC does not support ', class(object), 'objects'))
 }
 
 #' @export
-enumLC.matrix <- function(object, ...)
-{
-   # factor the matrix using QR decomposition and then process it
-   internalEnumLC(qr(object))
+enumLC.matrix <- function(object, ...) {
+  # factor the matrix using QR decomposition and then process it
+  internalEnumLC(qr(object))
 }
 
 #' @export
-enumLC.lm <- function(object, ...)
-{
-   # extract the QR decomposition and the process it
-   internalEnumLC(object$qr)
+enumLC.lm <- function(object, ...) {
+  # extract the QR decomposition and the process it
+  internalEnumLC(object$qr)
 }
 
 #' @export
-enumLC.formula <- function(object, ...)
-{
-   # create an lm fit object from the formula, and then call
-   # appropriate enumLC method
-   enumLC(lm(object))
+enumLC.formula <- function(object, ...) {
+  # create an lm fit object from the formula, and then call
+  # appropriate enumLC method
+  enumLC(lm(object))
 }
 
 # this function does the actual work for all of the enumLC methods
-internalEnumLC <- function(qrObj, ...)
-{
-   R <- qr.R(qrObj)                     # extract R matrix
-   numColumns <- dim(R)[2]              # number of columns in R
-   rank <- qrObj$rank                   # number of independent columns
-   pivot <- qrObj$pivot                 # get the pivot vector
+internalEnumLC <- function(qrObj, ...) {
+  R <- qr.R(qrObj) # extract R matrix
+  numColumns <- dim(R)[2] # number of columns in R
+  rank <- qrObj$rank # number of independent columns
+  pivot <- qrObj$pivot # get the pivot vector
 
-   if (is.null(numColumns) || rank == numColumns)
-   {
-      list()                            # there are no linear combinations
-   } else {
-      p1 <- 1:rank
-      X <- R[p1, p1]                    # extract the independent columns
-      Y <- R[p1, -p1, drop = FALSE]     # extract the dependent columns
-      b <- qr(X)                        # factor the independent columns
-      b <- qr.coef(b, Y)                # get regression coefficients of
-                                        # the dependent columns
-      b[abs(b) < 1e-6] <- 0             # zap small values
+  if (is.null(numColumns) || rank == numColumns) {
+    list() # there are no linear combinations
+  } else {
+    p1 <- 1:rank
+    X <- R[p1, p1] # extract the independent columns
+    Y <- R[p1, -p1, drop = FALSE] # extract the dependent columns
+    b <- qr(X) # factor the independent columns
+    b <- qr.coef(b, Y) # get regression coefficients of
+    # the dependent columns
+    b[abs(b) < 1e-6] <- 0 # zap small values
 
-      # generate a list with one element for each dependent column
-      lapply(1:dim(Y)[2],
-         function(i) c(pivot[rank + i], pivot[which(b[,i] != 0)]))
-   }
+    # generate a list with one element for each dependent column
+    lapply(1:dim(Y)[2], function(i) {
+      c(pivot[rank + i], pivot[which(b[, i] != 0)])
+    })
+  }
 }
-
 
 
 #' Determine linear combinations in a matrix
@@ -81,7 +75,7 @@ internalEnumLC <- function(qrObj, ...)
 #'   (`findLinearCombos`)
 #' @keywords manip
 #' @examples
-#' 
+#'
 #' testData1 <- matrix(0, nrow = 20, ncol = 8)
 #' testData1[, 1] <- 1
 #' testData1[, 2] <- round(rnorm(20), 1)
@@ -94,9 +88,9 @@ internalEnumLC <- function(qrObj, ...)
 #' testData1[1:4, 6] <- 1
 #' testData1[5:10, 7] <- 1
 #' testData1[11:20, 8] <- 1
-#' 
+#'
 #' findLinearCombos(testData1)
-#' 
+#'
 #' testData2 <- matrix(0, nrow = 6, ncol = 6)
 #' testData2[, 1] <- c(1, 1, 1, 1, 1, 1)
 #' testData2[, 2] <- c(1, 1, 1, 0, 0, 0)
@@ -104,28 +98,29 @@ internalEnumLC <- function(qrObj, ...)
 #' testData2[, 4] <- c(1, 0, 0, 1, 0, 0)
 #' testData2[, 5] <- c(0, 1, 0, 0, 1, 0)
 #' testData2[, 6] <- c(0, 0, 1, 0, 0, 1)
-#' 
+#'
 #' findLinearCombos(testData2)
-#' 
+#'
 #' @export findLinearCombos
-findLinearCombos <- function(x)
-{
-   if(!is.matrix(x)) x <- as.matrix(x)
-   lcList <- enumLC(x)
-   initialList <- lcList
-   badList <- NULL
-   if(length(lcList) > 0)
-   {
-      continue <- TRUE
-      while(continue)
-      {
-         # keep removing linear dependencies until it resolves
-         tmp <- unlist(lapply(lcList, function(x) x[1]))
-         tmp <- unique(tmp[!is.na(tmp)])
-         badList <- unique(c(tmp, badList))
-         lcList <- enumLC(x[,-badList, drop = FALSE])
-         continue <- (length(lcList) > 0)
-      }
-   } else badList <- NULL
-   list(linearCombos = initialList, remove = badList)
+findLinearCombos <- function(x) {
+  if (!is.matrix(x)) {
+    x <- as.matrix(x)
+  }
+  lcList <- enumLC(x)
+  initialList <- lcList
+  badList <- NULL
+  if (length(lcList) > 0) {
+    continue <- TRUE
+    while (continue) {
+      # keep removing linear dependencies until it resolves
+      tmp <- unlist(lapply(lcList, function(x) x[1]))
+      tmp <- unique(tmp[!is.na(tmp)])
+      badList <- unique(c(tmp, badList))
+      lcList <- enumLC(x[, -badList, drop = FALSE])
+      continue <- (length(lcList) > 0)
+    }
+  } else {
+    badList <- NULL
+  }
+  list(linearCombos = initialList, remove = badList)
 }

--- a/R/format.bagEarth.R
+++ b/R/format.bagEarth.R
@@ -52,5 +52,9 @@ format.bagEarth <- function(x, file = "", cat = TRUE, ...) {
     "\n"
   )
 
-  if (cat) cat(allEq, file = file) else return(allEq)
+  if (cat) {
+    cat(allEq, file = file)
+  } else {
+    return(allEq)
+  }
 }

--- a/R/format.bagEarth.R
+++ b/R/format.bagEarth.R
@@ -12,10 +12,10 @@
 #' @seealso [earth::earth()]
 #' @keywords models
 #' @examples
-#' 
+#'
 #' a <- bagEarth(Volume ~ ., data = trees, B = 3)
 #' format(a)
-#' 
+#'
 #' # yields:
 #' # (
 #' #   31.61075
@@ -34,22 +34,23 @@
 #' #   -  3.660456 * pmax(0,   14.2 -  Girth)
 #' #   + 0.6489774 * pmax(0, Height -     80)
 #' # )/3
-#' 
+#'
 #' @export
-format.bagEarth <- function(x, file = "", cat = TRUE, ...) 
-{
+format.bagEarth <- function(x, file = "", cat = TRUE, ...) {
   requireNamespaceQuietStop("earth")
 
   eachEq <- lapply(
-                   x$fit,
-                   function(u, ...) format(u, ...),
-                   ...)
+    x$fit,
+    function(u, ...) format(u, ...),
+    ...
+  )
   allEq <- paste(
-                 "(",
-                 paste(eachEq, collapse = "+"),
-                 ") /",
-                 x$B,
-                 "\n")
-  
-  if(cat) cat(allEq, file = file) else return(allEq)  
+    "(",
+    paste(eachEq, collapse = "+"),
+    ") /",
+    x$B,
+    "\n"
+  )
+
+  if (cat) cat(allEq, file = file) else return(allEq)
 }

--- a/R/gafs.R
+++ b/R/gafs.R
@@ -116,14 +116,14 @@ ga_func_check <- function(x) {
 #'
 #' <http://topepo.github.io/caret/feature-selection-using-genetic-algorithms.html>
 #' @examplesIf !caret:::is_cran_check()
-#' 
+#'
 #' pop <- gafs_initial(vars = 10, popSize = 10)
 #' pop
-#' 
+#'
 #' gafs_lrSelection(population = pop, fitness = 1:10)
-#' 
+#'
 #' gafs_spCrossover(population = pop, fitness = 1:10, parents = 1:2)
-#' 
+#'
 #' ## Hypothetical usage (not run):
 #' ## lda_ga <- gafs(x = predictors,
 #' ##                y = classes,
@@ -138,7 +138,7 @@ ga_func_check <- function(x) {
 #' ##               gafsControl = gafsControl(functions = rfGA),
 #' ##               ntree = 1000,
 #' ##               importance = TRUE)
-#' 
+#'
 #' @export gafs_initial
 gafs_initial <- function(vars, popSize, ...) {
   x <- matrix(NA, nrow = popSize, ncol = vars)
@@ -996,26 +996,26 @@ print.gafs <- function(
 #' @keywords multivariate
 #' @export
 #' @examplesIf !caret:::is_cran_check()
-#' 
-#' 
+#'
+#'
 #' set.seed(1)
 #' train_data <- twoClassSim(100, noiseVars = 10)
 #' test_data <- twoClassSim(10, noiseVars = 10)
-#' 
+#'
 #' ## A short example
 #' ctrl <- safsControl(functions = rfSA, method = "cv", number = 3)
-#' 
+#'
 #' rf_search <- safs(
 #'   x = train_data[, -ncol(train_data)],
 #'   y = train_data$Class,
 #'   iters = 3,
 #'   safsControl = ctrl
 #' )
-#' 
+#'
 #' rf_search
-#' 
+#'
 #' predict(rf_search, train_data)
-#' 
+#'
 #' @export predict.gafs
 predict.gafs <- function(object, newdata, ...) {
   if (any(names(object) == "recipe") && !is.null(object$recipe)) {
@@ -1144,23 +1144,23 @@ gafs <- function(x, ...) UseMethod("gafs")
 #' @keywords models
 #' @export
 #' @examplesIf !caret:::is_cran_check()
-#' 
+#'
 #' set.seed(1)
 #' train_data <- twoClassSim(100, noiseVars = 10)
 #' test_data <- twoClassSim(10, noiseVars = 10)
-#' 
+#'
 #' ## A short example
 #' ctrl <- gafsControl(functions = rfGA, method = "cv", number = 3)
-#' 
+#'
 #' rf_search <- gafs(
 #'   x = train_data[, -ncol(train_data)],
 #'   y = train_data$Class,
 #'   iters = 3,
 #'   gafsControl = ctrl
 #' )
-#' 
+#'
 #' rf_search
-#' 
+#'
 #' @export gafs.default
 "gafs.default" <-
   function(
@@ -1481,27 +1481,27 @@ gafs <- function(x, ...) UseMethod("gafs")
 #' @keywords hplot
 #' @export
 #' @examplesIf !caret:::is_cran_check()
-#' 
+#'
 #' set.seed(1)
 #' train_data <- twoClassSim(100, noiseVars = 10)
 #' test_data <- twoClassSim(10, noiseVars = 10)
-#' 
+#'
 #' ## A short example
 #' ctrl <- safsControl(functions = rfSA, method = "cv", number = 3)
-#' 
+#'
 #' rf_search <- safs(
 #'   x = train_data[, -ncol(train_data)],
 #'   y = train_data$Class,
 #'   iters = 50,
 #'   safsControl = ctrl
 #' )
-#' 
+#'
 #' plot(rf_search)
 #' plot(rf_search, output = "lattice", auto.key = list(columns = 2))
-#' 
+#'
 #' plot_data <- plot(rf_search, output = "data")
 #' summary(plot_data)
-#' 
+#'
 #' @export plot.gafs
 plot.gafs <- function(
   x,
@@ -1913,7 +1913,11 @@ update.gafs <- function(object, iter, x, y, ...) {
     if (!is.null(perf_data)) {
       testOutput <- cbind(
         testOutput,
-        perf_data[sample(seq_len(nrow(perf_data)), nrow(testOutput)), , drop = FALSE]
+        perf_data[
+          sample(seq_len(nrow(perf_data)), nrow(testOutput)),
+          ,
+          drop = FALSE
+        ]
       )
     }
 

--- a/R/gafs.R
+++ b/R/gafs.R
@@ -509,7 +509,11 @@ ga_select <- function(
     Similarity_M = rep(0 * NA, iters),
     stringsAsFactors = FALSE
   )
-  external <- if (!is.null(testX)) data.frame(Iter = 1:(iters)) else NULL
+  if (!is.null(testX)) {
+    external <- data.frame(Iter = 1:(iters))
+  } else {
+    external <- NULL
+  }
 
   ## add GA package warnings
 
@@ -611,7 +615,11 @@ ga_select <- function(
     rownames(current_int) <- NULL
     rm(currennt_results)
 
-    Fitness <- if (is.matrix(current_int)) current_int[, ga_metric["internal"]]
+    if (is.matrix(current_int)) {
+      Fitness <- current_int[, ga_metric["internal"]]
+    } else {
+      Fitness <- NULL
+    }
     best_index <- which.max(Fitness)
     best_internal <- current_int[best_index, ]
     if (!is.null(testX)) {
@@ -658,7 +666,9 @@ ga_select <- function(
       }
     } else {
       internal[generation, (nr - k + 1):nr] <- best_internal
-      if (!is.null(testX)) external[generation, -1] <- best_external
+      if (!is.null(testX)) {
+        external[generation, -1] <- best_external
+      }
     }
 
     if (ga_verbose) {
@@ -750,7 +760,11 @@ ga_select <- function(
     }
 
     # mutation
-    pm <- if (is.function(pmutation)) pmutation(object) else pmutation
+    if (is.function(pmutation)) {
+      pm <- pmutation(object)
+    } else {
+      pm <- pmutation
+    }
     if (is.function(funcs$mutation) && pm > 0) {
       for (i in seq_len(popSize)) {
         if (pm > runif(1)) {
@@ -1400,10 +1414,10 @@ gafs <- function(x, ...) UseMethod("gafs")
       best_iter <- averages$Iter[best_index]
       best_vars <- colnames(x)[final_ga$subsets[[best_index]]]
     } else {
-      best_index <- if (gafsControl$maximize["external"]) {
-        which.max(averages[, gafsControl$metric["external"]])
+      if (gafsControl$maximize["external"]) {
+        best_index <- which.max(averages[, gafsControl$metric["external"]])
       } else {
-        which.min(averages[, gafsControl$metric["external"]])
+        best_index <- which.min(averages[, gafsControl$metric["external"]])
       }
       best_iter <- averages$Iter[best_index]
       best_vars <- colnames(x)[final_ga$subsets[[best_index]]]
@@ -1542,27 +1556,30 @@ plot.gafs <- function(
   if (output == "data") {
     out <- plot_dat
   }
-  plot_dat <- if (both_estimates) {
-    ddply(plot_dat, c("Iter", "Estimate"), function(x) {
+  if (both_estimates) {
+    plot_dat <- ddply(plot_dat, c("Iter", "Estimate"), function(x) {
       c(Mean = mean(x[, metric]))
     })
   } else {
-    ddply(plot_dat, c("Iter"), function(x) c(Mean = mean(x[, metric])))
+    plot_dat <- ddply(plot_dat, c("Iter"), function(x) {
+      c(Mean = mean(x[, metric]))
+    })
   }
 
   if (output == "ggplot") {
-    out <- if (both_estimates) {
-      ggplot(plot_dat, aes(x = Iter, y = Mean, color = Estimate)) + geom_point()
+    if (both_estimates) {
+      out <- ggplot(plot_dat, aes(x = Iter, y = Mean, color = Estimate)) +
+        geom_point()
     } else {
-      ggplot(plot_dat, aes(x = Iter, y = Mean)) + geom_point()
+      out <- ggplot(plot_dat, aes(x = Iter, y = Mean)) + geom_point()
     }
     out <- out + xlab("Generation")
   }
   if (output == "lattice") {
-    out <- if (both_estimates) {
-      xyplot(Mean ~ Iter, data = plot_dat, groups = Estimate, ...)
+    if (both_estimates) {
+      out <- xyplot(Mean ~ Iter, data = plot_dat, groups = Estimate, ...)
     } else {
-      xyplot(Mean ~ Iter, data = plot_dat, ...)
+      out <- xyplot(Mean ~ Iter, data = plot_dat, ...)
     }
     out <- update(out, xlab = "Generation")
   }
@@ -2065,10 +2082,10 @@ update.gafs <- function(object, iter, x, y, ...) {
       best_iter <- averages$Iter[best_index]
       best_vars <- colnames(x)[final_ga$subsets[[best_index]]]
     } else {
-      best_index <- if (gafsControl$maximize["external"]) {
-        which.max(averages[, gafsControl$metric["external"]])
+      if (gafsControl$maximize["external"]) {
+        best_index <- which.max(averages[, gafsControl$metric["external"]])
       } else {
-        which.min(averages[, gafsControl$metric["external"]])
+        best_index <- which.min(averages[, gafsControl$metric["external"]])
       }
       best_iter <- averages$Iter[best_index]
       best_vars <- colnames(x)[final_ga$subsets[[best_index]]]

--- a/R/ggplot.R
+++ b/R/ggplot.R
@@ -1,144 +1,241 @@
 #' @rdname plot.train
 #' @export
-ggplot.train <- function(data = NULL, mapping = NULL, metric = data$metric[1], plotType = "scatter", output = "layered",
-               nameInStrip = FALSE, highlight = FALSE, ..., environment = NULL) {
-  if(!(output %in% c("data", "layered", "ggplot"))) stop("'outout' should be either 'data', 'ggplot' or 'layered'")
+ggplot.train <- function(
+  data = NULL,
+  mapping = NULL,
+  metric = data$metric[1],
+  plotType = "scatter",
+  output = "layered",
+  nameInStrip = FALSE,
+  highlight = FALSE,
+  ...,
+  environment = NULL
+) {
+  if (!(output %in% c("data", "layered", "ggplot"))) {
+    stop("'outout' should be either 'data', 'ggplot' or 'layered'")
+  }
   params <- data$modelInfo$parameters$parameter
   paramData <- data$modelInfo$parameters
 
-  if(grepl("adapt", data$control$method))
-    warning("When using adaptive resampling, this plot may not accurately capture the relationship between the tuning parameters and model performance.")
-
+  if (grepl("adapt", data$control$method)) {
+    warning(
+      "When using adaptive resampling, this plot may not accurately capture the relationship between the tuning parameters and model performance."
+    )
+  }
 
   plotIt <- "yes"
-  if(all(params == "parameter"))
-  {
+  if (all(params == "parameter")) {
     plotIt <- "There are no tuning parameters for this model."
   } else {
     dat <- data$results
 
     ## Some exceptions for pretty printing
-    if(data$method == "nb") dat$usekernel <- factor(ifelse(dat$usekernel, "Nonparametric", "Gaussian"))
-    if(data$method == "gam") dat$select <- factor(ifelse(dat$select, "Feature Selection", "No Feature Selection"))
-    if(data$method == "qrnn") dat$bag <- factor(ifelse(dat$bag, "Bagging", "No Bagging"))
-    if(data$method == "C5.0") dat$winnow <- factor(ifelse(dat$winnow, "Winnowing", "No Winnowing"))
-    if(data$method == "M5") dat$rules <- factor(ifelse(dat$rules == "Yes", "Rules", "Trees"))
+    if (data$method == "nb") {
+      dat$usekernel <- factor(ifelse(
+        dat$usekernel,
+        "Nonparametric",
+        "Gaussian"
+      ))
+    }
+    if (data$method == "gam") {
+      dat$select <- factor(ifelse(
+        dat$select,
+        "Feature Selection",
+        "No Feature Selection"
+      ))
+    }
+    if (data$method == "qrnn") {
+      dat$bag <- factor(ifelse(dat$bag, "Bagging", "No Bagging"))
+    }
+    if (data$method == "C5.0") {
+      dat$winnow <- factor(ifelse(dat$winnow, "Winnowing", "No Winnowing"))
+    }
+    if (data$method == "M5") {
+      dat$rules <- factor(ifelse(dat$rules == "Yes", "Rules", "Trees"))
+    }
 
     ## Check to see which tuning parameters were varied
     #       params is a factor, so just using params does not work properly when model metric is not the first column in dat
     #           e.g. oob resampling
-    paramValues <- apply(dat[,as.character(params),drop = FALSE],
-                         2,
-                         function(x) length(unique(x)))
-    if(any(paramValues > 1))
-    {
+    paramValues <- apply(
+      dat[, as.character(params), drop = FALSE],
+      2,
+      function(x) length(unique(x))
+    )
+    if (any(paramValues > 1)) {
       params <- names(paramValues)[paramValues > 1]
       paramData <- subset(paramData, parameter %in% params)
-    } else plotIt <- "There are no tuning parameters with more than 1 value."
+    } else {
+      plotIt <- "There are no tuning parameters with more than 1 value."
+    }
   }
-  if(plotIt == "yes")
-  {
+  if (plotIt == "yes") {
     p <- length(params)
     dat <- dat[, c(metric, params)]
 
     resampText <- resampName(data, FALSE)
     resampText <- paste(metric, resampText)
-  }  else stop(plotIt)
+  } else {
+    stop(plotIt)
+  }
   p <- ncol(dat) - 1
-  if(p > 1) {
+  if (p > 1) {
     numUnique <- unlist(lapply(dat[, -1], function(x) length(unique(x))))
-    numUnique <- sort(numUnique,  decreasing = TRUE)
+    numUnique <- sort(numUnique, decreasing = TRUE)
     dat <- dat[, c(metric, names(numUnique))]
   }
 
-  if(output == "data") return(dat)
-  if(data$control$search == "random") return(random_search_plot(data, metric = metric))
+  if (output == "data") {
+    return(dat)
+  }
+  if (data$control$search == "random") {
+    return(random_search_plot(data, metric = metric))
+  }
 
-  if(plotType == "scatter") {
+  if (plotType == "scatter") {
     # To highlight bestTune parameters in the plot
     if (highlight) {
       bstRes <- data$results
-      for (par in as.character(params))
+      for (par in as.character(params)) {
         bstRes <- bstRes[which(bstRes[, par] == data$bestTune[, par]), ]
-      if (nrow(bstRes) > 1)
+      }
+      if (nrow(bstRes) > 1) {
         stop("problem in extracting model$bestTune row from model$results")
+      }
     }
 
     dnm <- names(dat)
-    if(p > 1 && is.numeric(dat[, 3])) dat[, 3] <- factor(format(dat[, 3]))
-    if(p > 2 && nameInStrip) {
+    if (p > 1 && is.numeric(dat[, 3])) {
+      dat[, 3] <- factor(format(dat[, 3]))
+    }
+    if (p > 2 && nameInStrip) {
       strip_vars <- names(dat)[-(1:3)]
-      strip_lab <- as.character(subset(data$modelInfo$parameters, parameter %in% strip_vars)$label)
-      for(i in seq_along(strip_vars))
-        dat[, strip_vars[i]] <- factor(paste(strip_lab[i], dat[, strip_vars[i]], sep = ": "))
+      strip_lab <- as.character(
+        subset(data$modelInfo$parameters, parameter %in% strip_vars)$label
+      )
+      for (i in seq_along(strip_vars)) {
+        dat[, strip_vars[i]] <- factor(paste(
+          strip_lab[i],
+          dat[, strip_vars[i]],
+          sep = ": "
+        ))
+      }
     }
 
     # If a parameter is assigned to a facet panel, it needs to be converted to a factor
     #   otherwise, highlighting the bestTune parameters in a facet creates an extraneous panel
     #   potentially, a bug in ggplot ?
-    if (p >= 3)
-      for (col in 1:(p-2)) {
-        lvls <- as.character(unique(dat[, dnm[col+3]]))
-        dat[, dnm[col+3]] <- factor(dat[, dnm[col+3]], levels = lvls)
-        if (highlight)
-          bstRes[, dnm[col+3]] <- factor(bstRes[, dnm[col+3]], levels = lvls)
+    if (p >= 3) {
+      for (col in 1:(p - 2)) {
+        lvls <- as.character(unique(dat[, dnm[col + 3]]))
+        dat[, dnm[col + 3]] <- factor(dat[, dnm[col + 3]], levels = lvls)
+        if (highlight) {
+          bstRes[, dnm[col + 3]] <- factor(
+            bstRes[, dnm[col + 3]],
+            levels = lvls
+          )
+        }
       }
+    }
 
     out <- ggplot(dat, aes(x = .data[[dnm[2]]], y = .data[[dnm[1]]]))
     out <- out + ylab(resampText)
 
     # names(dat)[.] changed to dnm[.] to make the code more readable & (marginally) efficient
     out <- out + xlab(paramData$label[paramData$parameter == dnm[2]])
-    if (highlight)
-      out <- out + geom_point(data = bstRes,
-                              aes(x = .data[[dnm[2]]], y = .data[[dnm[1]]]),
-                              size = 4, shape = 5)
+    if (highlight) {
+      out <- out +
+        geom_point(
+          data = bstRes,
+          aes(x = .data[[dnm[2]]], y = .data[[dnm[1]]]),
+          size = 4,
+          shape = 5
+        )
+    }
 
-    if(output == "layered") {
-      if(p >= 2) {
+    if (output == "layered") {
+      if (p >= 2) {
         leg_name <- paramData$label[paramData$parameter == dnm[3]]
-        out <- out + geom_point(aes(color = .data[[dnm[3]]], shape = .data[[dnm[3]]]))
+        out <- out +
+          geom_point(aes(color = .data[[dnm[3]]], shape = .data[[dnm[3]]]))
         out <- out + geom_line(aes(color = .data[[dnm[3]]]))
-        out <- out + scale_colour_discrete(name = leg_name) +
+        out <- out +
+          scale_colour_discrete(name = leg_name) +
           scale_shape_discrete(name = leg_name)
-      } else out <- out + geom_point() + geom_line()
+      } else {
+        out <- out + geom_point() + geom_line()
+      }
 
-      if(p == 3)
+      if (p == 3) {
         out <- out + facet_wrap(as.formula(paste("~", dnm[4])))
-      if(p == 4)
-        out <- out + facet_grid(as.formula(paste(names(dat)[4], "~", names(dat)[5])))
-      if(p > 4) stop("The function can only handle <= 4 tuning parameters for scatter plots. Use output = 'ggplot' to create your own")
+      }
+      if (p == 4) {
+        out <- out +
+          facet_grid(as.formula(paste(names(dat)[4], "~", names(dat)[5])))
+      }
+      if (p > 4) {
+        stop(
+          "The function can only handle <= 4 tuning parameters for scatter plots. Use output = 'ggplot' to create your own"
+        )
+      }
     }
   }
 
-  if(plotType == "level") {
-    if(p == 1) stop("Two tuning parameters are required for a level plot")
+  if (plotType == "level") {
+    if (p == 1) {
+      stop("Two tuning parameters are required for a level plot")
+    }
     dnm <- names(dat)
-    if(is.numeric(dat[,2])) dat[,2] <- factor(format(dat[,2]), levels = format(sort(unique(dat[,2]))))
-    if(is.numeric(dat[,3])) dat[,3] <- factor(format(dat[,3]), levels = format(sort(unique(dat[,3]))))
-    if(p > 2 && nameInStrip) {
+    if (is.numeric(dat[, 2])) {
+      dat[, 2] <- factor(
+        format(dat[, 2]),
+        levels = format(sort(unique(dat[, 2])))
+      )
+    }
+    if (is.numeric(dat[, 3])) {
+      dat[, 3] <- factor(
+        format(dat[, 3]),
+        levels = format(sort(unique(dat[, 3])))
+      )
+    }
+    if (p > 2 && nameInStrip) {
       strip_vars <- names(dat)[-(1:3)]
-      strip_lab <- as.character(subset(data$modelInfo$parameters, parameter %in% strip_vars)$label)
-      for(i in seq_along(strip_vars))
+      strip_lab <- as.character(
+        subset(data$modelInfo$parameters, parameter %in% strip_vars)$label
+      )
+      for (i in seq_along(strip_vars)) {
         dat[, strip_vars[i]] <- factor(
           paste(strip_lab[i], format(dat[, strip_vars[i]]), sep = ": "),
-          levels = paste(strip_lab[i], format(sort(unique(dat[, strip_vars[i]]))), sep = ": ")
+          levels = paste(
+            strip_lab[i],
+            format(sort(unique(dat[, strip_vars[i]]))),
+            sep = ": "
+          )
         )
+      }
     }
     ## TODO: use factor(format(x)) to make a solid block of colors?
-    out <- ggplot(dat, aes(x = .data[[dnm[2]]], y = .data[[dnm[3]]], fill = .data[[metric]]))
+    out <- ggplot(
+      dat,
+      aes(x = .data[[dnm[2]]], y = .data[[dnm[3]]], fill = .data[[metric]])
+    )
     out <- out + ylab(paramData$label[paramData$parameter == dnm[3]])
     out <- out + xlab(paramData$label[paramData$parameter == dnm[2]])
-    if(output == "layered") {
+    if (output == "layered") {
       out <- out + geom_tile()
-      if(p == 3)
+      if (p == 3) {
         out <- out + facet_wrap(as.formula(paste("~", dnm[4])))
+      }
 
       # incorrect facet_wrap call for p == 4 ? fixed errors for p >= 4
-      if(p == 4)
+      if (p == 4) {
         out <- out + facet_grid(as.formula(paste(dnm[4], "~", dnm[5])))
-      if(p > 4) stop("The function can only handle <= 4 tuning parameters for level plots. Use output = 'ggplot' to create your own")
-
+      }
+      if (p > 4) {
+        stop(
+          "The function can only handle <= 4 tuning parameters for level plots. Use output = 'ggplot' to create your own"
+        )
+      }
     }
   }
   out
@@ -146,53 +243,82 @@ ggplot.train <- function(data = NULL, mapping = NULL, metric = data$metric[1], p
 
 #' @rdname plot.rfe
 #' @export
-ggplot.rfe <- function(data = NULL, mapping = NULL, metric = data$metric[1],
-                       output = "layered", ..., environment = NULL) {
-  if(!(output %in% c("data", "layered", "ggplot")))
+ggplot.rfe <- function(
+  data = NULL,
+  mapping = NULL,
+  metric = data$metric[1],
+  output = "layered",
+  ...,
+  environment = NULL
+) {
+  if (!(output %in% c("data", "layered", "ggplot"))) {
     stop("'outout' should be either 'data', 'ggplot' or 'layered'")
+  }
   resampText <- resampName(data, FALSE)
   resampText <- paste(metric, resampText)
-  if(output == "data") return(data$results)
-
-    if(any(names(data$results) == "Num_Resamples")) {
-      data$results <- 
-        subset(data$results, Num_Resamples >= floor(0.5 * length(data$control$index)))
+  if (output == "data") {
+    return(data$results)
   }
-  
+
+  if (any(names(data$results) == "Num_Resamples")) {
+    data$results <-
+      subset(
+        data$results,
+        Num_Resamples >= floor(0.5 * length(data$control$index))
+      )
+  }
+
   notBest <- subset(data$results, Variables != data$bestSubset)
   best <- subset(data$results, Variables == data$bestSubset)
-  
-  out <- ggplot(data$results, aes(x = .data[["Variables"]], y = .data[[metric]]))
-  if(output == "ggplot") return(out)
+
+  out <- ggplot(
+    data$results,
+    aes(x = .data[["Variables"]], y = .data[[metric]])
+  )
+  if (output == "ggplot") {
+    return(out)
+  }
   out <- out + geom_line()
   out <- out + ylab(resampText)
-  out <- out + geom_point(data = notBest, aes(x = .data[["Variables"]], y = .data[[metric]]))
+  out <- out +
+    geom_point(
+      data = notBest,
+      aes(x = .data[["Variables"]], y = .data[[metric]])
+    )
 
-  out <- out + geom_point(data=best, aes(x = .data[["Variables"]], y = .data[[metric]]),
-                          size = 3, colour="blue")
+  out <- out +
+    geom_point(
+      data = best,
+      aes(x = .data[["Variables"]], y = .data[[metric]]),
+      size = 3,
+      colour = "blue"
+    )
   out
 }
 
 random_search_plot <- function(x, metric = x$metric[1]) {
-
   params <- x$modelInfo$parameters
   p_names <- as.character(params$parameter)
 
   exclude <- NULL
-  for(i in seq(along.with = p_names)) {
-    if(all(is.na(x$results[, p_names[i]])))
+  for (i in seq(along.with = p_names)) {
+    if (all(is.na(x$results[, p_names[i]]))) {
       exclude <- c(exclude, i)
+    }
   }
-  if(length(exclude) > 0) p_names <- p_names[-exclude]
+  if (length(exclude) > 0) {
+    p_names <- p_names[-exclude]
+  }
   x$results <- x$results[, c(metric, p_names)]
-  res <- x$results[complete.cases(x$results),]
+  res <- x$results[complete.cases(x$results), ]
   combos <- res[, p_names, drop = FALSE]
 
   nvals <- unlist(lapply(combos, function(x) length(unique(x))))
   p_names <- p_names[which(nvals > 1)]
 
-  if(nrow(combos) == 1 || length(p_names) == 0)
+  if (nrow(combos) == 1 || length(p_names) == 0) {
     stop("Can't plot results with a single tuning parameter combination")
+  }
   combos <- combos[, p_names, drop = FALSE]
   nvals <- sort(nvals[p_names], decreasing = TRUE)
 
@@ -202,69 +328,124 @@ random_search_plot <- function(x, metric = x$metric[1]) {
 
   num_num <- sum(is_num)
   num_other <- length(p_names) - num_num
-  if(num_other == 0) {
-    if(num_num == 1) {
+  if (num_other == 0) {
+    if (num_num == 1) {
       out <- ggplot(res, aes(x = .data[[num_cols[1]]], y = .data[[metric]])) +
-        geom_point() + xlab(as.character(params$label[params$parameter == num_cols[1]]))
+        geom_point() +
+        xlab(as.character(params$label[params$parameter == num_cols[1]]))
     } else {
-      if(num_num == 2) {
-        out <- ggplot(res, aes(x = .data[[num_cols[1]]], y = .data[[num_cols[2]]], size = .data[[metric]])) +
+      if (num_num == 2) {
+        out <- ggplot(
+          res,
+          aes(
+            x = .data[[num_cols[1]]],
+            y = .data[[num_cols[2]]],
+            size = .data[[metric]]
+          )
+        ) +
           geom_point() +
           xlab(as.character(params$label[params$parameter == num_cols[1]])) +
           ylab(as.character(params$label[params$parameter == num_cols[2]]))
       } else {
         ## feature plot
-        vert <- melt(res[, c(metric, num_cols)], id.vars = metric, variable.name = "parameter")
+        vert <- melt(
+          res[, c(metric, num_cols)],
+          id.vars = metric,
+          variable.name = "parameter"
+        )
         vert <- merge(vert, params)
         names(vert)[names(vert) == "label"] <- "Parameter"
         out <- ggplot(vert, aes(x = .data[["value"]], y = .data[[metric]])) +
-          geom_point() + facet_wrap(~Parameter, scales = "free_x") + xlab("")
+          geom_point() +
+          facet_wrap(~Parameter, scales = "free_x") +
+          xlab("")
       }
     }
   } else {
-    if(num_other == length(p_names)) {
+    if (num_other == length(p_names)) {
       ## do an interaction plot
-      if(num_other == 1) {
-        out <- ggplot(res, aes(x = .data[[other_cols[1]]], y = .data[[metric]])) +
+      if (num_other == 1) {
+        out <- ggplot(
+          res,
+          aes(x = .data[[other_cols[1]]], y = .data[[metric]])
+        ) +
           geom_point() +
           xlab(as.character(params$label[params$parameter == other_cols[1]]))
       } else {
-        if(num_other == 2) {
-          out <- ggplot(res, aes(x = .data[[other_cols[1]]], shape = .data[[other_cols[2]]],  y = .data[[metric]])) +
-            geom_point() + geom_line(aes(group = .data[[other_cols[2]]])) +
+        if (num_other == 2) {
+          out <- ggplot(
+            res,
+            aes(
+              x = .data[[other_cols[1]]],
+              shape = .data[[other_cols[2]]],
+              y = .data[[metric]]
+            )
+          ) +
+            geom_point() +
+            geom_line(aes(group = .data[[other_cols[2]]])) +
             xlab(as.character(params$label[params$parameter == other_cols[1]]))
         } else {
-          if(num_other == 3) {
-            pname <- as.character(params$label[params$parameter == other_cols[3]])
-            res[,other_cols[3]] <- paste0(pname, ": ", res[,other_cols[3]])
-            out <- ggplot(res, aes(x = .data[[other_cols[1]]], shape = .data[[other_cols[2]]],  y = .data[[metric]])) +
-              geom_point() + geom_line(aes(group = .data[[other_cols[2]]])) +
+          if (num_other == 3) {
+            pname <- as.character(params$label[
+              params$parameter == other_cols[3]
+            ])
+            res[, other_cols[3]] <- paste0(pname, ": ", res[, other_cols[3]])
+            out <- ggplot(
+              res,
+              aes(
+                x = .data[[other_cols[1]]],
+                shape = .data[[other_cols[2]]],
+                y = .data[[metric]]
+              )
+            ) +
+              geom_point() +
+              geom_line(aes(group = .data[[other_cols[2]]])) +
               facet_grid(paste0(".~", other_cols[3])) +
-              xlab(as.character(params$label[params$parameter == other_cols[1]]))
+              xlab(as.character(params$label[
+                params$parameter == other_cols[1]
+              ]))
           } else {
-            stop(paste("There are",
-                       num_other, "non-numeric variables; I don't have code for",
-                       "that Dave"))
+            stop(paste(
+              "There are",
+              num_other,
+              "non-numeric variables; I don't have code for",
+              "that Dave"
+            ))
           }
         }
       }
     } else {
       ## feature plot with colors and or shapes
-      vert <- melt(res[, c(metric, num_cols, other_cols)],
-                   id.vars = c(metric, other_cols),
-                   variable.name = "parameter")
+      vert <- melt(
+        res[, c(metric, num_cols, other_cols)],
+        id.vars = c(metric, other_cols),
+        variable.name = "parameter"
+      )
       vert <- merge(vert, params)
       names(vert)[names(vert) == "label"] <- "Parameter"
-      if(num_other == 1) {
-        out <- ggplot(vert, aes(x = .data[["value"]], y = .data[[metric]], color = .data[[other_cols]])) +
-          geom_point() + facet_wrap(~Parameter, scales = "free_x") + xlab("")
+      if (num_other == 1) {
+        out <- ggplot(
+          vert,
+          aes(
+            x = .data[["value"]],
+            y = .data[[metric]],
+            color = .data[[other_cols]]
+          )
+        ) +
+          geom_point() +
+          facet_wrap(~Parameter, scales = "free_x") +
+          xlab("")
       } else {
-        stop(paste("There are", num_num, "numeric tuning variables and",
-                   num_other, "non-numeric variables; I don't have code for",
-                   "that Dave"))
+        stop(paste(
+          "There are",
+          num_num,
+          "numeric tuning variables and",
+          num_other,
+          "non-numeric variables; I don't have code for",
+          "that Dave"
+        ))
       }
     }
   }
   out
-
 }

--- a/R/heldout.R
+++ b/R/heldout.R
@@ -17,29 +17,35 @@
 ###################################################################
 ##
 
-oob_pred <- function (x, ...) UseMethod("oob_pred")
+oob_pred <- function(x, ...) UseMethod("oob_pred")
 
 #' @export
 oob_pred.train <- function(x, best = TRUE, average = TRUE, ...) {
-
-  if(is.null(x$pred))
+  if (is.null(x$pred)) {
     stop("re-fit the model using 'trainControl(savePredictions=TRUE)'")
+  }
   prd <- x$pred
   pname <- as.character(x$modelInfo$parameters$parameter)
-  if(best) {
+  if (best) {
     prd <- merge(prd, x$bestTune)
     prd <- prd[, !(colnames(prd) %in% pname)]
   }
   bycol <- "rowIndex"
-  if(!best) bycol <- c(bycol, pname)
+  if (!best) {
+    bycol <- c(bycol, pname)
+  }
 
-  if(average) prd <- get_averages(x, prd, bycol)
+  if (average) {
+    prd <- get_averages(x, prd, bycol)
+  }
 
-  if(x$modelType == "Classification") {
+  if (x$modelType == "Classification") {
     lev <- train_lev(x)
-    if(!is.null(lev)) {
-      if(is.character(prd$obs))  prd$obs  <- factor(prd$obs,  levels = lev)
-      if(is.character(prd$pred))  prd$pred <- factor(prd$pred, levels = lev)
+    if (!is.null(lev)) {
+      if (is.character(prd$obs)) {
+        prd$obs <- factor(prd$obs, levels = lev)
+      }
+      if (is.character(prd$pred)) prd$pred <- factor(prd$pred, levels = lev)
     }
   }
   prd
@@ -47,45 +53,55 @@ oob_pred.train <- function(x, best = TRUE, average = TRUE, ...) {
 
 #' @export
 oob_pred.rfe <- function(x, best = TRUE, average = TRUE, ...) {
-
-  if(is.null(x$pred))
+  if (is.null(x$pred)) {
     stop("re-fit the model using 'rfeControl(saveDetails=TRUE)'")
+  }
   prd <- x$pred
 
-  if(best) {
+  if (best) {
     prd <- subset(prd, Variables == x$bestSubset)
     prd <- prd[, colnames(prd) != "Variables"]
     bycol <- "rowIndex"
-  } else bycol <- c("rowIndex", "Variables")
+  } else {
+    bycol <- c("rowIndex", "Variables")
+  }
   ## Temp kludge since I think there is an issue with
   ## how `rfe` saves the data
-  prd <- prd[!duplicated(prd),]
+  prd <- prd[!duplicated(prd), ]
 
-  if(average)  prd <- get_averages(x, prd, bycol)
+  if (average) {
+    prd <- get_averages(x, prd, bycol)
+  }
 
-  if(is.character(prd$obs)  && !is.null(x$obsLevels))
-    prd$obs  <- factor(prd$obs,  levels = x$obsLevels)
-  if(is.character(prd$pred) && !is.null(x$obsLevels))
+  if (is.character(prd$obs) && !is.null(x$obsLevels)) {
+    prd$obs <- factor(prd$obs, levels = x$obsLevels)
+  }
+  if (is.character(prd$pred) && !is.null(x$obsLevels)) {
     prd$pred <- factor(prd$pred, levels = x$obsLevels)
+  }
 
   prd
 }
 
 #' @export
 oob_pred.sbf <- function(x, average = TRUE, ...) {
-
-  if(is.null(x$pred))
+  if (is.null(x$pred)) {
     stop("re-fit the model using 'rfeControl(saveDetails=TRUE)'")
+  }
   prd <- x$pred[names(x$pred) == "predictions"]
   prd <- rbind.fill(prd)
-  prd <- prd[!duplicated(prd),]
+  prd <- prd[!duplicated(prd), ]
 
-  if(average) prd <- get_averages(x, prd, bycol = "rowIndex")
+  if (average) {
+    prd <- get_averages(x, prd, bycol = "rowIndex")
+  }
 
-  if(is.character(prd$obs)  && !is.null(x$obsLevels))
-    prd$obs  <- factor(prd$obs,  levels = x$obsLevels)
-  if(is.character(prd$pred) && !is.null(x$obsLevels))
+  if (is.character(prd$obs) && !is.null(x$obsLevels)) {
+    prd$obs <- factor(prd$obs, levels = x$obsLevels)
+  }
+  if (is.character(prd$pred) && !is.null(x$obsLevels)) {
     prd$pred <- factor(prd$pred, levels = x$obsLevels)
+  }
 
   prd
 }
@@ -98,35 +114,49 @@ oob_pred.list <- function(x, direction = "wide", what = "both", ...) {
   ## check column names and get those common to everything
   cnames <- lapply(oob, colnames)
   cnames <- table(unlist(cnames))
-  if(any(cnames < num)) {
+  if (any(cnames < num)) {
     cnames <- names(cnames[cnames == num])
-    for(i in 1:num) oob[[i]] <- oob[[i]][, cnames]
+    for (i in 1:num) {
+      oob[[i]] <- oob[[i]][, cnames]
+    }
   }
 
   nms <- names(oob)
-  if(is.null(nms)) nms <- well_numbered("Model", length(oob))
-  for(i in seq(along.with = nms)) oob[[i]]$.label <- nms[i]
+  if (is.null(nms)) {
+    nms <- well_numbered("Model", length(oob))
+  }
+  for (i in seq(along.with = nms)) {
+    oob[[i]]$.label <- nms[i]
+  }
   oob <- rbind.fill(oob)
-  if(length(table(table(oob$n))) > 1)
+  if (length(table(table(oob$n))) > 1) {
     stop("Some averages have different sample sizes than others")
-  if(direction == "wide") {
+  }
+  if (direction == "wide") {
     vert_names <- colnames(oob)
-    vert_names <- vert_names[!(vert_names %in% c("rowIndex", "n", "obs", ".label"))]
+    vert_names <- vert_names[
+      !(vert_names %in% c("rowIndex", "n", "obs", ".label"))
+    ]
 
-    oob <- reshape(oob, direction = "wide",
-                   v.names = vert_names,
-                   idvar = c("rowIndex", "obs", "n"),
-                   timevar = ".label")
+    oob <- reshape(
+      oob,
+      direction = "wide",
+      v.names = vert_names,
+      idvar = c("rowIndex", "obs", "n"),
+      timevar = ".label"
+    )
     vert_names <- vert_names[vert_names != "pred"]
     exclude <- vert_names[length(vert_names)]
     oob <- oob[, !grepl(paste0("^", exclude, "\\."), names(oob))]
 
-    if(!is.null(what) && !("both" %in% what)) {
-      if(!is.null(what) && !("pred" %in% what))
+    if (!is.null(what) && !("both" %in% what)) {
+      if (!is.null(what) && !("pred" %in% what)) {
         oob <- oob[, !grepl("^pred\\.", names(oob))]
-      if(!is.null(what) && !("prob" %in% what)) {
-        for(i in vert_names)
+      }
+      if (!is.null(what) && !("prob" %in% what)) {
+        for (i in vert_names) {
           oob <- oob[, !grepl(paste0("^", i, "\\."), names(oob))]
+        }
       }
     }
   }
@@ -136,22 +166,24 @@ oob_pred.list <- function(x, direction = "wide", what = "both", ...) {
 ###################################################################
 ##
 
-get_averages <- function (x, ...) UseMethod("get_averages")
+get_averages <- function(x, ...) UseMethod("get_averages")
 
 #' @export
 get_averages.train <- function(x, prd, bycol = "rowIndex", ...) {
-  if("Regression" %in% x$modelType) {
-    out <- ddply(prd, bycol,
-                 function(x) c(colMeans(x[, c("pred", "obs")])))
+  if ("Regression" %in% x$modelType) {
+    out <- ddply(prd, bycol, function(x) c(colMeans(x[, c("pred", "obs")])))
   } else {
-    out <- ddply(prd, bycol,
-                 function(x) c(pred = char_mode(x$pred),
-                               obs = as.character(x$obs)[1]))
-    if(x$control$classProbs) {
+    out <- ddply(prd, bycol, function(x) {
+      c(pred = char_mode(x$pred), obs = as.character(x$obs)[1])
+    })
+    if (x$control$classProbs) {
       lev <- train_lev(x)
-      cprobs <- ddply(prd, bycol,
-                      function(x, lev) c(colMeans(x[, lev])),
-                      lev = lev)
+      cprobs <- ddply(
+        prd,
+        bycol,
+        function(x, lev) c(colMeans(x[, lev])),
+        lev = lev
+      )
       out <- merge(out, cprobs)
     }
   }
@@ -162,18 +194,20 @@ get_averages.train <- function(x, prd, bycol = "rowIndex", ...) {
 
 #' @export
 get_averages.rfe <- function(x, prd, bycol = "rowIndex", ...) {
-  if(is.null(x$obsLevels)) {
-    out <- ddply(prd, bycol,
-                 function(x) c(colMeans(x[, c("pred", "obs")])))
+  if (is.null(x$obsLevels)) {
+    out <- ddply(prd, bycol, function(x) c(colMeans(x[, c("pred", "obs")])))
   } else {
-    out <- ddply(prd, bycol,
-                 function(x) c(pred = char_mode(x$pred),
-                               obs = as.character(x$obs)[1]))
-    if(all(x$obsLevels %in% colnames(prd))) {
+    out <- ddply(prd, bycol, function(x) {
+      c(pred = char_mode(x$pred), obs = as.character(x$obs)[1])
+    })
+    if (all(x$obsLevels %in% colnames(prd))) {
       lev <- x$obsLevels
-      cprobs <- ddply(prd, bycol,
-                      function(x, lev) c(colMeans(x[, lev])),
-                      lev = lev)
+      cprobs <- ddply(
+        prd,
+        bycol,
+        function(x, lev) c(colMeans(x[, lev])),
+        lev = lev
+      )
       out <- merge(out, cprobs)
     }
   }
@@ -184,18 +218,20 @@ get_averages.rfe <- function(x, prd, bycol = "rowIndex", ...) {
 
 #' @export
 get_averages.sbf <- function(x, prd, bycol = "rowIndex", ...) {
-  if(is.null(x$obsLevels)) {
-    out <- ddply(prd, bycol,
-                 function(x) c(colMeans(x[, c("pred", "obs")])))
+  if (is.null(x$obsLevels)) {
+    out <- ddply(prd, bycol, function(x) c(colMeans(x[, c("pred", "obs")])))
   } else {
-    out <- ddply(prd, bycol,
-                 function(x) c(pred = char_mode(x$pred),
-                               obs = as.character(x$obs)[1]))
-    if(all(x$obsLevels %in% colnames(prd))) {
+    out <- ddply(prd, bycol, function(x) {
+      c(pred = char_mode(x$pred), obs = as.character(x$obs)[1])
+    })
+    if (all(x$obsLevels %in% colnames(prd))) {
       lev <- x$obsLevels
-      cprobs <- ddply(prd, bycol,
-                      function(x, lev) c(colMeans(x[, lev])),
-                      lev = lev)
+      cprobs <- ddply(
+        prd,
+        bycol,
+        function(x, lev) c(colMeans(x[, lev])),
+        lev = lev
+      )
       out <- merge(out, cprobs)
     }
   }
@@ -208,32 +244,32 @@ get_averages.sbf <- function(x, prd, bycol = "rowIndex", ...) {
 ##
 
 char_mode <- function(x, random = TRUE, na.rm = FALSE) {
-  if(na.rm) x <- x[complete.cases(x)]
+  if (na.rm) {
+    x <- x[complete.cases(x)]
+  }
   tab <- table(x)
   tab <- tab[tab == max(tab)]
-  tab <- if(length(tab) > 1 && random) sample(tab, 1) else tab[1]
+  tab <- if (length(tab) > 1 && random) sample(tab, 1) else tab[1]
   as.vector(names(tab))
 }
 
 train_lev <- function(x) {
-  if(x$modelType == "Classification") {
-    if(!is.null(x$modelInfo$levels)) {
+  if (x$modelType == "Classification") {
+    if (!is.null(x$modelInfo$levels)) {
       lev <- x$modelInfo$levels(x$finalModel)
     } else {
-      lev <- if(!isS4(x)) x$finalModel$obsLevel else unique(x$pred$obs)
+      lev <- if (!isS4(x)) x$finalModel$obsLevel else unique(x$pred$obs)
     }
-  } else lev <- NULL
+  } else {
+    lev <- NULL
+  }
   lev
 }
 
 
-corr_mat <- function (object, metric = object$metrics,
-                       ...) {
-  dat <- object$values[, grepl(paste0("~", metric[1]),
-                               colnames(object$values))]
+corr_mat <- function(object, metric = object$metrics, ...) {
+  dat <- object$values[, grepl(paste0("~", metric[1]), colnames(object$values))]
   colnames(dat) <- gsub(paste0("~", metric[1]), "", colnames(dat))
   dat <- cor(dat, ...)
   dat
 }
-
-

--- a/R/heldout.R
+++ b/R/heldout.R
@@ -45,7 +45,9 @@ oob_pred.train <- function(x, best = TRUE, average = TRUE, ...) {
       if (is.character(prd$obs)) {
         prd$obs <- factor(prd$obs, levels = lev)
       }
-      if (is.character(prd$pred)) prd$pred <- factor(prd$pred, levels = lev)
+      if (is.character(prd$pred)) {
+        prd$pred <- factor(prd$pred, levels = lev)
+      }
     }
   }
   prd
@@ -249,7 +251,11 @@ char_mode <- function(x, random = TRUE, na.rm = FALSE) {
   }
   tab <- table(x)
   tab <- tab[tab == max(tab)]
-  tab <- if (length(tab) > 1 && random) sample(tab, 1) else tab[1]
+  if (length(tab) > 1 && random) {
+    tab <- sample(tab, 1)
+  } else {
+    tab <- tab[1]
+  }
   as.vector(names(tab))
 }
 
@@ -258,7 +264,11 @@ train_lev <- function(x) {
     if (!is.null(x$modelInfo$levels)) {
       lev <- x$modelInfo$levels(x$finalModel)
     } else {
-      lev <- if (!isS4(x)) x$finalModel$obsLevel else unique(x$pred$obs)
+      if (!isS4(x)) {
+        lev <- x$finalModel$obsLevel
+      } else {
+        lev <- unique(x$pred$obs)
+      }
     }
   } else {
     lev <- NULL

--- a/R/icr.R
+++ b/R/icr.R
@@ -93,7 +93,11 @@ icr.default <- function(x, y, ...) {
     stop("y must be numeric")
   }
 
-  data <- if (is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
+  if (is.data.frame(x)) {
+    data <- x
+  } else {
+    data <- as.data.frame(x, stringsAsFactors = TRUE)
+  }
   data$y <- y
 
   modelFit <- lm(y ~ ., data = data)

--- a/R/icr.R
+++ b/R/icr.R
@@ -1,6 +1,5 @@
 #' @export
-icr <- function (x, ...) UseMethod("icr")
-
+icr <- function(x, ...) UseMethod("icr")
 
 
 #' Independent Component Regression
@@ -35,131 +34,153 @@ icr <- function (x, ...) UseMethod("icr")
 #' @seealso [fastICA::fastICA()], [preProcess()], [stats::lm()]
 #' @keywords multivariate
 #' @examples
-#' 
+#'
 #' data(BloodBrain)
-#' 
+#'
 #' icrFit <- icr(bbbDescr, logBBB, n.comp = 5)
-#' 
+#'
 #' icrFit
-#' 
+#'
 #' predict(icrFit, bbbDescr[1:5, ])
 #' @export
-icr.formula <- function (formula, data, weights, ...,
-                         subset, na.action, contrasts = NULL)
-{
-    m <- match.call(expand.dots = FALSE)
-    if (is.matrix(eval.parent(m$data)))
-        m$data <- as.data.frame(data, stringsAsFactors = TRUE)
-    m$... <- m$contrasts <- NULL
-    m[[1]] <- as.name("model.frame")
-    m <- eval.parent(m)
-    Terms <- attr(m, "terms")
-    x <- model.matrix(Terms, m, contrasts)
-    cons <- attr(x, "contrast")
-    xint <- match("(Intercept)", colnames(x), nomatch = 0)
-    if (xint > 0)
-        x <- x[, -xint, drop = FALSE]
-    w <- model.weights(m)
-    if (length(w) == 0)
-        w <- rep(1, nrow(x))
-    y <- model.response(m)
+icr.formula <- function(
+  formula,
+  data,
+  weights,
+  ...,
+  subset,
+  na.action,
+  contrasts = NULL
+) {
+  m <- match.call(expand.dots = FALSE)
+  if (is.matrix(eval.parent(m$data))) {
+    m$data <- as.data.frame(data, stringsAsFactors = TRUE)
+  }
+  m$... <- m$contrasts <- NULL
+  m[[1]] <- as.name("model.frame")
+  m <- eval.parent(m)
+  Terms <- attr(m, "terms")
+  x <- model.matrix(Terms, m, contrasts)
+  cons <- attr(x, "contrast")
+  xint <- match("(Intercept)", colnames(x), nomatch = 0)
+  if (xint > 0) {
+    x <- x[, -xint, drop = FALSE]
+  }
+  w <- model.weights(m)
+  if (length(w) == 0) {
+    w <- rep(1, nrow(x))
+  }
+  y <- model.response(m)
 
-    res <- icr.default(x, y, weights = w, thresh = thresh, ...)
-    res$terms <- Terms
-    res$coefnames <- colnames(x)
-    res$na.action <- attr(m, "na.action")
-    res$contrasts <- cons
-    res$xlevels <- .getXlevels(Terms, m)
-    class(res) <- c("icr.formula", "icr")
-    res
+  res <- icr.default(x, y, weights = w, thresh = thresh, ...)
+  res$terms <- Terms
+  res$coefnames <- colnames(x)
+  res$na.action <- attr(m, "na.action")
+  res$contrasts <- cons
+  res$xlevels <- .getXlevels(Terms, m)
+  class(res) <- c("icr.formula", "icr")
+  res
 }
 
 #' @rdname icr.formula
 #' @export
-icr.default <- function(x, y, ...)
-  {
-    xNames <- colnames(x)
-    pp <- preProcess(x, "ica", ...)
-    x <- predict(pp, x)
+icr.default <- function(x, y, ...) {
+  xNames <- colnames(x)
+  pp <- preProcess(x, "ica", ...)
+  x <- predict(pp, x)
 
-    if(is.factor(y)) stop("y must be numeric")
-
-    data <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-    data$y <- y
-
-    modelFit <- lm(y ~ ., data = data)
-
-    out <- list(model = modelFit,
-                ica = pp,
-                dim = dim(x),
-                n.comp = list(...)$n.comp,
-                names = xNames)
-    class(out) <- "icr"
-    out
+  if (is.factor(y)) {
+    stop("y must be numeric")
   }
+
+  data <- if (is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
+  data$y <- y
+
+  modelFit <- lm(y ~ ., data = data)
+
+  out <- list(
+    model = modelFit,
+    ica = pp,
+    dim = dim(x),
+    n.comp = list(...)$n.comp,
+    names = xNames
+  )
+  class(out) <- "icr"
+  out
+}
 
 
 #' @export
-print.icr <- function (x, digits = max(3, getOption("digits") - 3), ...)
-{
+print.icr <- function(x, digits = max(3, getOption("digits") - 3), ...) {
   cat("Independent Component Regression\n\n")
 
   cat("Created from", x$dim[1], "samples and", x$dim[2], "variables\n\n")
 
   if (length(coef(x$model))) {
-        cat("Coefficients:\n")
-        print.default(
-                      format(
-                             coef(x$model),
-                             digits = digits),
-                      print.gap = 2,
-            quote = FALSE)
-    }
-    else cat("No coefficients\n")
+    cat("Coefficients:\n")
+    print.default(
+      format(
+        coef(x$model),
+        digits = digits
+      ),
+      print.gap = 2,
+      quote = FALSE
+    )
+  } else {
+    cat("No coefficients\n")
+  }
   cat("\n")
   invisible(x)
 }
 
 #' @rdname icr.formula
 #' @export
-predict.icr <- function(object, newdata, ...)
-  {
+predict.icr <- function(object, newdata, ...) {
   loadNamespace("fastICA")
-    if (!inherits(object, "icr")) stop("object not of class \"icr\"")
-    if (missing(newdata))
-      {
-        return(fitted(object$model))
-      }  else {
-        if (inherits(object, "icr.formula")) {
-          newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-          rn <- row.names(newdata)
-          Terms <- delete.response(object$terms)
-          m <- model.frame(Terms, newdata, na.action = na.omit,
-                           xlev = object$xlevels)
-          if (!is.null(cl <- attr(Terms, "dataClasses")))
-            .checkMFClasses(cl, m)
-          keep <- match(row.names(m), rn)
-          x <- model.matrix(Terms, m, contrasts = object$contrasts)
-          xint <- match("(Intercept)", colnames(x), nomatch = 0)
-          if (xint > 0)
-            x <- x[, -xint, drop = FALSE]
-        }
-        else {
-          if (is.null(dim(newdata)))
-            dim(newdata) <- c(1, length(newdata))
-          x <- as.matrix(newdata)
-          if (anyNA(x))
-            stop("missing values in 'x'")
-          keep <- seq_len(nrow(x))
-          rn <- rownames(x)
-        }
-      }
-
-    if(!is.null(object$names))
-      {
-        x <- x[, object$names, drop = FALSE]
-      }
-    if(!is.data.frame(x)) x <- as.data.frame(x, stringsAsFactors = TRUE)
-    x <- predict(object$ica, x)
-    predict(object$model, x, ...)
+  if (!inherits(object, "icr")) {
+    stop("object not of class \"icr\"")
   }
+  if (missing(newdata)) {
+    return(fitted(object$model))
+  } else {
+    if (inherits(object, "icr.formula")) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+      rn <- row.names(newdata)
+      Terms <- delete.response(object$terms)
+      m <- model.frame(
+        Terms,
+        newdata,
+        na.action = na.omit,
+        xlev = object$xlevels
+      )
+      if (!is.null(cl <- attr(Terms, "dataClasses"))) {
+        .checkMFClasses(cl, m)
+      }
+      keep <- match(row.names(m), rn)
+      x <- model.matrix(Terms, m, contrasts = object$contrasts)
+      xint <- match("(Intercept)", colnames(x), nomatch = 0)
+      if (xint > 0) {
+        x <- x[, -xint, drop = FALSE]
+      }
+    } else {
+      if (is.null(dim(newdata))) {
+        dim(newdata) <- c(1, length(newdata))
+      }
+      x <- as.matrix(newdata)
+      if (anyNA(x)) {
+        stop("missing values in 'x'")
+      }
+      keep <- seq_len(nrow(x))
+      rn <- rownames(x)
+    }
+  }
+
+  if (!is.null(object$names)) {
+    x <- x[, object$names, drop = FALSE]
+  }
+  if (!is.data.frame(x)) {
+    x <- as.data.frame(x, stringsAsFactors = TRUE)
+  }
+  x <- predict(object$ica, x)
+  predict(object$model, x, ...)
+}

--- a/R/knn3.R
+++ b/R/knn3.R
@@ -45,73 +45,76 @@
 #'   Andre Williams
 #' @keywords multivariate
 #' @examples
-#' 
+#'
 #' irisFit1 <- knn3(Species ~ ., iris)
-#' 
+#'
 #' irisFit2 <- knn3(as.matrix(iris[, -5]), iris[, 5])
-#' 
+#'
 #' data(iris3)
 #' train <- rbind(iris3[1:25, , 1], iris3[1:25, , 2], iris3[1:25, , 3])
 #' test <- rbind(iris3[26:50, , 1], iris3[26:50, , 2], iris3[26:50, , 3])
 #' cl <- factor(c(rep("s", 25), rep("c", 25), rep("v", 25)))
 #' knn3Train(train, test, cl, k = 5, prob = TRUE)
-#' 
+#'
 #' @export
-"knn3" <- function(x, ...)   UseMethod("knn3")
+"knn3" <- function(x, ...) UseMethod("knn3")
 
 #' @export
-knn3.default <- function(x, ...)
-{
-   if(!inherits(x, "formula"))  stop("knn3 only implemented for formula objects")
+knn3.default <- function(x, ...) {
+  if (!inherits(x, "formula")) stop("knn3 only implemented for formula objects")
 }
 
 #' @rdname knn3
 #' @export
-knn3.formula <- function (formula, data, subset, na.action, k = 5, ...)
-{
-
-    if (missing(formula) ||
-        (length(formula) != 3) ||
-        (length(attr(terms(formula[-2], data = data), "term.labels")) < 1) ||
-        (length(attr(terms(formula[-3], data = data), "term.labels")) != 1))
-        stop("formula missing or incorrect")
-    m <- match.call(expand.dots = FALSE)
-    if (is.matrix(eval(m$data, parent.frame())))
-        m$data <- as.data.frame(data, stringsAsFactors = TRUE)
-    m[[1]] <- as.name("model.frame")
-    m$... <- NULL
-    m$k <- NULL
-    m <- eval(m, parent.frame())
-    Terms <- attr(m, "terms")
-    y <- model.extract(m, "response")
-    x <- model.matrix(Terms, m)
-    xvars <- as.character(attr(Terms, "variables"))[-1]
-    if ((yvar <- attr(Terms, "response")) > 0)
-        xvars <- xvars[-yvar]
-    xlev <- if (length(xvars) > 0) {
-        xlev <- lapply(m[xvars], levels)
-        xlev[!sapply(xlev, is.null)]
-    }
-    xint <- match("(Intercept)", colnames(x), nomatch = 0)
-    if (xint > 0)
-        x <- x[, -xint, drop = FALSE]
-    RET <- list(learn = list(y = y, X = x))
-    RET$k <- k
-    RET$terms <- Terms
-    RET$contrasts <- attr(x, "contrasts")
-    RET$xlevels <- xlev
-    RET$theDots <- list(...)
-    attr(RET, "na.message") <- attr(m, "na.message")
-    if (!is.null(attr(m, "na.action")))
-        RET$na.action <- attr(m, "na.action")
-    class(RET) <- "knn3"
-    RET
+knn3.formula <- function(formula, data, subset, na.action, k = 5, ...) {
+  if (
+    missing(formula) ||
+      (length(formula) != 3) ||
+      (length(attr(terms(formula[-2], data = data), "term.labels")) < 1) ||
+      (length(attr(terms(formula[-3], data = data), "term.labels")) != 1)
+  ) {
+    stop("formula missing or incorrect")
+  }
+  m <- match.call(expand.dots = FALSE)
+  if (is.matrix(eval(m$data, parent.frame()))) {
+    m$data <- as.data.frame(data, stringsAsFactors = TRUE)
+  }
+  m[[1]] <- as.name("model.frame")
+  m$... <- NULL
+  m$k <- NULL
+  m <- eval(m, parent.frame())
+  Terms <- attr(m, "terms")
+  y <- model.extract(m, "response")
+  x <- model.matrix(Terms, m)
+  xvars <- as.character(attr(Terms, "variables"))[-1]
+  if ((yvar <- attr(Terms, "response")) > 0) {
+    xvars <- xvars[-yvar]
+  }
+  xlev <- if (length(xvars) > 0) {
+    xlev <- lapply(m[xvars], levels)
+    xlev[!sapply(xlev, is.null)]
+  }
+  xint <- match("(Intercept)", colnames(x), nomatch = 0)
+  if (xint > 0) {
+    x <- x[, -xint, drop = FALSE]
+  }
+  RET <- list(learn = list(y = y, X = x))
+  RET$k <- k
+  RET$terms <- Terms
+  RET$contrasts <- attr(x, "contrasts")
+  RET$xlevels <- xlev
+  RET$theDots <- list(...)
+  attr(RET, "na.message") <- attr(m, "na.message")
+  if (!is.null(attr(m, "na.action"))) {
+    RET$na.action <- attr(m, "na.action")
+  }
+  class(RET) <- "knn3"
+  RET
 }
 
 #' @rdname knn3
 #' @export
-knn3.data.frame <- function(x, y, k = 5, ...)
-{
+knn3.data.frame <- function(x, y, k = 5, ...) {
   x <- as.matrix(x)
   out <- knn3(x, y = y, k = k, ...)
   out
@@ -119,107 +122,141 @@ knn3.data.frame <- function(x, y, k = 5, ...)
 
 #' @rdname knn3
 #' @export
-knn3.matrix <- function(x, y, k = 5, ...)
-{
-    if(!is.matrix(x)) x <- as.matrix(x)
-    if(!is.factor(y)) stop("y must be a factor")
-    RET <- list(learn = list(y = y, X = x))
-    RET$k <- k
-    RET$terms <- NULL
-    RET$contrasts <- NULL
-    RET$xlevels <- NULL
-    RET$theDots <- list(...)
-     class(RET) <- "knn3"
-    RET
+knn3.matrix <- function(x, y, k = 5, ...) {
+  if (!is.matrix(x)) {
+    x <- as.matrix(x)
+  }
+  if (!is.factor(y)) {
+    stop("y must be a factor")
+  }
+  RET <- list(learn = list(y = y, X = x))
+  RET$k <- k
+  RET$terms <- NULL
+  RET$contrasts <- NULL
+  RET$xlevels <- NULL
+  RET$theDots <- list(...)
+  class(RET) <- "knn3"
+  RET
 }
 
 #' @rdname knn3
 #' @export
-print.knn3 <- function (x, ...)
-{
-   cat(x$k, "-nearest neighbor model\n", sep = "")
-   cat("Training set outcome distribution:\n")
-   if(is.factor(x$learn$y)) {
-     print(table(x$learn$y))
-   } else print(summary(x$learn$y))
+print.knn3 <- function(x, ...) {
+  cat(x$k, "-nearest neighbor model\n", sep = "")
+  cat("Training set outcome distribution:\n")
+  if (is.factor(x$learn$y)) {
+    print(table(x$learn$y))
+  } else {
+    print(summary(x$learn$y))
+  }
 
-   cat("\n")
-   invisible(x)
+  cat("\n")
+  invisible(x)
 }
-
 
 
 #' @rdname knn3
 #' @export
-predict.knn3 <- function (object, newdata, type = c("prob", "class"), ...)
-{
-    type <- match.arg(type)
-    if (!inherits(object, "knn3"))
-        stop("object not of class knn3")
-    if (!is.null(Terms <- object$terms)) {
-        if (missing(newdata))
-            newdata <- model.frame(object)
-        else {
-            newdata <- model.frame(as.formula(delete.response(Terms)),
-                newdata, na.action = function(x) x, xlev = object$xlevels)
-        }
-        x <- model.matrix(delete.response(Terms), newdata, contrasts = object$contrasts)
-        xint <- match("(Intercept)", colnames(x), nomatch = 0)
-        if (xint > 0)
-            x <- x[, -xint, drop = FALSE]
+predict.knn3 <- function(object, newdata, type = c("prob", "class"), ...) {
+  type <- match.arg(type)
+  if (!inherits(object, "knn3")) {
+    stop("object not of class knn3")
+  }
+  if (!is.null(Terms <- object$terms)) {
+    if (missing(newdata)) {
+      newdata <- model.frame(object)
+    } else {
+      newdata <- model.frame(
+        as.formula(delete.response(Terms)),
+        newdata,
+        na.action = function(x) x,
+        xlev = object$xlevels
+      )
     }
-    else {
-        x <- as.matrix(newdata)
+    x <- model.matrix(
+      delete.response(Terms),
+      newdata,
+      contrasts = object$contrasts
+    )
+    xint <- match("(Intercept)", colnames(x), nomatch = 0)
+    if (xint > 0) {
+      x <- x[, -xint, drop = FALSE]
     }
+  } else {
+    x <- as.matrix(newdata)
+  }
 
-    argList <- list(
-      train = object$learn$X,
-      test = x,
-      cl = object$learn$y,
-      k = object$k)
+  argList <- list(
+    train = object$learn$X,
+    test = x,
+    cl = object$learn$y,
+    k = object$k
+  )
 
-    if(length(object$theDots) == 0) object$theDots <- list(prob = TRUE)
-    if(any(names(object$theDots) == "prob")) object$theDots$prob <- TRUE
+  if (length(object$theDots) == 0) {
+    object$theDots <- list(prob = TRUE)
+  }
+  if (any(names(object$theDots) == "prob")) {
+    object$theDots$prob <- TRUE
+  }
 
-    argList <- c(argList, object$theDots)
+  argList <- c(argList, object$theDots)
 
-    RET <- do.call(
-      "knn3Train",
-      argList)
+  RET <- do.call(
+    "knn3Train",
+    argList
+  )
 
-    if (type == "prob")
-    {
-       return(attr(RET, "prob"))
-    }  else {
-      RET <- factor(RET, levels = levels(object$learn$y))
-      return(RET)
-    }
+  if (type == "prob") {
+    return(attr(RET, "prob"))
+  } else {
+    RET <- factor(RET, levels = levels(object$learn$y))
+    return(RET)
+  }
 }
 
 #' @rdname knn3
 #' @export
-knn3Train <- function(train, test, cl, k=1, l=0, prob = TRUE, use.all=TRUE)
-{
+knn3Train <- function(
+  train,
+  test,
+  cl,
+  k = 1,
+  l = 0,
+  prob = TRUE,
+  use.all = TRUE
+) {
   train <- as.matrix(train)
-  if(is.null(dim(test))) dim(test) <- c(1, length(test))
+  if (is.null(dim(test))) {
+    dim(test) <- c(1, length(test))
+  }
   test <- as.matrix(test)
-        if(anyNA(train) || anyNA(test) || anyNA(cl))
-            stop("no missing values are allowed")
+  if (anyNA(train) || anyNA(test) || anyNA(cl)) {
+    stop("no missing values are allowed")
+  }
   p <- ncol(train)
   ntr <- nrow(train)
-  if(length(cl) != ntr) stop("'train' and 'class' have different lengths")
-  if(ntr < k) {
-            warning(gettextf("k = %d exceeds number %d of patterns", k, ntr),
-                    domain = NA)
-     k <- ntr
+  if (length(cl) != ntr) {
+    stop("'train' and 'class' have different lengths")
   }
-  if (k < 1)
-            stop(gettextf("k = %d must be at least 1", k), domain = NA)
+  if (ntr < k) {
+    warning(
+      gettextf("k = %d exceeds number %d of patterns", k, ntr),
+      domain = NA
+    )
+    k <- ntr
+  }
+  if (k < 1) {
+    stop(gettextf("k = %d must be at least 1", k), domain = NA)
+  }
   nte <- nrow(test)
-  if(ncol(test) != p) stop("dims of 'test' and 'train differ")
+  if (ncol(test) != p) {
+    stop("dims of 'test' and 'train differ")
+  }
   clf <- as.factor(cl)
   nc <- max(unclass(clf))
-  Z <- .C("knn3",
+  Z <- .C(
+    "knn3",
     as.integer(k),
     as.integer(l),
     as.integer(ntr),
@@ -228,30 +265,34 @@ knn3Train <- function(train, test, cl, k=1, l=0, prob = TRUE, use.all=TRUE)
     as.double(train),
     as.integer(unclass(clf)),
     as.double(test),
-    integer(nc+1),
+    integer(nc + 1),
     as.integer(nc),
     as.integer(FALSE),
     as.integer(use.all),
-    all_vote=double(as.integer(nte*nc))
+    all_vote = double(as.integer(nte * nc))
+  )
 
-    )
+  classProbs <- matrix(Z$all_vote, nrow = nte, ncol = nc, byrow = TRUE)
+  colnames(classProbs) <- sort(unique(clf))
 
-  classProbs <- matrix(Z$all_vote,nrow=nte,ncol=nc,byrow=TRUE)
-  colnames(classProbs)<-sort(unique(clf))
+  bestClass <- function(x) {
+    out <- which(x == max(x))
+    if (length(out) > 1) {
+      out <- sample(out, 1)
+    }
+    out
+  }
 
-   bestClass <- function(x)
-   {
-      out <- which(x == max(x))
-      if(length(out) > 1) out <- sample(out, 1)
-      out
-   }
+  res <- colnames(classProbs)[apply(classProbs, 1, bestClass)]
 
-   res <- colnames(classProbs)[apply(classProbs, 1, bestClass)]
+  votes <- apply(classProbs * k, 1, max)
+  inDoubt <- (votes < l)
+  if (any(inDoubt)) {
+    res[inDoubt] <- NA
+  }
 
-   votes <- apply(classProbs * k, 1, max)
-   inDoubt <- (votes < l)
-   if(any(inDoubt)) res[inDoubt] <- NA
-
-   if (prob) attr(res, "prob") <- classProbs
-   res
+  if (prob) {
+    attr(res, "prob") <- classProbs
+  }
+  res
 }

--- a/R/knn3.R
+++ b/R/knn3.R
@@ -61,7 +61,9 @@
 
 #' @export
 knn3.default <- function(x, ...) {
-  if (!inherits(x, "formula")) stop("knn3 only implemented for formula objects")
+  if (!inherits(x, "formula")) {
+    stop("knn3 only implemented for formula objects")
+  }
 }
 
 #' @rdname knn3
@@ -90,9 +92,11 @@ knn3.formula <- function(formula, data, subset, na.action, k = 5, ...) {
   if ((yvar <- attr(Terms, "response")) > 0) {
     xvars <- xvars[-yvar]
   }
-  xlev <- if (length(xvars) > 0) {
+  if (length(xvars) > 0) {
     xlev <- lapply(m[xvars], levels)
-    xlev[!sapply(xlev, is.null)]
+    xlev <- xlev[!sapply(xlev, is.null)]
+  } else {
+    xlev <- NULL
   }
   xint <- match("(Intercept)", colnames(x), nomatch = 0)
   if (xint > 0) {

--- a/R/knnreg.R
+++ b/R/knnreg.R
@@ -35,43 +35,47 @@
 #'   Chris Keefer
 #' @keywords multivariate
 #' @examples
-#' 
+#'
 #' data(BloodBrain)
-#' 
+#'
 #' inTrain <- createDataPartition(logBBB, p = .8)[[1]]
-#' 
+#'
 #' trainX <- bbbDescr[inTrain, ]
 #' trainY <- logBBB[inTrain]
-#' 
+#'
 #' testX <- bbbDescr[-inTrain, ]
 #' testY <- logBBB[-inTrain]
-#' 
+#'
 #' fit <- knnreg(trainX, trainY, k = 3)
-#' 
+#'
 #' plot(testY, predict(fit, testX))
-#' 
+#'
 #' @export knnreg
-"knnreg" <- function(x, ...)   UseMethod("knnreg")
+"knnreg" <- function(x, ...) UseMethod("knnreg")
 
 #' @rdname knnreg
 #' @export
-knnreg.default <- function(x, ...)
-{
-  if(!any(class(x) %in% "formula"))  stop("knnreg only implemented for formula objects")
+knnreg.default <- function(x, ...) {
+  if (!any(class(x) %in% "formula")) {
+    stop("knnreg only implemented for formula objects")
+  }
 }
 
 #' @rdname knnreg
 #' @export
-knnreg.formula <- function (formula, data, subset, na.action, k = 5, ...)
-{
-  if (missing(formula) ||
+knnreg.formula <- function(formula, data, subset, na.action, k = 5, ...) {
+  if (
+    missing(formula) ||
       (length(formula) != 3) ||
-      (length(attr(terms(formula[-2],  data = data), "term.labels")) < 1) ||
-      (length(attr(terms(formula[-3],  data = data), "term.labels")) != 1))
+      (length(attr(terms(formula[-2], data = data), "term.labels")) < 1) ||
+      (length(attr(terms(formula[-3], data = data), "term.labels")) != 1)
+  ) {
     stop("formula missing or incorrect")
+  }
   m <- match.call(expand.dots = FALSE)
-  if (is.matrix(eval(m$data, parent.frame())))
+  if (is.matrix(eval(m$data, parent.frame()))) {
     m$data <- as.data.frame(data, stringsAsFactors = FALSE)
+  }
   m[[1]] <- as.name("model.frame")
   m$... <- NULL
   m$k <- NULL
@@ -80,15 +84,17 @@ knnreg.formula <- function (formula, data, subset, na.action, k = 5, ...)
   y <- model.extract(m, "response")
   x <- model.matrix(Terms, m)
   xvars <- as.character(attr(Terms, "variables"))[-1]
-  if ((yvar <- attr(Terms, "response")) > 0)
+  if ((yvar <- attr(Terms, "response")) > 0) {
     xvars <- xvars[-yvar]
+  }
   xlev <- if (length(xvars) > 0) {
     xlev <- lapply(m[xvars], levels)
     xlev[!sapply(xlev, is.null)]
   }
   xint <- match("(Intercept)", colnames(x), nomatch = 0)
-  if (xint > 0)
+  if (xint > 0) {
     x <- x[, -xint, drop = FALSE]
+  }
   RET <- list(learn = list(y = y, X = x))
   RET$k <- k
   RET$terms <- Terms
@@ -96,18 +102,22 @@ knnreg.formula <- function (formula, data, subset, na.action, k = 5, ...)
   RET$xlevels <- xlev
   RET$theDots <- list(...)
   attr(RET, "na.message") <- attr(m, "na.message")
-  if (!is.null(attr(m, "na.action")))
+  if (!is.null(attr(m, "na.action"))) {
     RET$na.action <- attr(m, "na.action")
+  }
   class(RET) <- "knnreg"
   RET
 }
 
 #' @rdname knnreg
 #' @export
-knnreg.matrix <- function(x, y, k = 5, ...)
-{
-  if(!is.matrix(x)) x <- as.matrix(x)
-  if(!is.numeric(y)) stop("y must be numeric")
+knnreg.matrix <- function(x, y, k = 5, ...) {
+  if (!is.matrix(x)) {
+    x <- as.matrix(x)
+  }
+  if (!is.numeric(y)) {
+    stop("y must be numeric")
+  }
   RET <- list(learn = list(y = y, X = x))
   RET$k <- k
   RET$terms <- NULL
@@ -119,10 +129,11 @@ knnreg.matrix <- function(x, y, k = 5, ...)
 
 #' @rdname knnreg
 #' @export
-knnreg.data.frame <- function(x, y, k = 5, ...)
-{
+knnreg.data.frame <- function(x, y, k = 5, ...) {
   x <- as.data.frame(x, stringsAsFactors = TRUE)
-  if(!is.numeric(y)) stop("y must be numeric")
+  if (!is.numeric(y)) {
+    stop("y must be numeric")
+  }
   RET <- list(learn = list(y = y, X = x))
   RET$k <- k
   RET$terms <- NULL
@@ -134,41 +145,43 @@ knnreg.data.frame <- function(x, y, k = 5, ...)
 
 #' @rdname knnreg
 #' @export
-print.knnreg <- function (x, ...)
-{
+print.knnreg <- function(x, ...) {
   cat(x$k, "-nearest neighbor regression model\n", sep = "")
   invisible(x)
 }
 
 
-
 #' @rdname knnreg
 #' @export
-predict.knnreg <- function (object, newdata, ...)
-{
-  if (!inherits(object, "knnreg"))
+predict.knnreg <- function(object, newdata, ...) {
+  if (!inherits(object, "knnreg")) {
     stop("object not of class knnreg")
-  if (!is.null(Terms <- object$terms)) {
-    if (missing(newdata))
-      newdata <- model.frame(object)
-    else {
-      newdata <- model.frame(as.formula(delete.response(Terms)),
-                             newdata)
-    }
-    x <- model.matrix(delete.response(Terms), newdata, contrasts = object$contrasts)
-    xint <- match("(Intercept)", colnames(x), nomatch = 0)
-    if (xint > 0)
-      x <- x[, -xint, drop = FALSE]
   }
-  else {
+  if (!is.null(Terms <- object$terms)) {
+    if (missing(newdata)) {
+      newdata <- model.frame(object)
+    } else {
+      newdata <- model.frame(as.formula(delete.response(Terms)), newdata)
+    }
+    x <- model.matrix(
+      delete.response(Terms),
+      newdata,
+      contrasts = object$contrasts
+    )
+    xint <- match("(Intercept)", colnames(x), nomatch = 0)
+    if (xint > 0) {
+      x <- x[, -xint, drop = FALSE]
+    }
+  } else {
     x <- as.matrix(newdata)
   }
 
-  argList <- list(train = object$learn$X,
-                  test = x,
-                  y = object$learn$y,
-                  k = object$k)
-
+  argList <- list(
+    train = object$learn$X,
+    test = x,
+    y = object$learn$y,
+    k = object$k
+  )
 
   RET <- do.call("knnregTrain", argList)
 
@@ -177,37 +190,48 @@ predict.knnreg <- function (object, newdata, ...)
 
 #' @rdname knnreg
 #' @export
-knnregTrain <- function(train, test, y, k = 5, use.all=TRUE)
-{
+knnregTrain <- function(train, test, y, k = 5, use.all = TRUE) {
   train <- as.matrix(train)
-  if(is.null(dim(test))) dim(test) <- c(1, length(test))
+  if (is.null(dim(test))) {
+    dim(test) <- c(1, length(test))
+  }
   test <- as.matrix(test)
-  if(anyNA(train) || anyNA(test) || anyNA(y))
+  if (anyNA(train) || anyNA(test) || anyNA(y)) {
     stop("no missing values are allowed")
+  }
   p <- ncol(train)
   ntr <- nrow(train)
-  if(length(y) != ntr) stop("'train' and 'class' have different lengths")
-  if(ntr < k) {
-    warning(gettextf("k = %d exceeds number %d of patterns", k, ntr),
-            domain = NA)
+  if (length(y) != ntr) {
+    stop("'train' and 'class' have different lengths")
+  }
+  if (ntr < k) {
+    warning(
+      gettextf("k = %d exceeds number %d of patterns", k, ntr),
+      domain = NA
+    )
     k <- ntr
   }
-  if (k < 1)
+  if (k < 1) {
     stop(gettextf("k = %d must be at least 1", k), domain = NA)
+  }
   nte <- nrow(test)
-  if(ncol(test) != p) stop("dims of 'test' and 'train differ")
+  if (ncol(test) != p) {
+    stop("dims of 'test' and 'train differ")
+  }
 
-  Z <- .C("knn3reg",
-          as.integer(k),
-          as.integer(ntr),
-          as.integer(nte),
-          as.integer(p),
-          as.double(train),
-          as.double(y),
-          as.double(test),
-          double(nte),
-          as.integer(FALSE),
-          as.integer(use.all))
+  Z <- .C(
+    "knn3reg",
+    as.integer(k),
+    as.integer(ntr),
+    as.integer(nte),
+    as.integer(p),
+    as.double(train),
+    as.double(y),
+    as.double(test),
+    double(nte),
+    as.integer(FALSE),
+    as.integer(use.all)
+  )
 
   Z[[8]]
 }

--- a/R/knnreg.R
+++ b/R/knnreg.R
@@ -87,9 +87,11 @@ knnreg.formula <- function(formula, data, subset, na.action, k = 5, ...) {
   if ((yvar <- attr(Terms, "response")) > 0) {
     xvars <- xvars[-yvar]
   }
-  xlev <- if (length(xvars) > 0) {
+  if (length(xvars) > 0) {
     xlev <- lapply(m[xvars], levels)
-    xlev[!sapply(xlev, is.null)]
+    xlev <- xlev[!sapply(xlev, is.null)]
+  } else {
+    xlev <- NULL
   }
   xint <- match("(Intercept)", colnames(x), nomatch = 0)
   if (xint > 0) {

--- a/R/lattice.train.R
+++ b/R/lattice.train.R
@@ -197,10 +197,10 @@ stripplot.train <- function(x, data = NULL, metric = x$metric, ...) {
   if (any(tNames %in% colnames(resamp))) {
     theDots <- list(...)
     if (any(names(theDots) == "horizontal")) {
-      formText <- if (theDots$horizontal) {
-        paste(tNames1, "~", mName)
+      if (theDots$horizontal) {
+        formText <- paste(tNames1, "~", mName)
       } else {
-        paste(mName, "~", tNames1)
+        formText <- paste(mName, "~", tNames1)
       }
     } else {
       formText <- paste(tNames1, "~", mName)

--- a/R/lattice.train.R
+++ b/R/lattice.train.R
@@ -1,50 +1,49 @@
 #' @export
-densityplot.train <- function(x,
-                              data = NULL,
-                              metric = x$metric,
-                              ...)
-  {
+densityplot.train <- function(x, data = NULL, metric = x$metric, ...) {
+  if (!is.null(match.call()$data)) {
+    warning("explicit 'data' specification ignored")
+  }
 
-    if (!is.null(match.call()$data))
-        warning("explicit 'data' specification ignored")
+  if (x$control$method %in% c("oob", "LOOCV")) {
+    stop(
+      "Resampling plots cannot be done with leave-out-out CV or out-of-bag resampling"
+    )
+  }
 
-    if(x$control$method %in%  c("oob", "LOOCV"))
-      stop("Resampling plots cannot be done with leave-out-out CV or out-of-bag resampling")
-    
-    resamp <- x$resample
-    tNames <- gsub("^\\.", "", names(x$bestTune))
+  resamp <- x$resample
+  tNames <- gsub("^\\.", "", names(x$bestTune))
 
-    # adapt formula to work with muliple metrics
-    mName <- names(resamp)[names(resamp) %in% metric][1]
-    
-    # Look for constant tuning parameters and remove them
-    numVals <- unlist(
-                      lapply(resamp,
-                             function(u) length(unique(u))))
-    if(any(numVals == 1))
-      {
-        # make sure that these are tuning parameters
+  # adapt formula to work with muliple metrics
+  mName <- names(resamp)[names(resamp) %in% metric][1]
 
-        resamp <- resamp[, numVals > 1, drop = FALSE]
-        tNames <- tNames[tNames %in% names(numVals)[numVals > 1]]
-      }
+  # Look for constant tuning parameters and remove them
+  numVals <- unlist(
+    lapply(resamp, function(u) length(unique(u)))
+  )
+  if (any(numVals == 1)) {
+    # make sure that these are tuning parameters
 
-    # Create the formula based on the data
-    formText <- paste("~", mName)
-    if(any(tNames %in% colnames(resamp)))
-      {
-        formText <- paste(formText,
-                          "|",
-                          paste(
-                                tNames,
-                                collapse = "*"))
-      }
+    resamp <- resamp[, numVals > 1, drop = FALSE]
+    tNames <- tNames[tNames %in% names(numVals)[numVals > 1]]
+  }
 
-    form <- as.formula(formText)
-    
-    densityplot(form, data = resamp, ...)
+  # Create the formula based on the data
+  formText <- paste("~", mName)
+  if (any(tNames %in% colnames(resamp))) {
+    formText <- paste(
+      formText,
+      "|",
+      paste(
+        tNames,
+        collapse = "*"
+      )
+    )
+  }
+
+  form <- as.formula(formText)
+
+  densityplot(form, data = resamp, ...)
 }
-
 
 
 #' Lattice functions for plotting resampling results
@@ -80,11 +79,11 @@ densityplot.train <- function(x,
 #'   [lattice::densityplot()], [lattice::xyplot()], [lattice::stripplot()]
 #' @keywords hplot
 #' @examplesIf !caret:::is_cran_check()
-#' 
-#' 
+#'
+#'
 #' library(mlbench)
 #' data(BostonHousing)
-#' 
+#'
 #' library(rpart)
 #' rpartFit <- train(
 #'   medv ~ .,
@@ -96,183 +95,188 @@ densityplot.train <- function(x,
 #'     returnResamp = "all"
 #'   )
 #' )
-#' 
+#'
 #' densityplot(rpartFit, adjust = 1.25)
-#' 
+#'
 #' xyplot(rpartFit, metric = "Rsquared", type = c("p", "a"))
-#' 
+#'
 #' stripplot(rpartFit, horizontal = FALSE, jitter = TRUE)
-#' 
+#'
 #' @export
 
-histogram.train <- function(x,
-                              data = NULL,
-                              metric = x$metric,
-                              ...)
-  {
+histogram.train <- function(x, data = NULL, metric = x$metric, ...) {
+  if (!is.null(match.call()$data)) {
+    warning("explicit 'data' specification ignored")
+  }
 
-    if (!is.null(match.call()$data))
-        warning("explicit 'data' specification ignored")
+  if (x$control$method %in% c("oob", "LOOCV")) {
+    stop(
+      "Resampling plots cannot be done with leave-out-out CV or out-of-bag resampling"
+    )
+  }
 
-    if(x$control$method %in%  c("oob", "LOOCV"))
-      stop("Resampling plots cannot be done with leave-out-out CV or out-of-bag resampling")
-    
-    resamp <- x$resample
-    tNames <- gsub("^\\.", "", names(x$bestTune))
+  resamp <- x$resample
+  tNames <- gsub("^\\.", "", names(x$bestTune))
 
-    # adapt formula to work with muliple metrics
-    mName <- names(resamp)[names(resamp) %in% metric][1]
-    
-    # Look for constant tuning parameters and remove them
-    numVals <- unlist(
-                      lapply(resamp,
-                             function(u) length(unique(u))))
-    if(any(numVals == 1))
-      {
-        # make sure that these are tuning parameters
+  # adapt formula to work with muliple metrics
+  mName <- names(resamp)[names(resamp) %in% metric][1]
 
-        resamp <- resamp[, numVals > 1, drop = FALSE]
-        tNames <- tNames[tNames %in% names(numVals)[numVals > 1]]
+  # Look for constant tuning parameters and remove them
+  numVals <- unlist(
+    lapply(resamp, function(u) length(unique(u)))
+  )
+  if (any(numVals == 1)) {
+    # make sure that these are tuning parameters
+
+    resamp <- resamp[, numVals > 1, drop = FALSE]
+    tNames <- tNames[tNames %in% names(numVals)[numVals > 1]]
+  }
+
+  # Create the formula based on the data
+  formText <- paste("~", mName)
+  if (any(tNames %in% colnames(resamp))) {
+    formText <- paste(
+      formText,
+      "|",
+      paste(
+        tNames,
+        collapse = "*"
+      )
+    )
+  }
+
+  form <- as.formula(formText)
+
+  histogram(form, data = resamp, ...)
+}
+
+#' @export
+stripplot.train <- function(x, data = NULL, metric = x$metric, ...) {
+  if (!is.null(match.call()$data)) {
+    warning("explicit 'data' specification ignored")
+  }
+
+  if (x$control$method %in% c("oob", "LOOCV")) {
+    stop(
+      "Resampling plots cannot be done with leave-out-out CV or out-of-bag resampling"
+    )
+  }
+
+  resamp <- x$resample
+  tNames <- gsub("^\\.", "", names(x$bestTune))
+
+  # adapt formula to work with muliple metrics
+  mName <- names(resamp)[names(resamp) %in% metric][1]
+
+  # Look for constant tuning parameters and remove them
+  numVals <- unlist(
+    lapply(resamp, function(u) length(unique(u)))
+  )
+  if (any(numVals == 1)) {
+    # make sure that these are tuning parameters
+
+    resamp <- resamp[, numVals > 1, drop = FALSE]
+    tNames <- tNames[tNames %in% names(numVals)[numVals > 1]]
+  }
+
+  # determine which tuning parameter has the most values
+  tNames1 <- names(which.max(numVals[names(numVals) %in% tNames]))
+  tNames2 <- tNames[!(tNames %in% tNames1)]
+
+  # The variable in tNames1 will be converted to a factor, so
+  # we will make sure that numeric data gets changed correctly
+
+  resamp[, tNames1] <- factor(
+    as.character(resamp[, tNames1]),
+    levels = paste(
+      sort(unique(resamp[, tNames1]))
+    )
+  )
+
+  # Create the formula based on the data
+  if (any(tNames %in% colnames(resamp))) {
+    theDots <- list(...)
+    if (any(names(theDots) == "horizontal")) {
+      formText <- if (theDots$horizontal) {
+        paste(tNames1, "~", mName)
+      } else {
+        paste(mName, "~", tNames1)
       }
+    } else {
+      formText <- paste(tNames1, "~", mName)
+    }
 
-    # Create the formula based on the data
+    if (length(tNames2) > 0) {
+      formText <- paste(
+        formText,
+        "|",
+        paste(
+          tNames2,
+          collapse = "*"
+        )
+      )
+    }
+  } else {
     formText <- paste("~", mName)
-    if(any(tNames %in% colnames(resamp)))
-      {
-        formText <- paste(formText,
-                          "|",
-                          paste(
-                                tNames,
-                                collapse = "*"))
-      }
+  }
 
-    form <- as.formula(formText)
-    
-    histogram(form, data = resamp, ...)
+  form <- as.formula(formText)
+
+  stripplot(form, data = resamp, ...)
 }
 
 #' @export
-stripplot.train <- function(x,
-                              data = NULL,
-                              metric = x$metric,
-                              ...)
-  {
-    if (!is.null(match.call()$data))
-        warning("explicit 'data' specification ignored")
+xyplot.train <- function(x, data = NULL, metric = x$metric, ...) {
+  if (!is.null(match.call()$data)) {
+    warning("explicit 'data' specification ignored")
+  }
 
-    if(x$control$method %in%  c("oob", "LOOCV"))
-      stop("Resampling plots cannot be done with leave-out-out CV or out-of-bag resampling")
-    
-    resamp <- x$resample
-    tNames <- gsub("^\\.", "", names(x$bestTune))
+  if (x$control$method %in% c("oob", "LOOCV")) {
+    stop(
+      "Resampling plots cannot be done with leave-out-out CV or out-of-bag resampling"
+    )
+  }
 
-    # adapt formula to work with muliple metrics
-    mName <- names(resamp)[names(resamp) %in% metric][1]
-    
-    # Look for constant tuning parameters and remove them
-    numVals <- unlist(
-                      lapply(resamp,
-                             function(u) length(unique(u))))
-    if(any(numVals == 1))
-      {
-        # make sure that these are tuning parameters
+  resamp <- x$resample
+  tNames <- gsub("^\\.", "", names(x$bestTune))
 
-        resamp <- resamp[, numVals > 1, drop = FALSE]
-        tNames <- tNames[tNames %in% names(numVals)[numVals > 1]]
-      }
+  # adapt formula to work with muliple metrics
+  mName <- names(resamp)[names(resamp) %in% metric][1]
 
-    # determine which tuning parameter has the most values
-    tNames1 <- names(which.max(numVals[names(numVals) %in% tNames]))
-    tNames2 <- tNames[!(tNames %in% tNames1)]
+  # Look for constant tuning parameters and remove them
+  numVals <- unlist(
+    lapply(resamp, function(u) length(unique(u)))
+  )
+  if (any(numVals == 1)) {
+    # make sure that these are tuning parameters
 
-    # The variable in tNames1 will be converted to a factor, so
-    # we will make sure that numeric data gets changed correctly
+    resamp <- resamp[, numVals > 1, drop = FALSE]
+    tNames <- tNames[tNames %in% names(numVals)[numVals > 1]]
+  }
 
-    resamp[,tNames1] <- factor(
-                               as.character(resamp[,tNames1]),
-                               levels = paste(
-                                 sort(unique(resamp[,tNames1]))))
+  # determine which tuning parameter has the most values
+  tNames1 <- names(which.max(numVals[names(numVals) %in% tNames]))
+  tNames2 <- tNames[!(tNames %in% tNames1)]
 
+  # Create the formula based on the data
+  if (any(tNames %in% colnames(resamp))) {
+    formText <- paste(mName, "~", tNames1)
 
+    if (length(tNames2) > 0) {
+      formText <- paste(
+        formText,
+        "|",
+        paste(
+          tNames2,
+          collapse = "*"
+        )
+      )
+    }
+  } else {
+    stop("there must be at least one tuning parameter for a scatter plot")
+  }
 
-    
-    # Create the formula based on the data 
-    if(any(tNames %in% colnames(resamp)))
-      {
-        theDots <- list(...)
-        if(any(names(theDots) == "horizontal"))
-           {
-             formText <- if(theDots$horizontal) paste(tNames1, "~", mName) else paste(mName, "~", tNames1)
-           } else  formText <- paste(tNames1, "~", mName)
-        
-        if(length(tNames2) > 0)
-          {
-            formText <- paste(formText,
-                              "|",
-                              paste(
-                                    tNames2,
-                                    collapse = "*"))
-          }
-        
-      } else formText <- paste("~", mName)
+  form <- as.formula(formText)
 
-    form <- as.formula(formText)
-    
-    stripplot(form, data = resamp, ...)
-}
-
-#' @export
-xyplot.train <- function(x,
-                              data = NULL,
-                              metric = x$metric,
-                              ...)
-  {
-    if (!is.null(match.call()$data))
-        warning("explicit 'data' specification ignored")
-
-    if(x$control$method %in%  c("oob", "LOOCV"))
-      stop("Resampling plots cannot be done with leave-out-out CV or out-of-bag resampling")
-    
-    resamp <- x$resample
-    tNames <- gsub("^\\.", "", names(x$bestTune))
-
-    # adapt formula to work with muliple metrics
-    mName <- names(resamp)[names(resamp) %in% metric][1]
-    
-    # Look for constant tuning parameters and remove them
-    numVals <- unlist(
-                      lapply(resamp,
-                             function(u) length(unique(u))))
-    if(any(numVals == 1))
-      {
-        # make sure that these are tuning parameters
-
-        resamp <- resamp[, numVals > 1, drop = FALSE]
-        tNames <- tNames[tNames %in% names(numVals)[numVals > 1]]
-      }
-
-    # determine which tuning parameter has the most values
-    tNames1 <- names(which.max(numVals[names(numVals) %in% tNames]))
-    tNames2 <- tNames[!(tNames %in% tNames1)]
-
-   
-    # Create the formula based on the data 
-    if(any(tNames %in% colnames(resamp)))
-      {
-        formText <-  paste(mName, "~", tNames1)
-        
-        if(length(tNames2) > 0)
-          {
-            formText <- paste(formText,
-                              "|",
-                              paste(
-                                    tNames2,
-                                    collapse = "*"))
-          }
-        
-      } else stop("there must be at least one tuning parameter for a scatter plot")
-
-    form <- as.formula(formText)
-    
-    xyplot(form, data = resamp, ...)
+  xyplot(form, data = resamp, ...)
 }

--- a/R/learning_curve.R
+++ b/R/learning_curve.R
@@ -84,7 +84,11 @@ learning_curve_dat <- function(
   n <- length(for_model)
 
   resampled <- vector(mode = "list", length = n_size)
-  tested <- if (test_prop > 0) resampled else NULL
+  if (test_prop > 0) {
+    tested <- resampled
+  } else {
+    tested <- NULL
+  }
   apparent <- resampled
   for (i in seq(along.with = proportion)) {
     if (verbose) {
@@ -97,10 +101,10 @@ learning_curve_dat <- function(
         sep = ""
       )
     }
-    in_mod <- if (proportion[i] < 1) {
-      sample(for_model, size = floor(n * proportion[i]))
+    if (proportion[i] < 1) {
+      in_mod <- sample(for_model, size = floor(n * proportion[i]))
     } else {
-      for_model
+      in_mod <- for_model
     }
     mod <- train(
       x = dat[in_mod, colnames(dat) != outcome, drop = FALSE],

--- a/R/learning_curve.R
+++ b/R/learning_curve.R
@@ -36,12 +36,12 @@
 #' @seealso [train()]
 #' @keywords models
 #' @examplesIf !caret:::is_cran_check()
-#' 
+#'
 #' set.seed(1412)
 #' class_dat <- twoClassSim(1000)
-#' 
+#'
 #' ctrl <- trainControl(classProbs = TRUE, summaryFunction = twoClassSummary)
-#' 
+#'
 #' set.seed(29510)
 #' lda_data <-
 #'   learning_curve_dat(dat = class_dat,
@@ -51,73 +51,117 @@
 #'                      method = "lda",
 #'                      metric = "ROC",
 #'                      trControl = ctrl)
-#' 
+#'
 #' ggplot(lda_data, aes(x = Training_Size, y = ROC, color = Data)) +
 #'   geom_smooth(method = loess, span = .8) +
 #'   theme_bw()
-#' 
+#'
 #' @export learning_curve_dat
-learning_curve_dat <- function(dat,
-                              outcome = NULL,
-                              proportion = (1:10)/10,
-                              test_prop = 0,
-                              verbose = TRUE, ...) {
-  if(is.null(outcome))
+learning_curve_dat <- function(
+  dat,
+  outcome = NULL,
+  proportion = (1:10) / 10,
+  test_prop = 0,
+  verbose = TRUE,
+  ...
+) {
+  if (is.null(outcome)) {
     stop("Please give a character stirng for the outcome column name")
+  }
   proportion <- sort(unique(proportion))
   n_size <- length(proportion)
 
-  if(test_prop > 0) {
-    for_model <- createDataPartition(dat[, outcome], p = 1 - test_prop, list = FALSE)
-  } else for_model <- seq_len(nrow(dat))
+  if (test_prop > 0) {
+    for_model <- createDataPartition(
+      dat[, outcome],
+      p = 1 - test_prop,
+      list = FALSE
+    )
+  } else {
+    for_model <- seq_len(nrow(dat))
+  }
 
   n <- length(for_model)
 
   resampled <- vector(mode = "list", length = n_size)
-  tested <- if(test_prop > 0) resampled else NULL
+  tested <- if (test_prop > 0) resampled else NULL
   apparent <- resampled
-  for(i in seq(along.with = proportion)) {
-    if(verbose) cat("Training for ", round(proportion[i]*100, 1),
-                    "% (n = ", floor(n*proportion[i]), ")\n", sep = "")
-    in_mod <- if(proportion[i] < 1) sample(for_model, size = floor(n*proportion[i])) else for_model
-    mod <- train(x = dat[in_mod, colnames(dat) != outcome, drop = FALSE],
-                 y = dat[in_mod, outcome],
-                 ...)
-    if (mod$control$method == "none")
-      stop("`learning_curve_dat` uses resampling so please choose a value of ",
-           "`method` that is not 'none'", call. = FALSE)
+  for (i in seq(along.with = proportion)) {
+    if (verbose) {
+      cat(
+        "Training for ",
+        round(proportion[i] * 100, 1),
+        "% (n = ",
+        floor(n * proportion[i]),
+        ")\n",
+        sep = ""
+      )
+    }
+    in_mod <- if (proportion[i] < 1) {
+      sample(for_model, size = floor(n * proportion[i]))
+    } else {
+      for_model
+    }
+    mod <- train(
+      x = dat[in_mod, colnames(dat) != outcome, drop = FALSE],
+      y = dat[in_mod, outcome],
+      ...
+    )
+    if (mod$control$method == "none") {
+      stop(
+        "`learning_curve_dat` uses resampling so please choose a value of ",
+        "`method` that is not 'none'",
+        call. = FALSE
+      )
+    }
 
-    if(i == 1) perf_names <- mod$perfNames
+    if (i == 1) {
+      perf_names <- mod$perfNames
+    }
     resampled[[i]] <- merge(mod$resample, mod$bestTune)
     resampled[[i]]$Training_Size <- length(in_mod)
 
-    if(test_prop > 0) {
-      if(!mod$control$classProbs) {
-        test_preds <- extractPrediction(list(model = mod),
-                                        testX = dat[-for_model, colnames(dat) != outcome, drop = FALSE],
-                                        testY = dat[-for_model, outcome])
+    if (test_prop > 0) {
+      if (!mod$control$classProbs) {
+        test_preds <- extractPrediction(
+          list(model = mod),
+          testX = dat[-for_model, colnames(dat) != outcome, drop = FALSE],
+          testY = dat[-for_model, outcome]
+        )
       } else {
-        test_preds <- extractProb(list(model = mod),
-                                  testX = dat[-for_model, colnames(dat) != outcome, drop = FALSE],
-                                  testY = dat[-for_model, outcome])
+        test_preds <- extractProb(
+          list(model = mod),
+          testX = dat[-for_model, colnames(dat) != outcome, drop = FALSE],
+          testY = dat[-for_model, outcome]
+        )
       }
-      test_perf <- mod$control$summaryFunction(test_preds, lev = mod$finalModel$obsLevels)
+      test_perf <- mod$control$summaryFunction(
+        test_preds,
+        lev = mod$finalModel$obsLevels
+      )
       test_perf <- as.data.frame(t(test_perf), stringsAsFactors = FALSE)
       test_perf$Training_Size <- length(in_mod)
       tested[[i]] <- test_perf
       try(rm(test_preds, test_perf), silent = TRUE)
     }
 
-    if(!mod$control$classProbs) {
-      app_preds <- extractPrediction(list(model = mod),
-                                     testX = dat[in_mod, colnames(dat) != outcome, drop = FALSE],
-                                     testY = dat[in_mod, outcome])
+    if (!mod$control$classProbs) {
+      app_preds <- extractPrediction(
+        list(model = mod),
+        testX = dat[in_mod, colnames(dat) != outcome, drop = FALSE],
+        testY = dat[in_mod, outcome]
+      )
     } else {
-      app_preds <- extractProb(list(model = mod),
-                               testX = dat[in_mod, colnames(dat) != outcome, drop = FALSE],
-                               testY = dat[in_mod, outcome])
+      app_preds <- extractProb(
+        list(model = mod),
+        testX = dat[in_mod, colnames(dat) != outcome, drop = FALSE],
+        testY = dat[in_mod, outcome]
+      )
     }
-    app_perf <- mod$control$summaryFunction(app_preds, lev = mod$finalModel$obsLevels)
+    app_perf <- mod$control$summaryFunction(
+      app_preds,
+      lev = mod$finalModel$obsLevels
+    )
     app_perf <- as.data.frame(t(app_perf), stringsAsFactors = FALSE)
     app_perf$Training_Size <- length(in_mod)
     apparent[[i]] <- app_perf
@@ -132,7 +176,7 @@ learning_curve_dat <- function(dat,
   apparent <- apparent[, c(perf_names, "Training_Size")]
   apparent$Data <- "Training"
   out <- rbind(resampled, apparent)
-  if(test_prop > 0) {
+  if (test_prop > 0) {
     tested <- do.call("rbind", tested)
     tested <- tested[, c(perf_names, "Training_Size")]
     tested$Data <- "Testing"

--- a/R/lift.R
+++ b/R/lift.R
@@ -161,10 +161,10 @@ lift.formula <- function(
     liftClassVar = rep(form$left, length(probNames)),
     liftProbVar = form$right
   )
-  liftData$liftModelVar <- if (length(probNames) > 1) {
-    form$condition[[length(form$condition)]]
+  if (length(probNames) > 1) {
+    liftData$liftModelVar <- form$condition[[length(form$condition)]]
   } else {
-    probNames
+    liftData$liftModelVar <- probNames
   }
 
   if (length(form$condition) > 0 && any(names(form$condition) != "")) {
@@ -242,7 +242,9 @@ xyplot.lift <- function(x, data = NULL, plot = "gain", values = NULL, ...) {
     if (!any(names(opts) == "xlim")) {
       opts$xlim <- rng
     }
-    if (!any(names(opts) == "panel")) opts$panel <- panel.lift2
+    if (!any(names(opts) == "panel")) {
+      opts$panel <- panel.lift2
+    }
   } else {
     lFormula <- "lift ~ cuts"
     x$data <- x$data[order(x$data$liftModelVar, x$data$cuts), ]
@@ -254,7 +256,9 @@ xyplot.lift <- function(x, data = NULL, plot = "gain", values = NULL, ...) {
     if (!any(names(opts) == "ylab")) {
       opts$ylab <- "Lift"
     }
-    if (!any(names(opts) == "type")) opts$type <- "l"
+    if (!any(names(opts) == "type")) {
+      opts$type <- "l"
+    }
   }
   args <- list(
     x = as.formula(lFormula),
@@ -471,10 +475,10 @@ ggplot.lift <- function(
       ylab("% Samples Found") +
       xlim(rng) +
       ylim(rng)
-    res <- if (nmod == 1) {
-      res + geom_line()
+    if (nmod == 1) {
+      res <- res + geom_line()
     } else {
-      res + geom_line(aes(col = Model))
+      res <- res + geom_line(aes(col = Model))
     }
     if (!is.null(values)) {
       ref_values <- ddply(data$data, .(Model), get_ref_point, v = values)
@@ -530,10 +534,10 @@ ggplot.lift <- function(
     res <- ggplot(data$data, aes(x = cuts, y = lift)) +
       xlab("Cut-Off") +
       ylab("Lift")
-    res <- if (nmod == 1) {
-      res + geom_line()
+    if (nmod == 1) {
+      res <- res + geom_line()
     } else {
-      res + geom_line(aes(col = Model))
+      res <- res + geom_line(aes(col = Model))
     }
   }
   res
@@ -551,12 +555,11 @@ get_ref_point <- function(dat, v, window = 5) {
   for (i in seq(along.with = v)) {
     nearest <- which.min((y - v[i])^2)
     index <- max(1, nearest - window):min(length(y), nearest + window)
-    res$CumTestedPct[i] <-
-      if (length(index) > 2) {
-        approx(y[index], x[index], xout = v[i])$y
-      } else {
-        NA
-      }
+    if (length(index) > 2) {
+      res$CumTestedPct[i] <- approx(y[index], x[index], xout = v[i])$y
+    } else {
+      res$CumTestedPct[i] <- NA
+    }
   }
   res
 }

--- a/R/lift.R
+++ b/R/lift.R
@@ -82,26 +82,26 @@
 #' @seealso [lattice::xyplot()], [lattice::trellis.par.set()]
 #' @keywords hplot
 #' @examples
-#' 
+#'
 #' set.seed(1)
 #' simulated <- data.frame(
 #'   obs = factor(rep(letters[1:2], each = 100)),
 #'   perfect = sort(runif(200), decreasing = TRUE),
 #'   random = runif(200)
 #' )
-#' 
+#'
 #' lift1 <- lift(obs ~ random, data = simulated)
 #' lift1
 #' xyplot(lift1)
-#' 
+#'
 #' lift2 <- lift(obs ~ random + perfect, data = simulated)
 #' lift2
 #' xyplot(lift2, auto.key = list(columns = 2))
-#' 
+#'
 #' xyplot(lift2, auto.key = list(columns = 2), value = c(10, 30))
-#' 
+#'
 #' xyplot(lift2, plot = "lift", auto.key = list(columns = 2))
-#' 
+#'
 #' @export lift
 lift <- function(x, ...) UseMethod("lift")
 
@@ -345,25 +345,25 @@ panel.lift <- function(x, y, ...) {
 #'   [lattice::trellis.par.set()]
 #' @keywords hplot
 #' @examples
-#' 
+#'
 #' set.seed(1)
 #' simulated <- data.frame(
 #'   obs = factor(rep(letters[1:2], each = 100)),
 #'   perfect = sort(runif(200), decreasing = TRUE),
 #'   random = runif(200)
 #' )
-#' 
+#'
 #' regionInfo <- trellis.par.get("reference.line")
 #' regionInfo$col <- "lightblue"
 #' trellis.par.set("reference.line", regionInfo)
-#' 
+#'
 #' lift2 <- lift(obs ~ random + perfect, data = simulated)
 #' lift2
 #' xyplot(lift2, auto.key = list(columns = 2))
-#' 
+#'
 #' ## use a different panel function
 #' xyplot(lift2, panel = panel.lift)
-#' 
+#'
 #' @export panel.lift2
 panel.lift2 <- function(x, y, pct = 0, values = NULL, ...) {
   polyx <- c(0, pct, 100, 0)

--- a/R/maxDissim.R
+++ b/R/maxDissim.R
@@ -35,16 +35,16 @@
 #'   Computational Biology*, 6, 447-457.
 #' @keywords utilities
 #' @examples
-#' 
+#'
 #' example <- function(pct = 1, obj = minDiss, ...)
 #' {
 #'   tmp <- matrix(rnorm(200 * 2), nrow = 200)
-#' 
+#'
 #'   ## start with 15 data points
 #' start <- sample(1:dim(tmp)[1], 15)
 #' base <- tmp[start, ]
 #' pool <- tmp[-start, ]
-#'   
+#'
 #'   ## select 9 for addition
 #' newSamp <- maxDissim(
 #'   base,
@@ -54,9 +54,9 @@
 #'   obj = obj,
 #'   ...
 #' )
-#'   
+#'
 #' allSamp <- c(start, newSamp)
-#'   
+#'
 #' plot(
 #'   tmp[-newSamp, ],
 #'   xlim = extendrange(tmp[, 1]),
@@ -66,73 +66,95 @@
 #'   ylab = "variable 2"
 #' )
 #' points(base, pch = 16, cex = .7)
-#'   
+#'
 #'   for(i in seq(along.with = newSamp))
 #'     points(
-#'            pool[newSamp[i],1], 
-#'            pool[newSamp[i],2], 
-#'            pch = paste(i), col = "darkred") 
+#'            pool[newSamp[i],1],
+#'            pool[newSamp[i],2],
+#'            pch = paste(i), col = "darkred")
 #' }
-#' 
+#'
 #' par(mfrow = c(2, 2))
-#' 
+#'
 #' set.seed(414)
 #' example(1, minDiss)
 #' title("No Random Sampling, Min Score")
-#' 
+#'
 #' set.seed(414)
 #' example(.1, minDiss)
 #' title("10 Pct Random Sampling, Min Score")
-#' 
+#'
 #' set.seed(414)
 #' example(1, sumDiss)
 #' title("No Random Sampling, Sum Score")
-#' 
+#'
 #' set.seed(414)
 #' example(.1, sumDiss)
 #' title("10 Pct Random Sampling, Sum Score")
-#' 
+#'
 #' @export maxDissim
-maxDissim <- function(a, b, n = 2, obj = minDiss, useNames = FALSE, randomFrac = 1, verbose = FALSE, ...) 
-{
+maxDissim <- function(
+  a,
+  b,
+  n = 2,
+  obj = minDiss,
+  useNames = FALSE,
+  randomFrac = 1,
+  verbose = FALSE,
+  ...
+) {
   loadNamespace("proxy")
-  if(nrow(b) < 2) stop("there must be at least 2 samples in b")
-  if(ncol(a) != ncol(b)) stop("a and b must have the same number of columns")
-  if(nrow(b) < n) stop("n must be less than nrow(b)")
-  if(randomFrac > 1 || randomFrac <= 0) stop("randomFrac must be in (0, 1]")
+  if (nrow(b) < 2) {
+    stop("there must be at least 2 samples in b")
+  }
+  if (ncol(a) != ncol(b)) {
+    stop("a and b must have the same number of columns")
+  }
+  if (nrow(b) < n) {
+    stop("n must be less than nrow(b)")
+  }
+  if (randomFrac > 1 || randomFrac <= 0) {
+    stop("randomFrac must be in (0, 1]")
+  }
 
-
-  if(useNames)
-    {
-      if(is.null(rownames(b)))
-        {
-          warning("Cannot use rownames; swithcing to indices")
-          free <- seq_len(nrow(b))
-        } else free <- rownames(b)
-    } else free <- seq_len(nrow(b))
+  if (useNames) {
+    if (is.null(rownames(b))) {
+      warning("Cannot use rownames; swithcing to indices")
+      free <- seq_len(nrow(b))
+    } else {
+      free <- rownames(b)
+    }
+  } else {
+    free <- seq_len(nrow(b))
+  }
 
   inSubset <- NULL
   newA <- a
-  
-  
-  if(verbose) cat("  adding:")
-  for(i in 1:n)
-    {
-      pool <- if(randomFrac == 1) free else sample(free, max(2, floor(randomFrac * length(free))))
-      if(verbose)
-        {
-          cat("\nIter", i, "\n")
-          cat("Number of candidates:", length(free), "\n")
-          cat("Sampling from", length(pool), "samples\n")		
-        }
-      diss <- proxy::dist(newA, b[pool,, drop = FALSE], ...)
-      bNames <- colnames(b)[pool] 
-      tmp <- pool[which.max(apply(diss, 2, obj))]
-      if(verbose)cat("new sample:", tmp, "\n")      
-      inSubset <- c(inSubset, tmp)
-      newA <- rbind(newA, b[tmp,, drop = FALSE])
-      free <- free[!(free %in% inSubset)]
+
+  if (verbose) {
+    cat("  adding:")
+  }
+  for (i in 1:n) {
+    pool <- if (randomFrac == 1) {
+      free
+    } else {
+      sample(free, max(2, floor(randomFrac * length(free))))
     }
+    if (verbose) {
+      cat("\nIter", i, "\n")
+      cat("Number of candidates:", length(free), "\n")
+      cat("Sampling from", length(pool), "samples\n")
+    }
+    diss <- proxy::dist(newA, b[pool, , drop = FALSE], ...)
+    bNames <- colnames(b)[pool]
+    tmp <- pool[which.max(apply(diss, 2, obj))]
+    if (verbose) {
+      cat("new sample:", tmp, "\n")
+    }
+    inSubset <- c(inSubset, tmp)
+    newA <- rbind(newA, b[tmp, , drop = FALSE])
+    free <- free[!(free %in% inSubset)]
+  }
   inSubset
 }
 
@@ -145,49 +167,49 @@ minDiss <- function(u) min(u, na.rm = TRUE)
 sumDiss <- function(u) sum(u, na.rm = TRUE)
 
 
+splitter <- function(x, p = 0.8, start = NULL, ...) {
+  n <- nrow(x)
+  if (is.null(start)) {
+    start <- sample(1:n, 1)
+  }
+  n2 <- n - length(start)
+  m <- ceiling(p * n2)
+  pool <- maxDissim(
+    x[start, , drop = FALSE],
+    x[-start, , drop = FALSE],
+    n = m,
+    ...
+  )
+  c(start, pool)
+}
 
 
-
-
-
-splitter <- function(x, p = 0.8, start = NULL, ...)
-  {
-    n <- nrow(x)
-    if(is.null(start)) start <- sample(1:n, 1)
-    n2 <- n - length(start)
-    m <- ceiling(p * n2)
-    pool <- maxDissim(x[ start,,drop = FALSE],
-                      x[-start,,drop = FALSE],
-                      n = m,
-                      ...)
-    c(start, pool)
+splitByDissim <- function(x, p = 0.8, y = NULL, start = NULL, ...) {
+  if (!is.data.frame(x)) {
+    x <- as.data.frame(x, stringsAsFactors = TRUE)
   }
 
+  if (!is.null(y)) {
+    if (!is.factor(y)) {
+      y <- as.factor(y)
+    }
+    lvl <- levels(y)
 
-splitByDissim <- function(x, p = 0.8, y = NULL, start = NULL, ...)
-  {
-    if(!is.data.frame(x)) x <- as.data.frame(x, stringsAsFactors = TRUE)
-    
-    if(!is.null(y))
-      {
-        if(!is.factor(y)) y <- as.factor(y)
-        lvl <- levels(y)
-        
-        ind <- split(seq(along.with = y), y)
-        ind2 <- lapply(ind, function(x) seq(along.with = x))
-        start2 <- lapply(ind, function(x, start) which(x %in% start),
-                         start = start)
-        for(i in seq(along.with = lvl))
-          {
-            tmp <- splitter(x[ind[[i]],, drop = FALSE],
-                            p = p,
-                            start = start2[[i]],
-                            ...)
-            tmp2 <- ind[[i]][which(ind2[[i]] %in% tmp)]
-            out <- if(i == 1) tmp2 else c(tmp2, out)
-          }
-      } else {
-        out <- splitter(x, p = p, start = start, ...)
-      }
-    out
+    ind <- split(seq(along.with = y), y)
+    ind2 <- lapply(ind, function(x) seq(along.with = x))
+    start2 <- lapply(ind, function(x, start) which(x %in% start), start = start)
+    for (i in seq(along.with = lvl)) {
+      tmp <- splitter(
+        x[ind[[i]], , drop = FALSE],
+        p = p,
+        start = start2[[i]],
+        ...
+      )
+      tmp2 <- ind[[i]][which(ind2[[i]] %in% tmp)]
+      out <- if (i == 1) tmp2 else c(tmp2, out)
+    }
+  } else {
+    out <- splitter(x, p = p, start = start, ...)
   }
+  out
+}

--- a/R/maxDissim.R
+++ b/R/maxDissim.R
@@ -135,10 +135,10 @@ maxDissim <- function(
     cat("  adding:")
   }
   for (i in 1:n) {
-    pool <- if (randomFrac == 1) {
-      free
+    if (randomFrac == 1) {
+      pool <- free
     } else {
-      sample(free, max(2, floor(randomFrac * length(free))))
+      pool <- sample(free, max(2, floor(randomFrac * length(free))))
     }
     if (verbose) {
       cat("\nIter", i, "\n")
@@ -206,7 +206,11 @@ splitByDissim <- function(x, p = 0.8, y = NULL, start = NULL, ...) {
         ...
       )
       tmp2 <- ind[[i]][which(ind2[[i]] %in% tmp)]
-      out <- if (i == 1) tmp2 else c(tmp2, out)
+      if (i == 1) {
+        out <- tmp2
+      } else {
+        out <- c(tmp2, out)
+      }
     }
   } else {
     out <- splitter(x, p = p, start = start, ...)

--- a/R/misc.R
+++ b/R/misc.R
@@ -46,7 +46,11 @@ evalSummaryFunction <- function(
   metric,
   method
 ) {
-  n <- if (inherits(y, "Surv")) nrow(y) else length(y)
+  if (inherits(y, "Surv")) {
+    n <- nrow(y)
+  } else {
+    n <- length(y)
+  }
   ## sample doesn't work for Surv objects
   if (!inherits(y, "Surv")) {
     if (is.factor(y)) {
@@ -334,10 +338,10 @@ smootherFormula <- function(
   suffix <- rep("", ncol(data))
   prefix[numValues > cut] <- paste(smoother, "(", sep = "")
   if (smoother == "s") {
-    suffix[numValues > cut] <- if (df == 0) {
-      ")"
+    if (df == 0) {
+      suffix[numValues > cut] <- ")"
     } else {
-      paste(", df=", df, ")", sep = "")
+      suffix[numValues > cut] <- paste(", df=", df, ")", sep = "")
     }
   }
   if (smoother == "lo") {
@@ -396,7 +400,9 @@ makeTable <- function(x) {
 scrubCall <- function(x) {
   items <- c("x", "y", "data")
   for (i in items) {
-    if (nchar(as.character(x[i])) > 100) x[i] <- "scrubbed"
+    if (nchar(as.character(x[i])) > 100) {
+      x[i] <- "scrubbed"
+    }
   }
   x
 }
@@ -474,7 +480,11 @@ get_resample_perf.gafs <- function(x, ...) {
 #' @export var_seq
 var_seq <- function(p, classification = FALSE, len = 3) {
   if (len == 1) {
-    tuneSeq <- if (!classification) max(floor(p / 3), 1) else floor(sqrt(p))
+    if (!classification) {
+      tuneSeq <- max(floor(p / 3), 1)
+    } else {
+      tuneSeq <- floor(sqrt(p))
+    }
   } else {
     if (p <= len) {
       tuneSeq <- floor(seq(2, to = p, length.out = p))
@@ -610,10 +620,10 @@ check_samp_list <- function(x) {
 getSamplingInfo <- function(method = NULL, regex = TRUE, ...) {
   load(system.file("models", "sampling.RData", package = "caret"))
   if (!is.null(method)) {
-    keepers <- if (regex) {
-      grepl(method, names(sampling_methods), ...)
+    if (regex) {
+      keepers <- grepl(method, names(sampling_methods), ...)
     } else {
-      which(method == names(sampling_methods))[1]
+      keepers <- which(method == names(sampling_methods))[1]
     }
     sampling_methods <- sampling_methods[keepers]
   }
@@ -644,21 +654,29 @@ get_labels <- function(mods, format = FALSE) {
     labs <- gsub("Multivariate Adaptive Regression Spline", "MARS", labs)
     labs[labs == "glmnet"] <- "\\textsf{glmnet}"
   }
-  if (length(mods) > 1) data.frame(model = mods, label = labs) else labs[1]
+  if (length(mods) > 1) {
+    data.frame(model = mods, label = labs)
+  } else {
+    labs[1]
+  }
 }
 
 check_dims <- function(x, y) {
-  n <- if (inherits(y, "Surv")) nrow(y) else length(y)
+  if (inherits(y, "Surv")) {
+    n <- nrow(y)
+  } else {
+    n <- length(y)
+  }
   stopifnot(nrow(x) > 1)
   stopifnot(nrow(x) == n)
   invisible(NULL)
 }
 
 get_model_type <- function(y, method = NULL) {
-  type <- if (class(y)[1] %in% c("numeric", "Surv", "integer")) {
-    "Regression"
+  if (class(y)[1] %in% c("numeric", "Surv", "integer")) {
+    type <- "Regression"
   } else {
-    "Classification"
+    type <- "Classification"
   }
   type
 }
@@ -702,7 +720,11 @@ check_na_conflict <- function(call_obj) {
   has_pp <- grepl("^preProc", names(call_obj))
   if (any(has_pp)) {
     pp <- as.character(call_obj[has_pp])
-    imputes <- if (any(grepl("impute", tolower(pp)))) TRUE else FALSE
+    if (any(grepl("impute", tolower(pp)))) {
+      imputes <- TRUE
+    } else {
+      imputes <- FALSE
+    }
   } else {
     imputes <- FALSE
   }

--- a/R/misc.R
+++ b/R/misc.R
@@ -1,22 +1,30 @@
-subsemble_index <- function(y, J = 2, V = 10){
+subsemble_index <- function(y, J = 2, V = 10) {
   dat <- data.frame(y = y, index = seq(along.with = y))
   outer_index <- sample(1:J, size = nrow(dat), replace = TRUE)
   outer_splits <- vector(mode = "list", length = J)
-  for(i in 1:J) {
-    outer_splits[[i]] <- dat[outer_index == i,]
+  for (i in 1:J) {
+    outer_splits[[i]] <- dat[outer_index == i, ]
     outer_splits[[i]]$label <- well_numbered("Outer", J)[i]
   }
   foo <- function(x, V = 10) {
     inner_index_0 <- createFolds(x$y, k = V, returnTrain = TRUE)
     modeling_index <- lapply(inner_index_0, function(x, y) y[x], y = x$index)
-    holdout_index <- lapply(inner_index_0, function(x, y) y[-unique(x)], y = x$index)
-    names(modeling_index) <- names(holdout_index) <- paste(x$label[1], names(modeling_index), sep = ".")
+    holdout_index <- lapply(
+      inner_index_0,
+      function(x, y) y[-unique(x)],
+      y = x$index
+    )
+    names(modeling_index) <- names(holdout_index) <- paste(
+      x$label[1],
+      names(modeling_index),
+      sep = "."
+    )
     list(model = modeling_index, holdout = holdout_index)
   }
   all_index <- lapply(outer_splits, foo, V = V)
   model_index <- holdout_index <- NULL
-  for(i in seq(along.with = all_index)) {
-    model_index   <- c(model_index,   all_index[[i]]$model)
+  for (i in seq(along.with = all_index)) {
+    model_index <- c(model_index, all_index[[i]]$model)
     holdout_index <- c(holdout_index, all_index[[i]]$holdout)
   }
   list(model = model_index, holdout = holdout_index)
@@ -29,40 +37,56 @@ well_numbered <- function(prefix, items) {
 }
 
 
-evalSummaryFunction <- function(y, wts = NULL, perf = NULL, ctrl, lev, metric, method) {
-  n <- if(inherits(y, "Surv")) nrow(y) else length(y)
+evalSummaryFunction <- function(
+  y,
+  wts = NULL,
+  perf = NULL,
+  ctrl,
+  lev,
+  metric,
+  method
+) {
+  n <- if (inherits(y, "Surv")) nrow(y) else length(y)
   ## sample doesn't work for Surv objects
-  if(!inherits(y, "Surv")) {
-    if(is.factor(y)) {
+  if (!inherits(y, "Surv")) {
+    if (is.factor(y)) {
       values <- rep_len(levels(y), min(10, n))
       pred_samp <- factor(sample(values), levels = lev)
-      obs_samp  <- factor(sample(values), levels = lev)
+      obs_samp <- factor(sample(values), levels = lev)
     } else {
       pred_samp <- sample(y, min(10, n))
       obs_samp <- sample(y, min(10, n))
     }
   } else {
     pred_samp <- y[sample(1:n, min(10, n)), "time"]
-    obs_samp <- y[sample(1:n, min(10, n)),]
+    obs_samp <- y[sample(1:n, min(10, n)), ]
   }
 
   ## get phoney performance to obtain the names of the outputs
   testOutput <- data.frame(pred = pred_samp, obs = obs_samp)
-  if(!is.null(perf)) {
-    if(is.vector(perf))
+  if (!is.null(perf)) {
+    if (is.vector(perf)) {
       stop("`perf` should be a data frame", call. = FALSE)
-    perf <- perf[sample(seq_len(nrow(perf)), nrow(testOutput)),, drop = FALSE]
-    testOutput <-cbind(testOutput, perf)
+    }
+    perf <- perf[sample(seq_len(nrow(perf)), nrow(testOutput)), , drop = FALSE]
+    testOutput <- cbind(testOutput, perf)
   }
 
-  if(ctrl$classProbs) {
-    for(i in seq(along.with = lev)) testOutput[, lev[i]] <- runif(nrow(testOutput))
-    testOutput[, lev] <- t(apply(testOutput[, lev], 1, function(x) x/sum(x)))
+  if (ctrl$classProbs) {
+    for (i in seq(along.with = lev)) {
+      testOutput[, lev[i]] <- runif(nrow(testOutput))
+    }
+    testOutput[, lev] <- t(apply(testOutput[, lev], 1, function(x) x / sum(x)))
   } else {
-    if(metric == "ROC" && !ctrl$classProbs)
-      stop("train()'s use of ROC codes requires class probabilities. See the classProbs option of trainControl()")
+    if (metric == "ROC" && !ctrl$classProbs) {
+      stop(
+        "train()'s use of ROC codes requires class probabilities. See the classProbs option of trainControl()"
+      )
+    }
   }
-  if(!is.null(wts)) testOutput$weights <- sample(wts, min(10, length(wts)))
+  if (!is.null(wts)) {
+    testOutput$weights <- sample(wts, min(10, length(wts)))
+  }
   testOutput$rowIndex <- sample(1:n, size = nrow(testOutput))
   ctrl$summaryFunction(testOutput, lev, method)
 }
@@ -73,47 +97,55 @@ hasDots <- function(grid, info) {
   mnames2 <- paste(".", mnames, sep = "")
   gnames <- sort(colnames(grid))
   out <- all.equal(mnames2, gnames)
-  if(!inherits(out, "logical")) out <- FALSE
+  if (!inherits(out, "logical")) {
+    out <- FALSE
+  }
   out
 }
 
-model2method <- function(x)
-{
+model2method <- function(x) {
   ## There are some disconnecs between the object class and the
   ## method used by train.
 
-  switch(x,
-         randomForest = "rf",
-         rvm = "rvmRadial",
-         ksvm = "svmRadial",
-         lssvm = "lssvmRadial",
-         gausspr = "gaussprRadial",
-         NaiveBayes = "nb",
-         classbagg =, regbagg = "treebag",
-         plsda = "pls",
-         pamrtrained = "pam",
-         x)
+  switch(
+    x,
+    randomForest = "rf",
+    rvm = "rvmRadial",
+    ksvm = "svmRadial",
+    lssvm = "lssvmRadial",
+    gausspr = "gaussprRadial",
+    NaiveBayes = "nb",
+    classbagg = ,
+    regbagg = "treebag",
+    plsda = "pls",
+    pamrtrained = "pam",
+    x
+  )
 }
 
-Kim2009 <- function(n)
-{
-  grid <- matrix(runif(n*10), ncol = 10)
+Kim2009 <- function(n) {
+  grid <- matrix(runif(n * 10), ncol = 10)
   grid <- as.data.frame(grid, stringsAsFactors = TRUE)
   names(grid) = paste("x", 1:10, sep = "")
-  grid$x5 <- floor((grid$x5*3)+1)
-  pred <- -10 + 10 * sin(pi * grid$x1* grid$x2) + 5*(grid$x3 - 0.5)^2 + 5*grid$x4 + 2*grid$x5
-  prob <-  binomial()$linkinv(pred)
+  grid$x5 <- floor((grid$x5 * 3) + 1)
+  pred <- -10 +
+    10 * sin(pi * grid$x1 * grid$x2) +
+    5 * (grid$x3 - 0.5)^2 +
+    5 * grid$x4 +
+    2 * grid$x5
+  prob <- binomial()$linkinv(pred)
   grid$Class <- ifelse(prob <= runif(n), "Class1", "Class2")
-  grid$Class <- factor(grid$Class, levels = c("Class1","Class2"))
+  grid$Class <- factor(grid$Class, levels = c("Class1", "Class2"))
   grid
 }
 
 #' @rdname caret-internal
 #' @export
-gamFormula <- function(data, smoother = "s", cut = 8, y = "y")
-{
+gamFormula <- function(data, smoother = "s", cut = 8, y = "y") {
   nzv <- nearZeroVar(data)
-  if(length(nzv) > 0) data <- data[, -nzv, drop = FALSE]
+  if (length(nzv) > 0) {
+    data <- data[, -nzv, drop = FALSE]
+  }
 
   numValues <- apply(data, 2, function(x) length(unique(x)))
   prefix <- rep("", ncol(data))
@@ -126,40 +158,47 @@ gamFormula <- function(data, smoother = "s", cut = 8, y = "y")
   form
 }
 
-printCall <- function(x)
-{
+printCall <- function(x) {
   call <- paste(deparse(x), collapse = "\n")
   #     cat("\nCall:\n", call, "\n\n", sep = "")
   ## or
 
-  cat("\nCall:\n", truncateText(deparse(x, width.cutoff = 500)), "\n\n", sep = "")
+  cat(
+    "\nCall:\n",
+    truncateText(deparse(x, width.cutoff = 500)),
+    "\n\n",
+    sep = ""
+  )
   invisible(call)
 }
 
 #' @rdname caret-internal
 #' @export
-flatTable <- function(pred, obs)
-{
+flatTable <- function(pred, obs) {
   cells <- as.vector(table(pred, obs))
-  if(length(cells) == 0) cells <- rep(NA, length(levels(obs))^2)
-  names(cells) <- paste(".cell", seq(along.with= cells), sep = "")
+  if (length(cells) == 0) {
+    cells <- rep(NA, length(levels(obs))^2)
+  }
+  names(cells) <- paste(".cell", seq(along.with = cells), sep = "")
   cells
 }
 
 
-prettySeq <- function(x) paste("Resample", gsub(" ", "0", format(seq(along.with = x))), sep = "")
+prettySeq <- function(x) {
+  paste("Resample", gsub(" ", "0", format(seq(along.with = x))), sep = "")
+}
 
 #' @rdname caret-internal
 #' @export
-ipredStats    <- function(x) getModelInfo("treebag", regex = FALSE)[[1]]$oob(x)
+ipredStats <- function(x) getModelInfo("treebag", regex = FALSE)[[1]]$oob(x)
 
 #' @rdname caret-internal
 #' @export
-rfStats       <- function(x) getModelInfo("rf", regex = FALSE)[[1]]$oob(x)
+rfStats <- function(x) getModelInfo("rf", regex = FALSE)[[1]]$oob(x)
 
 #' @rdname caret-internal
 #' @export
-cforestStats  <- function(x) getModelInfo("cforest", regex = FALSE)[[1]]$oob(x)
+cforestStats <- function(x) getModelInfo("cforest", regex = FALSE)[[1]]$oob(x)
 
 #' @rdname caret-internal
 #' @export
@@ -167,46 +206,49 @@ bagEarthStats <- function(x) getModelInfo("bagEarth", regex = FALSE)[[1]]$oob(x)
 
 
 #' @export
-R2 <- function(pred, obs, formula = "corr", na.rm = FALSE)
-{
+R2 <- function(pred, obs, formula = "corr", na.rm = FALSE) {
   n <- sum(complete.cases(pred))
-  switch(formula,
-         corr = cor(obs, pred, use = ifelse(na.rm, "complete.obs", "everything"))^2,
-         traditional = 1 - (sum((obs-pred)^2, na.rm = na.rm)/((n-1)*var(obs, na.rm = na.rm))))
+  switch(
+    formula,
+    corr = cor(obs, pred, use = ifelse(na.rm, "complete.obs", "everything"))^2,
+    traditional = 1 -
+      (sum((obs - pred)^2, na.rm = na.rm) / ((n - 1) * var(obs, na.rm = na.rm)))
+  )
 }
 
 #' @export
-RMSE <- function(pred, obs, na.rm = FALSE) sqrt(mean((pred - obs)^2, na.rm = na.rm))
+RMSE <- function(pred, obs, na.rm = FALSE) {
+  sqrt(mean((pred - obs)^2, na.rm = na.rm))
+}
 
 #' @export
 MAE <- function(pred, obs, na.rm = FALSE) mean(abs(pred - obs), na.rm = na.rm)
 
-partRuleSummary <- function(x)
-{
+partRuleSummary <- function(x) {
   predictors <- all.vars(x$terms)
   predictors <- predictors[predictors != as.character(x$terms[[2]])]
   classes <- levels(x$predictions)
   rules <- capture.output(print(x))
   conditions <- grep("(<=|>=|<|>|=)", rules, value = TRUE)
   classPred <- grep("\\)$", conditions, value = TRUE)
-  varUsage <- data.frame(Var = predictors,
-                         Overall = 0)
-  for(i in seq(along.with = predictors))
-    varUsage$Overall[i] <- sum(grepl(paste("^", predictors[i], sep = ""), conditions))
+  varUsage <- data.frame(Var = predictors, Overall = 0)
+  for (i in seq(along.with = predictors)) {
+    varUsage$Overall[i] <- sum(grepl(
+      paste("^", predictors[i], sep = ""),
+      conditions
+    ))
+  }
 
   numClass <- rep(NA, length(classes))
   names(numClass) <- classes
-  for(i in seq(along.with = classes))
+  for (i in seq(along.with = classes)) {
     numClass[i] <- sum(grepl(paste(":", classes[i], sep = " "), classPred))
+  }
 
-  list(varUsage = varUsage,
-       numCond = length(conditions),
-       classes = numClass)
-
+  list(varUsage = varUsage, numCond = length(conditions), classes = numClass)
 }
 
-ripperRuleSummary <- function(x)
-{
+ripperRuleSummary <- function(x) {
   predictors <- all.vars(x$terms)
   predictors <- predictors[predictors != as.character(x$terms[[2]])]
   classes <- levels(x$predictions)
@@ -214,20 +256,24 @@ ripperRuleSummary <- function(x)
   ## remove header
   rules <- rules[-(1:min(which(rules == "")))]
   conditions <- grep("(<=|>=|<|>|=)", rules, value = TRUE)
-  varUsage <- data.frame(Var = predictors,
-                         Overall = 0)
-  for(i in seq(along.with = predictors))
-    varUsage$Overall[i] <- sum(grepl(paste("\\(", predictors[i], sep = ""), conditions))
+  varUsage <- data.frame(Var = predictors, Overall = 0)
+  for (i in seq(along.with = predictors)) {
+    varUsage$Overall[i] <- sum(grepl(
+      paste("\\(", predictors[i], sep = ""),
+      conditions
+    ))
+  }
 
   numClass <- rep(NA, length(classes))
   names(numClass) <- classes
-  for(i in seq(along.with = classes))
-    numClass[i] <- sum(grepl(paste(x$terms[[2]], "=", classes[i], sep = ""), conditions))
+  for (i in seq(along.with = classes)) {
+    numClass[i] <- sum(grepl(
+      paste(x$terms[[2]], "=", classes[i], sep = ""),
+      conditions
+    ))
+  }
 
-  list(varUsage = varUsage,
-       numCond = length(conditions),
-       classes = numClass)
-
+  list(varUsage = varUsage, numCond = length(conditions), classes = numClass)
 }
 
 ##########################################################################################################
@@ -235,56 +281,76 @@ ripperRuleSummary <- function(x)
 ## splitIndicies takes a number of tasks (n) and divides it into k groups
 ## of roughly equal size. The result is an integer vector of task groups
 
-splitIndicies <- function(n, k)
-{
-  out <- rep(1:k, n%/%k)
-  if(n %% k > 0)  out <- c(out, sample(1:k, n %% k))
+splitIndicies <- function(n, k) {
+  out <- rep(1:k, n %/% k)
+  if (n %% k > 0) {
+    out <- c(out, sample(1:k, n %% k))
+  }
   sort(out)
 }
 
 ## This makes a list of copies of another list
 
-
-repList <- function(x, times = 3, addIndex = FALSE)
-{
+repList <- function(x, times = 3, addIndex = FALSE) {
   out <- vector(mode = "list", length = times)
   out <- lapply(out, function(a, b) b, b = x)
-  if(addIndex) for(i in seq(along.with = out)) out[[i]]$.index <- i
+  if (addIndex) {
+    for (i in seq(along.with = out)) {
+      out[[i]]$.index <- i
+    }
+  }
   out
 }
 
-useMathSymbols <- function(x)
-{
-  if(x == "Rsquared") x <- expression(R^2)
+useMathSymbols <- function(x) {
+  if (x == "Rsquared") {
+    x <- expression(R^2)
+  }
   x
 }
 
-depth2cp <- function(x, depth)
-{
-  out <- approx(x[,"nsplit"], x[,"CP"], depth)$y
-  out[depth > max(x[,"nsplit"])] <- min(x[,"CP"]) * 0.99
+depth2cp <- function(x, depth) {
+  out <- approx(x[, "nsplit"], x[, "CP"], depth)$y
+  out[depth > max(x[, "nsplit"])] <- min(x[, "CP"]) * 0.99
   out
 }
 
-smootherFormula <- function(data, smoother = "s", cut = 10, df = 0, span = 0.5, degree = 1, y = ".outcome")
-{
+smootherFormula <- function(
+  data,
+  smoother = "s",
+  cut = 10,
+  df = 0,
+  span = 0.5,
+  degree = 1,
+  y = ".outcome"
+) {
   nzv <- nearZeroVar(data)
-  if(length(nzv) > 0) data <- data[, -nzv, drop = FALSE]
+  if (length(nzv) > 0) {
+    data <- data[, -nzv, drop = FALSE]
+  }
 
   numValues <- sort(apply(data, 2, function(x) length(unique(x))))
   prefix <- rep("", ncol(data))
   suffix <- rep("", ncol(data))
   prefix[numValues > cut] <- paste(smoother, "(", sep = "")
-  if(smoother == "s")
-  {
-    suffix[numValues > cut] <- if(df == 0) ")" else paste(", df=", df, ")", sep = "")
+  if (smoother == "s") {
+    suffix[numValues > cut] <- if (df == 0) {
+      ")"
+    } else {
+      paste(", df=", df, ")", sep = "")
+    }
   }
-  if(smoother == "lo")
-  {
-    suffix[numValues > cut] <- paste(", span=", span, ",degree=", degree, ")", sep = "")
+  if (smoother == "lo") {
+    suffix[numValues > cut] <- paste(
+      ", span=",
+      span,
+      ",degree=",
+      degree,
+      ")",
+      sep = ""
+    )
   }
-  if(smoother == "rcs")
-  {
+  if (smoother == "rcs") {
     suffix[numValues > cut] <- ")"
   }
   rhs <- paste(prefix, names(numValues), suffix, sep = "")
@@ -293,62 +359,80 @@ smootherFormula <- function(data, smoother = "s", cut = 10, df = 0, span = 0.5, 
   form
 }
 
-varSeq <- function(x)
-{
+varSeq <- function(x) {
   vars <- apply(summary(x)$which, 1, function(x) names(which(x)))
   vars <- lapply(vars, function(x) x[x != "(Intercept)"])
   vars
 }
 
-cranRef <- function(x) paste("{\\tt \\href{http://cran.r-project.org/web/packages/", x, "/index.html}{", x, "}}", sep = "")
-
-makeTable <- function(x)
-{
-  params <- paste("\\code{", as.character(x$parameter), "}", sep = "", collapse = ", ")
-  params <- ifelse(params == "\\code{parameter}", "None", params)
-
-  data.frame(method = as.character(x$model)[1],
-             Package = cranRef(as.character(x$Package)[1]),
-             Parameters = params)
-
-
+cranRef <- function(x) {
+  paste(
+    "{\\tt \\href{http://cran.r-project.org/web/packages/",
+    x,
+    "/index.html}{",
+    x,
+    "}}",
+    sep = ""
+  )
 }
 
-scrubCall <- function(x)
-{
+makeTable <- function(x) {
+  params <- paste(
+    "\\code{",
+    as.character(x$parameter),
+    "}",
+    sep = "",
+    collapse = ", "
+  )
+  params <- ifelse(params == "\\code{parameter}", "None", params)
+
+  data.frame(
+    method = as.character(x$model)[1],
+    Package = cranRef(as.character(x$Package)[1]),
+    Parameters = params
+  )
+}
+
+scrubCall <- function(x) {
   items <- c("x", "y", "data")
-  for(i in items) if(nchar(as.character(x[i])) > 100) x[i] <- "scrubbed"
+  for (i in items) {
+    if (nchar(as.character(x[i])) > 100) x[i] <- "scrubbed"
+  }
   x
 }
 
 
 requireNamespaceQuietStop <- function(package) {
-  if (!requireNamespace(package, quietly = TRUE))
-    stop(paste('package',package,'is required'), call. = FALSE)
+  if (!requireNamespace(package, quietly = TRUE)) {
+    stop(paste('package', package, 'is required'), call. = FALSE)
+  }
 }
 
-get_resample_perf <- function (x, ...) UseMethod("get_resample_perf")
+get_resample_perf <- function(x, ...) UseMethod("get_resample_perf")
 
 #' @export
 get_resample_perf.train <- function(x, ...) {
-  if(x$control$returnResamp == "none")
+  if (x$control$returnResamp == "none") {
     stop("use returnResamp == 'none' in trainControl()", call. = FALSE)
+  }
   out <- merge(x$resample, x$bestTune)
   out[, c(x$perfNames, "Resample")]
 }
 
 #' @export
 get_resample_perf.rfe <- function(x, ...) {
-  if(x$control$returnResamp == "none")
+  if (x$control$returnResamp == "none") {
     stop("use returnResamp == 'none' in trainControl()", call. = FALSE)
+  }
   out <- subset(x$resample, Variables == x$bestSubset)
   out[, c(x$perfNames, "Resample")]
 }
 
 #' @export
 get_resample_perf.sbf <- function(x, ...) {
-  if(x$control$returnResamp == "none")
+  if (x$control$returnResamp == "none") {
     stop("use returnResamp == 'none' in trainControl()", call. = FALSE)
+  }
   x$resample
 }
 
@@ -383,31 +467,35 @@ get_resample_perf.gafs <- function(x, ...) {
 #' @author Max Kuhn
 #' @keywords models
 #' @examples
-#' 
+#'
 #' var_seq(p = 100, len = 10)
 #' var_seq(p = 600, len = 10)
-#' 
+#'
 #' @export var_seq
 var_seq <- function(p, classification = FALSE, len = 3) {
-  if(len == 1) {
-    tuneSeq <- if(!classification) max(floor(p/3), 1) else floor(sqrt(p))
+  if (len == 1) {
+    tuneSeq <- if (!classification) max(floor(p / 3), 1) else floor(sqrt(p))
   } else {
-    if(p <= len)
-    {
+    if (p <= len) {
       tuneSeq <- floor(seq(2, to = p, length.out = p))
     } else {
-      if(p < 500 ) tuneSeq <- floor(seq(2, to = p, length.out = len))
-      else tuneSeq <- floor(2^seq(1, to = log(p, base = 2), length.out = len))
+      if (p < 500) {
+        tuneSeq <- floor(seq(2, to = p, length.out = len))
+      } else {
+        tuneSeq <- floor(2^seq(1, to = log(p, base = 2), length.out = len))
+      }
     }
   }
-  if(any(table(tuneSeq) > 1)) {
+  if (any(table(tuneSeq) > 1)) {
     tuneSeq <- unique(tuneSeq)
     cat(
       "note: only",
       length(tuneSeq),
       "unique complexity parameters in default grid.",
       "Truncating the grid to",
-      length(tuneSeq), ".\n\n")
+      length(tuneSeq),
+      ".\n\n"
+    )
   }
   tuneSeq
 }
@@ -423,33 +511,36 @@ parse_sampling <- function(x, check_install = TRUE) {
   ### func
   ### before_pp (logical)
   x_class <- class(x)[1]
-  if(!(x_class %in% c("character", "function", "list"))) {
-    stop(paste("The sampling argument should be either a",
-               "string, function, or list. See",
-               "http://topepo.github.io/caret/model-training-and-tuning.html"),
-         call. = FALSE)
+  if (!(x_class %in% c("character", "function", "list"))) {
+    stop(
+      paste(
+        "The sampling argument should be either a",
+        "string, function, or list. See",
+        "http://topepo.github.io/caret/model-training-and-tuning.html"
+      ),
+      call. = FALSE
+    )
   }
-  if(x_class == "character") {
+  if (x_class == "character") {
     x <- x[1]
     load(system.file("models", "sampling.RData", package = "caret"))
     s_method <- names(sampling_methods)
-    if(!(x %in% s_method)) {
-      stop("That sampling scheme is not in caret's built-in library",
-           call. = FALSE)
+    if (!(x %in% s_method)) {
+      stop(
+        "That sampling scheme is not in caret's built-in library",
+        call. = FALSE
+      )
     } else {
-      x <- list(name = x,
-                func = sampling_methods[x][[1]],
-                first = TRUE)
+      x <- list(name = x, func = sampling_methods[x][[1]], first = TRUE)
     }
     pkgs <- switch(x$name, rose = "ROSE", smote = "themis", "")
-    if(pkgs != "" && check_install)
+    if (pkgs != "" && check_install) {
       checkInstall(pkgs)
+    }
   } else {
-    if(x_class == "function") {
+    if (x_class == "function") {
       check_samp_func(x)
-      x <- list(name = "custom",
-                func = x,
-                first = TRUE)
+      x <- list(name = "custom", func = x, first = TRUE)
     } else {
       check_samp_list(x)
     }
@@ -459,13 +550,18 @@ parse_sampling <- function(x, check_install = TRUE) {
 
 check_samp_func <- function(x) {
   s_args <- sort(names(formals(x)))
-  if(length(s_args) != 2) {
-    stop("the 'sampling' function should have arguments 'x' and 'y'",
-         call. = FALSE)
+  if (length(s_args) != 2) {
+    stop(
+      "the 'sampling' function should have arguments 'x' and 'y'",
+      call. = FALSE
+    )
   } else {
-    if(!all(s_args == c("x", "y")))
-      stop("the 'sampling' function should have arguments 'x' and 'y'",
-           call. = FALSE)
+    if (!all(s_args == c("x", "y"))) {
+      stop(
+        "the 'sampling' function should have arguments 'x' and 'y'",
+        call. = FALSE
+      )
+    }
   }
   invisible(NULL)
 }
@@ -473,22 +569,31 @@ check_samp_func <- function(x) {
 check_samp_list <- function(x) {
   exp_names <- sort(c("name", "func", "first"))
   x_names <- sort(names(x))
-  if(length(x_names) != length(exp_names)) {
-    stop(paste("the 'sampling' list should have elements",
-               paste(exp_names, sep = "", collapse = ", ")),
-         call. = FALSE)
+  if (length(x_names) != length(exp_names)) {
+    stop(
+      paste(
+        "the 'sampling' list should have elements",
+        paste(exp_names, sep = "", collapse = ", ")
+      ),
+      call. = FALSE
+    )
   } else {
-    if(!all(exp_names == x_names))
-      stop(paste("the 'sampling' list should have elements",
-                 paste(exp_names, sep = "", collapse = ", ")),
-           call. = FALSE)
+    if (!all(exp_names == x_names)) {
+      stop(
+        paste(
+          "the 'sampling' list should have elements",
+          paste(exp_names, sep = "", collapse = ", ")
+        ),
+        call. = FALSE
+      )
+    }
   }
   check_samp_func(x$func)
-  if(!is.logical(x$first))
+  if (!is.logical(x$first)) {
     stop("The element 'first' should be a logical", call. = FALSE)
+  }
   invisible(NULL)
 }
-
 
 
 #' Get sampling info from a train model
@@ -505,14 +610,19 @@ check_samp_list <- function(x) {
 getSamplingInfo <- function(method = NULL, regex = TRUE, ...) {
   load(system.file("models", "sampling.RData", package = "caret"))
   if (!is.null(method)) {
-    keepers <- if (regex)
-      grepl(method, names(sampling_methods), ...) else
-        which(method == names(sampling_methods))[1]
+    keepers <- if (regex) {
+      grepl(method, names(sampling_methods), ...)
+    } else {
+      which(method == names(sampling_methods))[1]
+    }
     sampling_methods <- sampling_methods[keepers]
   }
-  if (length(sampling_methods) == 0)
-    stop("That sampling method is not in caret's built-in library",
-         call. = FALSE)
+  if (length(sampling_methods) == 0) {
+    stop(
+      "That sampling method is not in caret's built-in library",
+      call. = FALSE
+    )
+  }
   sampling_methods
 }
 
@@ -521,8 +631,10 @@ get_labels <- function(mods, format = FALSE) {
   lib_labs <- unlist(lapply(lib, function(x) x$label))
   labs <- mods
   is_match <- mods %in% names(lib)
-  if(any(is_match)) labs[is_match] <- lib_labs[mods[is_match]]
-  if(format) {
+  if (any(is_match)) {
+    labs[is_match] <- lib_labs[mods[is_match]]
+  }
+  if (format) {
     labs <- gsub("-", "--", labs)
     labs <- gsub("with Polynomial Kernel", "(Polynomial)", labs)
     labs <- gsub("with Radial Basis Function Kernel", "(RBF)", labs)
@@ -532,56 +644,80 @@ get_labels <- function(mods, format = FALSE) {
     labs <- gsub("Multivariate Adaptive Regression Spline", "MARS", labs)
     labs[labs == "glmnet"] <- "\\textsf{glmnet}"
   }
-  if(length(mods) > 1) data.frame(model = mods, label = labs) else labs[1]
+  if (length(mods) > 1) data.frame(model = mods, label = labs) else labs[1]
 }
 
 check_dims <- function(x, y) {
-  n <- if(inherits(y, "Surv")) nrow(y) else length(y)
+  n <- if (inherits(y, "Surv")) nrow(y) else length(y)
   stopifnot(nrow(x) > 1)
   stopifnot(nrow(x) == n)
   invisible(NULL)
 }
 
 get_model_type <- function(y, method = NULL) {
-  type <- if(class(y)[1] %in% c("numeric", "Surv", "integer")) "Regression" else "Classification"
+  type <- if (class(y)[1] %in% c("numeric", "Surv", "integer")) {
+    "Regression"
+  } else {
+    "Classification"
+  }
   type
 }
 
 get_range <- function(y) {
-  if(class(y)[1] == "factor") return(NA)
-  if(class(y)[1] %in% c("numeric", "integer")) extendrange(y) else extendrange(y[, "time"])
+  if (class(y)[1] == "factor") {
+    return(NA)
+  }
+  if (class(y)[1] %in% c("numeric", "integer")) {
+    extendrange(y)
+  } else {
+    extendrange(y[, "time"])
+  }
 }
 
 #' @rdname caret-internal
 #' @export
 outcome_conversion <- function(x, lv) {
-  if(is.factor(x) || is.character(x)) {
-    if(!is.null(attributes(lv)) && any(names(attributes(lv)) == "ordered" && attr(lv, "ordered")))
-      x <- ordered(as.character(x), levels = lv) else
-        x <- factor(as.character(x), levels = lv)
+  if (is.factor(x) || is.character(x)) {
+    if (
+      !is.null(attributes(lv)) &&
+        any(names(attributes(lv)) == "ordered" && attr(lv, "ordered"))
+    ) {
+      x <- ordered(as.character(x), levels = lv)
+    } else {
+      x <- factor(as.character(x), levels = lv)
+    }
   }
   x
 }
 
 check_na_conflict <- function(call_obj) {
-
   ## check for na.action info:
-  if("na.action" %in% names(as.list(call_obj))) {
+  if ("na.action" %in% names(as.list(call_obj))) {
     nam <- as.character(call_obj$na.action)
-  } else nam <- "na.fail"
+  } else {
+    nam <- "na.fail"
+  }
 
   ## check for preprocess info:
   has_pp <- grepl("^preProc", names(call_obj))
-  if(any(has_pp)) {
+  if (any(has_pp)) {
     pp <- as.character(call_obj[has_pp])
-    imputes <- if(any(grepl("impute", tolower(pp)))) TRUE else FALSE
-  } else imputes <- FALSE
+    imputes <- if (any(grepl("impute", tolower(pp)))) TRUE else FALSE
+  } else {
+    imputes <- FALSE
+  }
 
-  if(imputes && any(nam %in% c("na.omit", "na.exclude")))
-    warning(paste0("`preProcess` includes an imputation method but missing ",
-                   "data will be eliminated by the formula method using `na.action=",
-                   nam, "`. Consider using `na.actin=na.pass` instead."),
-            call. = FALSE)
+  if (imputes && any(nam %in% c("na.omit", "na.exclude"))) {
+    warning(
+      paste0(
+        "`preProcess` includes an imputation method but missing ",
+        "data will be eliminated by the formula method using `na.action=",
+        nam,
+        "`. Consider using `na.actin=na.pass` instead."
+      ),
+      call. = FALSE
+    )
+  }
   invisible(NULL)
 }
 
@@ -589,10 +725,12 @@ check_na_conflict <- function(call_obj) {
 # in case an object is a sparse matrix or tibble
 # do not use `drop` as an argument
 subset_x <- function(x, ind) {
-  if(is.matrix(x) || is.data.frame(x) || inherits(x, "dgCMatrix"))
-    x <- x[ind,,drop = FALSE] else
-      x <- x[ind,]
-    x
+  if (is.matrix(x) || is.data.frame(x) || inherits(x, "dgCMatrix")) {
+    x <- x[ind, , drop = FALSE]
+  } else {
+    x <- x[ind, ]
+  }
+  x
 }
 
 fail_warning <- function(settings, msg, where = "model fit", iter, verb) {
@@ -601,35 +739,35 @@ fail_warning <- function(settings, msg, where = "model fit", iter, verb) {
     msg <- msg[is_fail]
   }
 
-  if (!is.character(msg))
+  if (!is.character(msg)) {
     msg <- as.character(msg)
+  }
 
-  wrn <- paste(colnames(settings),
-               settings,
-               sep = "=",
-               collapse = ", ")
-  wrn <- paste(where, " failed for ", iter,
-               ": ", wrn, " ", msg, sep = "")
-  if (verb)
+  wrn <- paste(colnames(settings), settings, sep = "=", collapse = ", ")
+  wrn <- paste(where, " failed for ", iter, ": ", wrn, " ", msg, sep = "")
+  if (verb) {
     cat(wrn, "\n")
+  }
 
   warning(wrn, call. = FALSE)
   invisible(wrn)
 }
 
-fill_failed_pred <- function(index, lev, submod){
+fill_failed_pred <- function(index, lev, submod) {
   ## setup a dummy results with NA values for all predictions
   nPred <- length(index)
-  if(!is.null(lev)) {
+  if (!is.null(lev)) {
     predicted <- rep("", nPred)
     predicted[seq(along.with = predicted)] <- NA
   } else {
     predicted <- rep(NA, nPred)
   }
-  if(!is.null(submod)) {
+  if (!is.null(submod)) {
     tmp <- predicted
     predicted <- vector(mode = "list", length = nrow(submod) + 1)
-    for(i in seq(along.with = predicted)) predicted[[i]] <- tmp
+    for (i in seq(along.with = predicted)) {
+      predicted[[i]] <- tmp
+    }
     rm(tmp)
   }
   predicted
@@ -639,68 +777,101 @@ fill_failed_prob <- function(index, lev, submod) {
   probValues <- matrix(NA, nrow = length(index), ncol = length(lev))
   probValues <- as.data.frame(probValues, stringsAsFactors = TRUE)
   colnames(probValues) <- lev
-  if (!is.null(submod))
+  if (!is.null(submod)) {
     probValues <- rep(list(probValues), nrow(submod) + 1L)
+  }
   probValues
 }
 
-optimism_xy <- function(ctrl, x, y, wts, iter, lev, method, mod, predicted, submod, loop) {
+optimism_xy <- function(
+  ctrl,
+  x,
+  y,
+  wts,
+  iter,
+  lev,
+  method,
+  mod,
+  predicted,
+  submod,
+  loop
+) {
   indexExtra <- ctrl$indexExtra[[iter]]
 
-  if(is.null(indexExtra) || inherits(mod, "try-error") || inherits(predicted, "try-error"))
-    return (NULL)
+  if (
+    is.null(indexExtra) ||
+      inherits(mod, "try-error") ||
+      inherits(predicted, "try-error")
+  ) {
+    return(NULL)
+  }
 
   predictedExtra <- lapply(indexExtra, function(index) {
-    pred <- predictionFunction(method = method,
-                               modelFit = mod$fit,
-                               newdata = subset_x(x, index),
-                               preProc = mod$preProc,
-                               param = submod)
+    pred <- predictionFunction(
+      method = method,
+      modelFit = mod$fit,
+      newdata = subset_x(x, index),
+      preProc = mod$preProc,
+      param = submod
+    )
   })
 
-  if(ctrl$classProbs)
+  if (ctrl$classProbs) {
     probValuesExtra <- lapply(indexExtra, function(index) {
-      probFunction(method = method,
-                   modelFit = mod$fit,
-                   newdata = subset_x(x, index),
-                   preProc = mod$preProc,
-                   param = submod)
+      probFunction(
+        method = method,
+        modelFit = mod$fit,
+        newdata = subset_x(x, index),
+        preProc = mod$preProc,
+        param = submod
+      )
     })
-  else
+  } else {
     probValuesExtra <- lapply(indexExtra, function(index) {
       probValues <- matrix(NA, nrow = length(index), ncol = length(lev))
       probValues <- as.data.frame(probValues, stringsAsFactors = TRUE)
       colnames(probValues) <- lev
-      if (!is.null(submod)) probValues <- rep(list(probValues), nrow(submod) + 1L)
+      if (!is.null(submod)) {
+        probValues <- rep(list(probValues), nrow(submod) + 1L)
+      }
       probValues
     })
+  }
 
-  if(!is.null(submod)) {
+  if (!is.null(submod)) {
     allParam <- expandParameters(loop, submod)
-    allParam <- allParam[complete.cases(allParam),, drop = FALSE]
+    allParam <- allParam[complete.cases(allParam), , drop = FALSE]
 
-    predictedExtra <- Map(predictedExtra, indexExtra, f = function(predicted, holdoutIndex) {
-      lapply(predicted, function(x) {
-        y <- y[holdoutIndex]
-        wts <- wts[holdoutIndex]
-        x <- outcome_conversion(x, lv = lev)
-        out <- data.frame(pred = x, obs = y, stringsAsFactors = FALSE)
-        if(!is.null(wts)) out$weights <- wts
-        out$rowIndex <- holdoutIndex
-        out
-      })
-    })
+    predictedExtra <- Map(
+      predictedExtra,
+      indexExtra,
+      f = function(predicted, holdoutIndex) {
+        lapply(predicted, function(x) {
+          y <- y[holdoutIndex]
+          wts <- wts[holdoutIndex]
+          x <- outcome_conversion(x, lv = lev)
+          out <- data.frame(pred = x, obs = y, stringsAsFactors = FALSE)
+          if (!is.null(wts)) {
+            out$weights <- wts
+          }
+          out$rowIndex <- holdoutIndex
+          out
+        })
+      }
+    )
 
-    if(ctrl$classProbs)
-      predictedExtra <- Map(predictedExtra, probValuesExtra, f = function(predicted, probValues) {
-        Map(cbind, predicted, probValues)
-      })
+    if (ctrl$classProbs) {
+      predictedExtra <- Map(
+        predictedExtra,
+        probValuesExtra,
+        f = function(predicted, probValues) {
+          Map(cbind, predicted, probValues)
+        }
+      )
+    }
 
     thisResampleExtra <- lapply(predictedExtra, function(predicted) {
-      lapply(predicted,
-             ctrl$summaryFunction,
-             lev = lev,
-             model = method)
+      lapply(predicted, ctrl$summaryFunction, lev = lev, model = method)
     })
     thisResampleExtra[[1L]] <- lapply(thisResampleExtra[[1L]], function(res) {
       names(res) <- paste0(names(res), "Orig")
@@ -710,83 +881,132 @@ optimism_xy <- function(ctrl, x, y, wts, iter, lev, method, mod, predicted, subm
       names(res) <- paste0(names(res), "Boot")
       res
     })
-    thisResampleExtra <- do.call(cbind, lapply(thisResampleExtra, function(x) do.call(rbind, x)))
+    thisResampleExtra <- do.call(
+      cbind,
+      lapply(thisResampleExtra, function(x) do.call(rbind, x))
+    )
     thisResampleExtra <- cbind(allParam, thisResampleExtra)
-
   } else {
-    thisResampleExtra <- Map(predictedExtra, indexExtra, probValuesExtra,
-                             f = function(predicted, holdoutIndex, probValues) {
-                               if(is.factor(y)) predicted <- outcome_conversion(predicted, lv = lev)
-                               tmp <-  data.frame(pred = predicted,
-                                                  obs = y[holdoutIndex],
-                                                  stringsAsFactors = FALSE)
-                               ## Sometimes the code above does not coerce the first
-                               ## columnn to be named "pred" so force it
-                               names(tmp)[1] <- "pred"
-                               if(!is.null(wts)) tmp$weights <- wts[holdoutIndex]
-                               if(ctrl$classProbs) tmp <- cbind(tmp, probValues)
-                               tmp$rowIndex <- holdoutIndex
-                               ctrl$summaryFunction(tmp, lev = lev, model = method)
-                             })
-    names(thisResampleExtra[[1L]]) <- paste0(names(thisResampleExtra[[1L]]), "Orig")
-    names(thisResampleExtra[[2L]]) <- paste0(names(thisResampleExtra[[2L]]), "Boot")
+    thisResampleExtra <- Map(
+      predictedExtra,
+      indexExtra,
+      probValuesExtra,
+      f = function(predicted, holdoutIndex, probValues) {
+        if (is.factor(y)) {
+          predicted <- outcome_conversion(predicted, lv = lev)
+        }
+        tmp <- data.frame(
+          pred = predicted,
+          obs = y[holdoutIndex],
+          stringsAsFactors = FALSE
+        )
+        ## Sometimes the code above does not coerce the first
+        ## columnn to be named "pred" so force it
+        names(tmp)[1] <- "pred"
+        if (!is.null(wts)) {
+          tmp$weights <- wts[holdoutIndex]
+        }
+        if (ctrl$classProbs) {
+          tmp <- cbind(tmp, probValues)
+        }
+        tmp$rowIndex <- holdoutIndex
+        ctrl$summaryFunction(tmp, lev = lev, model = method)
+      }
+    )
+    names(thisResampleExtra[[1L]]) <- paste0(
+      names(thisResampleExtra[[1L]]),
+      "Orig"
+    )
+    names(thisResampleExtra[[2L]]) <- paste0(
+      names(thisResampleExtra[[2L]]),
+      "Boot"
+    )
     thisResampleExtra <- unlist(unname(thisResampleExtra), recursive = FALSE)
-    thisResampleExtra <- cbind(as.data.frame(t(thisResampleExtra), stringsAsFactors = TRUE), loop)
+    thisResampleExtra <- cbind(
+      as.data.frame(t(thisResampleExtra), stringsAsFactors = TRUE),
+      loop
+    )
   }
 
   # return
   thisResampleExtra
 }
 
-optimism_rec <- function(ctrl, dat, iter, lev, method, mod_rec, predicted, submod, loop) {
+optimism_rec <- function(
+  ctrl,
+  dat,
+  iter,
+  lev,
+  method,
+  mod_rec,
+  predicted,
+  submod,
+  loop
+) {
   indexExtra <- ctrl$indexExtra[[iter]]
 
-  if(is.null(indexExtra) || model_failed(mod_rec) || inherits(predicted, "try-error"))
-    return (NULL)
+  if (
+    is.null(indexExtra) ||
+      model_failed(mod_rec) ||
+      inherits(predicted, "try-error")
+  ) {
+    return(NULL)
+  }
 
   predictedExtra <- lapply(indexExtra, function(index) {
-    pred <- rec_pred(method = method,
-                     object = mod_rec,
-                     newdata = subset_x(dat, index),
-                     param = submod)
+    pred <- rec_pred(
+      method = method,
+      object = mod_rec,
+      newdata = subset_x(dat, index),
+      param = submod
+    )
     trim_values(pred, ctrl, is.null(lev))
   })
 
-  if(ctrl$classProbs)
+  if (ctrl$classProbs) {
     probValuesExtra <- lapply(indexExtra, function(index) {
-      rec_prob(method = method,
-               object = mod_rec,
-               newdata = subset_x(dat, index),
-               param = submod)
+      rec_prob(
+        method = method,
+        object = mod_rec,
+        newdata = subset_x(dat, index),
+        param = submod
+      )
     })
-  else
+  } else {
     probValuesExtra <- lapply(indexExtra, function(index) {
       fill_failed_prob(index, lev, submod)
     })
+  }
 
-  if(!is.null(submod)) {
+  if (!is.null(submod)) {
     allParam <- expandParameters(loop, submod)
-    allParam <- allParam[complete.cases(allParam),, drop = FALSE]
+    allParam <- allParam[complete.cases(allParam), , drop = FALSE]
 
-    predictedExtra <- Map(predictedExtra, indexExtra, f = function(predicted, holdoutIndex) {
-      lapply(predicted, function(x) {
-        x <- outcome_conversion(x, lv = lev)
-        dat <- holdout_rec(mod_rec, dat, holdoutIndex)
-        dat$pred <- x
-        dat
-      })
-    })
+    predictedExtra <- Map(
+      predictedExtra,
+      indexExtra,
+      f = function(predicted, holdoutIndex) {
+        lapply(predicted, function(x) {
+          x <- outcome_conversion(x, lv = lev)
+          dat <- holdout_rec(mod_rec, dat, holdoutIndex)
+          dat$pred <- x
+          dat
+        })
+      }
+    )
 
-    if(ctrl$classProbs)
-      predictedExtra <- Map(predictedExtra, probValuesExtra, f = function(predicted, probValues) {
-        Map(cbind, predicted, probValues)
-      })
+    if (ctrl$classProbs) {
+      predictedExtra <- Map(
+        predictedExtra,
+        probValuesExtra,
+        f = function(predicted, probValues) {
+          Map(cbind, predicted, probValues)
+        }
+      )
+    }
 
     thisResampleExtra <- lapply(predictedExtra, function(predicted) {
-      lapply(predicted,
-             ctrl$summaryFunction,
-             lev = lev,
-             model = method)
+      lapply(predicted, ctrl$summaryFunction, lev = lev, model = method)
     })
     thisResampleExtra[[1L]] <- lapply(thisResampleExtra[[1L]], function(res) {
       names(res) <- paste0(names(res), "Orig")
@@ -796,22 +1016,39 @@ optimism_rec <- function(ctrl, dat, iter, lev, method, mod_rec, predicted, submo
       names(res) <- paste0(names(res), "Boot")
       res
     })
-    thisResampleExtra <- do.call(cbind, lapply(thisResampleExtra, function(x) do.call(rbind, x)))
+    thisResampleExtra <- do.call(
+      cbind,
+      lapply(thisResampleExtra, function(x) do.call(rbind, x))
+    )
     thisResampleExtra <- cbind(allParam, thisResampleExtra)
-
   } else {
-    thisResampleExtra <- Map(predictedExtra, indexExtra, probValuesExtra,
-                             f = function(predicted, holdoutIndex, probValues) {
-                               tmp <- holdout_rec(mod_rec, dat, holdoutIndex)
-                               tmp$pred <- outcome_conversion(predicted, lv = lev)
-                               if(ctrl$classProbs) tmp <- cbind(tmp, probValues)
-                               tmp <- merge(tmp, loop, all = TRUE)
-                               ctrl$summaryFunction(tmp, lev = lev, model = method)
-                             })
-    names(thisResampleExtra[[1L]]) <- paste0(names(thisResampleExtra[[1L]]), "Orig")
-    names(thisResampleExtra[[2L]]) <- paste0(names(thisResampleExtra[[2L]]), "Boot")
+    thisResampleExtra <- Map(
+      predictedExtra,
+      indexExtra,
+      probValuesExtra,
+      f = function(predicted, holdoutIndex, probValues) {
+        tmp <- holdout_rec(mod_rec, dat, holdoutIndex)
+        tmp$pred <- outcome_conversion(predicted, lv = lev)
+        if (ctrl$classProbs) {
+          tmp <- cbind(tmp, probValues)
+        }
+        tmp <- merge(tmp, loop, all = TRUE)
+        ctrl$summaryFunction(tmp, lev = lev, model = method)
+      }
+    )
+    names(thisResampleExtra[[1L]]) <- paste0(
+      names(thisResampleExtra[[1L]]),
+      "Orig"
+    )
+    names(thisResampleExtra[[2L]]) <- paste0(
+      names(thisResampleExtra[[2L]]),
+      "Boot"
+    )
     thisResampleExtra <- unlist(unname(thisResampleExtra), recursive = FALSE)
-    thisResampleExtra <- cbind(as.data.frame(t(thisResampleExtra), stringsAsFactors = TRUE), loop)
+    thisResampleExtra <- cbind(
+      as.data.frame(t(thisResampleExtra), stringsAsFactors = TRUE),
+      loop
+    )
   }
 
   # return
@@ -819,9 +1056,18 @@ optimism_rec <- function(ctrl, dat, iter, lev, method, mod_rec, predicted, submo
 }
 
 parallel_check <- function(pkg, models) {
-  if(any(search() == "package:doMC") && getDoParRegistered() && pkg %in% models$library)
-    warning("Models using ", pkg, " will not work with parallel processing with multicore/doMC",
-            call. = FALSE)
+  if (
+    any(search() == "package:doMC") &&
+      getDoParRegistered() &&
+      pkg %in% models$library
+  ) {
+    warning(
+      "Models using ",
+      pkg,
+      " will not work with parallel processing with multicore/doMC",
+      call. = FALSE
+    )
+  }
   flush.console()
 }
 

--- a/R/modelLookup.R
+++ b/R/modelLookup.R
@@ -99,7 +99,9 @@ checkInstall <- function(pkg) {
   good <- rep(TRUE, length(pkg))
   for (i in seq(along.with = pkg)) {
     tested <- try(find.package(pkg[i]), silent = TRUE)
-    if (inherits(tested, "try-error")) good[i] <- FALSE
+    if (inherits(tested, "try-error")) {
+      good[i] <- FALSE
+    }
   }
   if (any(!good)) {
     pkList <- paste(pkg[!good], collapse = ", ")
@@ -149,10 +151,10 @@ checkInstall <- function(pkg) {
 getModelInfo <- function(model = NULL, regex = TRUE, ...) {
   load(system.file("models", "models.RData", package = "caret"))
   if (!is.null(model)) {
-    keepers <- if (regex) {
-      grepl(model, names(models), ...)
+    if (regex) {
+      keepers <- grepl(model, names(models), ...)
     } else {
-      which(model == names(models))[1]
+      keepers <- which(model == names(models))[1]
     }
     models <- models[keepers]
   }

--- a/R/modelLookup.R
+++ b/R/modelLookup.R
@@ -38,38 +38,53 @@
 #' @seealso [train()], [utils::install.packages()], [base::grepl()]
 #' @keywords utilities
 #' @examplesIf !caret:::is_cran_check()
-#' 
+#'
 #' modelLookup()
 #' modelLookup("gbm")
-#' 
+#'
 #' getModelInfo("pls")
 #' getModelInfo("^pls")
 #' getModelInfo("pls", regex = FALSE)
-#' 
+#'
 #' checkInstall(getModelInfo("pls")$library)
-#' 
+#'
 #' @export modelLookup
-modelLookup <- function(model = NULL){
+modelLookup <- function(model = NULL) {
   load(system.file("models", "models.RData", package = "caret"))
-  if(!is.null(model)){
-    if(!(model %in% names(models))) stop(paste("Model '", method, "' is not in the ",
-                                               "set of existing models", sep = ""))
+  if (!is.null(model)) {
+    if (!(model %in% names(models))) {
+      stop(paste(
+        "Model '",
+        method,
+        "' is not in the ",
+        "set of existing models",
+        sep = ""
+      ))
+    }
 
     models <- models[model == names(models)]
   }
-  out <- lapply(models,
-                function(x) {
-                  out <- x$parameters[, c("parameter", "label")]
-                  out$forReg <- "Regression" %in% x$type
-                  out$forClass <- "Classification" %in% x$type
-                  out$probModel <- !is.null(x$prob)
-                  out
-                })
-  for(i in seq(along.with = out)) out[[i]]$model <- names(models)[i]
+  out <- lapply(models, function(x) {
+    out <- x$parameters[, c("parameter", "label")]
+    out$forReg <- "Regression" %in% x$type
+    out$forClass <- "Classification" %in% x$type
+    out$probModel <- !is.null(x$prob)
+    out
+  })
+  for (i in seq(along.with = out)) {
+    out[[i]]$model <- names(models)[i]
+  }
   out <- do.call("rbind", out)
   rownames(out) <- NULL
-  out <- out[, c('model', 'parameter', 'label', 'forReg', 'forClass', 'probModel')]
-  out[order(out$model),]
+  out <- out[, c(
+    'model',
+    'parameter',
+    'label',
+    'forReg',
+    'forClass',
+    'probModel'
+  )]
+  out[order(out$model), ]
 }
 
 missing_packages <- function(mods = getModelInfo()) {
@@ -80,43 +95,47 @@ missing_packages <- function(mods = getModelInfo()) {
 
 #' @rdname modelLookup
 #' @export
-checkInstall <- function(pkg){
+checkInstall <- function(pkg) {
   good <- rep(TRUE, length(pkg))
-  for(i in seq(along.with = pkg)){
+  for (i in seq(along.with = pkg)) {
     tested <- try(find.package(pkg[i]), silent = TRUE)
     if (inherits(tested, "try-error")) good[i] <- FALSE
   }
-  if(any(!good)){
+  if (any(!good)) {
     pkList <- paste(pkg[!good], collapse = ", ")
-    msg <- paste(sum(!good),
-                 ifelse(sum(!good) > 1, " packages are", " package is"),
-                 " needed and",
-                 ifelse(sum(!good) > 1, " are", " is"),
-                 " not installed. (",
-                 pkList,
-                 "). Would you like to try to install",
-                 ifelse(sum(!good) > 1, " them", " it"),
-                 " now?",
-                 sep = "")
+    msg <- paste(
+      sum(!good),
+      ifelse(sum(!good) > 1, " packages are", " package is"),
+      " needed and",
+      ifelse(sum(!good) > 1, " are", " is"),
+      " not installed. (",
+      pkList,
+      "). Would you like to try to install",
+      ifelse(sum(!good) > 1, " them", " it"),
+      " now?",
+      sep = ""
+    )
 
-    if(interactive()) {
+    if (interactive()) {
       cat(msg)
       bioc <- c("affy", "logicFS", "gpls", "vbmp")
       installChoice <- menu(c("yes", "no"))
-      if(installChoice == 1){
+      if (installChoice == 1) {
         hasBioc <- any(pkg[!good] %in% bioc)
-        if(!hasBioc) {
+        if (!hasBioc) {
           install.packages(pkg[!good])
         } else {
           inst <- pkg[!good]
           instC <- inst[!(inst %in% bioc)]
           instB <- inst[inst %in% bioc]
-          if(length(instC) > 0) install.packages(instC)
+          if (length(instC) > 0) {
+            install.packages(instC)
+          }
           biocLite <- NULL
           source("http://bioconductor.org/biocLite.R")
           biocLite(instB)
         }
-      } else  {
+      } else {
         stop("Required packages are missing: ", pkList, call. = FALSE)
       }
     } else {
@@ -129,10 +148,16 @@ checkInstall <- function(pkg){
 #' @export
 getModelInfo <- function(model = NULL, regex = TRUE, ...) {
   load(system.file("models", "models.RData", package = "caret"))
-  if(!is.null(model)){
-    keepers <- if(regex) grepl(model, names(models), ...) else which(model == names(models))[1]
+  if (!is.null(model)) {
+    keepers <- if (regex) {
+      grepl(model, names(models), ...)
+    } else {
+      which(model == names(models))[1]
+    }
     models <- models[keepers]
   }
-  if(length(models) == 0) stop("That model is not in caret's built-in library")
+  if (length(models) == 0) {
+    stop("That model is not in caret's built-in library")
+  }
   models
 }

--- a/R/nearZeroVar.R
+++ b/R/nearZeroVar.R
@@ -131,7 +131,11 @@ nearZeroVar <- function(
           saveMetrics = FALSE
         )
         ## needed because either integer() or 1, r is never 0
-        if (length(r) > 0 && r == 1) TRUE else FALSE
+        if (length(r) > 0 && r == 1) {
+          TRUE
+        } else {
+          FALSE
+        }
       }
     res <- which(res)
     if (names) {

--- a/R/nearZeroVar.R
+++ b/R/nearZeroVar.R
@@ -64,50 +64,77 @@
 #' @family preprocessing
 #' @keywords utilities
 #' @examples
-#' 
+#'
 #' nearZeroVar(iris[, -5], saveMetrics = TRUE)
-#' 
+#'
 #' data(BloodBrain)
 #' nearZeroVar(bbbDescr)
 #' nearZeroVar(bbbDescr, names = TRUE)
-#' 
+#'
 #' set.seed(1)
 #' classes <- factor(rep(letters[1:3], each = 30))
 #' x <- data.frame(x1 = rep(c(0, 1), 45), x2 = c(rep(0, 10), rep(1, 80)))
-#' 
+#'
 #' lapply(x, table, y = classes)
 #' checkConditionalX(x, classes)
-#' 
+#'
 #' folds <- createFolds(classes, k = 3, returnTrain = TRUE)
 #' x$x3 <- x$x1
 #' x$x3[folds[[1]]] <- 0
-#' 
+#'
 #' checkResamples(folds, x, classes)
-#' 
+#'
 #' @export nearZeroVar
-nearZeroVar <- function (x, freqCut = 95/5, uniqueCut = 10, saveMetrics = FALSE, names = FALSE, foreach = FALSE, allowParallel = TRUE) {
-
-  if(!foreach) return(nzv(x, freqCut = freqCut, uniqueCut = uniqueCut, saveMetrics = saveMetrics, names = names))
+nearZeroVar <- function(
+  x,
+  freqCut = 95 / 5,
+  uniqueCut = 10,
+  saveMetrics = FALSE,
+  names = FALSE,
+  foreach = FALSE,
+  allowParallel = TRUE
+) {
+  if (!foreach) {
+    return(nzv(
+      x,
+      freqCut = freqCut,
+      uniqueCut = uniqueCut,
+      saveMetrics = saveMetrics,
+      names = names
+    ))
+  }
 
   `%op%` <- getOper(foreach && allowParallel && getDoParWorkers() > 1)
 
-  if(saveMetrics) {
-    res <- foreach(name = colnames(x), .combine=rbind) %op% {
-      r <- nzv(x[[name]], freqCut = freqCut, uniqueCut = uniqueCut, saveMetrics = TRUE)
-      r[,"column" ] <-  name
-      r
-    }
+  if (saveMetrics) {
+    res <- foreach(name = colnames(x), .combine = rbind) %op%
+      {
+        r <- nzv(
+          x[[name]],
+          freqCut = freqCut,
+          uniqueCut = uniqueCut,
+          saveMetrics = TRUE
+        )
+        r[, "column"] <- name
+        r
+      }
     res <- res[, c(5, 1, 2, 3, 4)]
     rownames(res) <- as.character(res$column)
     res$column <- NULL
   } else {
-    res <- foreach(name = colnames(x), .combine=c) %op% {
-      r <- nzv(x[[name]], freqCut = freqCut, uniqueCut = uniqueCut, saveMetrics = FALSE)
-      ## needed because either integer() or 1, r is never 0
-      if (length(r) > 0 && r == 1) TRUE else FALSE
-    }
+    res <- foreach(name = colnames(x), .combine = c) %op%
+      {
+        r <- nzv(
+          x[[name]],
+          freqCut = freqCut,
+          uniqueCut = uniqueCut,
+          saveMetrics = FALSE
+        )
+        ## needed because either integer() or 1, r is never 0
+        if (length(r) > 0 && r == 1) TRUE else FALSE
+      }
     res <- which(res)
-    if(names){
+    if (names) {
       res <- colnames(x)[res]
     }
   }
@@ -115,58 +142,67 @@ nearZeroVar <- function (x, freqCut = 95/5, uniqueCut = 10, saveMetrics = FALSE,
 }
 
 #' @export
-nzv <- function (x, freqCut = 95/5, uniqueCut = 10, saveMetrics = FALSE, names = FALSE)
-{
-  if (is.null(dim(x))) x <- matrix(x, ncol = 1)
-  freqRatio <- apply(x, 2, function(data)
-  {
+nzv <- function(
+  x,
+  freqCut = 95 / 5,
+  uniqueCut = 10,
+  saveMetrics = FALSE,
+  names = FALSE
+) {
+  if (is.null(dim(x))) {
+    x <- matrix(x, ncol = 1)
+  }
+  freqRatio <- apply(x, 2, function(data) {
     t <- table(data[!is.na(data)])
     if (length(t) <= 1) {
-      return(0);
+      return(0)
     }
-    w <- which.max(t);
-    return(max(t, na.rm=TRUE)/max(t[-w], na.rm=TRUE))
+    w <- which.max(t)
+    return(max(t, na.rm = TRUE) / max(t[-w], na.rm = TRUE))
   })
   lunique <- apply(x, 2, function(data) length(unique(data[!is.na(data)])))
   percentUnique <- 100 * lunique / apply(x, 2, length)
   zeroVar <- (lunique == 1) | apply(x, 2, function(data) all(is.na(data)))
-  if (saveMetrics)
-  {
-    out <- data.frame(freqRatio = freqRatio,
-                      percentUnique = percentUnique,
-                      zeroVar = zeroVar,
-                      nzv = (freqRatio > freqCut & percentUnique <= uniqueCut) | zeroVar)
-  }
-  else {
+  if (saveMetrics) {
+    out <- data.frame(
+      freqRatio = freqRatio,
+      percentUnique = percentUnique,
+      zeroVar = zeroVar,
+      nzv = (freqRatio > freqCut & percentUnique <= uniqueCut) | zeroVar
+    )
+  } else {
     out <- which((freqRatio > freqCut & percentUnique <= uniqueCut) | zeroVar)
     names(out) <- NULL
-    if(names){
+    if (names) {
       out <- colnames(x)[out]
     }
   }
   out
 }
 
-zeroVar <- function(x)
-{
-  x <- x[,colnames(x) != ".outcome", drop = FALSE]
+zeroVar <- function(x) {
+  x <- x[, colnames(x) != ".outcome", drop = FALSE]
   which(apply(x, 2, function(x) length(unique(x)) < 2))
 }
 
 #' @rdname nearZeroVar
 #' @export
-checkConditionalX <- function(x, y)
-{
+checkConditionalX <- function(x, y) {
   x$.outcome <- y
   unique(unlist(dlply(x, .(.outcome), zeroVar)))
 }
 
 #' @rdname nearZeroVar
 #' @export
-checkResamples <- function(index, x, y)
-{
-  if(!is.factor(y)) stop("y must be a factor")
-  if(length(levels(y)) < 2) stop("y must have at least 2 levels")
-  wrap <- function(index, x, y) checkConditionalX(x[index,,drop=FALSE], y[index])
+checkResamples <- function(index, x, y) {
+  if (!is.factor(y)) {
+    stop("y must be a factor")
+  }
+  if (length(levels(y)) < 2) {
+    stop("y must have at least 2 levels")
+  }
+  wrap <- function(index, x, y) {
+    checkConditionalX(x[index, , drop = FALSE], y[index])
+  }
   unique(unlist(lapply(index, wrap, x = x, y = y)))
 }

--- a/R/negPredValue.R
+++ b/R/negPredValue.R
@@ -1,69 +1,82 @@
 #' @rdname sensitivity
 #' @export
-negPredValue <- 
-  function(data, ...){
+negPredValue <-
+  function(data, ...) {
     UseMethod("negPredValue")
   }
 
 #' @rdname sensitivity
 #' @export
 "negPredValue.default" <-
-function(data, reference, negative = levels(reference)[2], prevalence = NULL, ...)
-{
-   if(!is.factor(reference) || !is.factor(data)) 
+  function(
+    data,
+    reference,
+    negative = levels(reference)[2],
+    prevalence = NULL,
+    ...
+  ) {
+    if (!is.factor(reference) || !is.factor(data)) {
       stop("input data must be a factor")
-   
-   if(length(unique(c(levels(reference), levels(data)))) != 2)
-      stop("input data must have the same two levels")   
+    }
 
-   lvls <- levels(data) 
-   if(is.null(prevalence)) prevalence <- mean(reference == lvls[lvls != negative])
-   sens <- sensitivity(data, reference, lvls[lvls != negative])
-   spec <- specificity(data, reference, negative)
-   (spec * (1-prevalence))/(((1-sens)*prevalence) + ((spec)*(1-prevalence)))
-}
+    if (length(unique(c(levels(reference), levels(data)))) != 2) {
+      stop("input data must have the same two levels")
+    }
+
+    lvls <- levels(data)
+    if (is.null(prevalence)) {
+      prevalence <- mean(reference == lvls[lvls != negative])
+    }
+    sens <- sensitivity(data, reference, lvls[lvls != negative])
+    spec <- specificity(data, reference, negative)
+    (spec * (1 - prevalence)) /
+      (((1 - sens) * prevalence) + ((spec) * (1 - prevalence)))
+  }
 
 #' @rdname sensitivity
 #' @export
 "negPredValue.table" <-
-  function(data, negative = rownames(data)[-1], prevalence = NULL, ...)
-{
-  ## "truth" in columns, predictions in rows
-  if(!all.equal(nrow(data), ncol(data))) stop("the table must have nrow = ncol")
-  if(!all.equal(rownames(data), colnames(data))) stop("the table must the same groups in the same order")
+  function(data, negative = rownames(data)[-1], prevalence = NULL, ...) {
+    ## "truth" in columns, predictions in rows
+    if (!all.equal(nrow(data), ncol(data))) {
+      stop("the table must have nrow = ncol")
+    }
+    if (!all.equal(rownames(data), colnames(data))) {
+      stop("the table must the same groups in the same order")
+    }
 
-  if(nrow(data) > 2)
-    {
+    if (nrow(data) > 2) {
       tmp <- data
       data <- matrix(NA, 2, 2)
-      
-     colnames(data) <- rownames(data) <- c("pos", "neg")
+
+      colnames(data) <- rownames(data) <- c("pos", "neg")
       negCol <- which(colnames(tmp) %in% negative)
       posCol <- which(!(colnames(tmp) %in% negative))
-      
+
       data[1, 1] <- sum(tmp[posCol, posCol])
       data[1, 2] <- sum(tmp[posCol, negCol])
-      data[2, 1] <- sum(tmp[negCol, posCol])      
+      data[2, 1] <- sum(tmp[negCol, posCol])
       data[2, 2] <- sum(tmp[negCol, negCol])
       data <- as.table(data)
       negative <- "neg"
       rm(tmp)
     }
 
-  positive <- colnames(data)[colnames(data) != negative]
-  if(is.null(prevalence)) prevalence <- sum(data[, positive])/sum(data)
-  
-  sens <- sensitivity(data, positive)
-  spec <- specificity(data, negative)
-  (spec * (1-prevalence))/(((1-sens)*prevalence) + ((spec)*(1-prevalence)))
+    positive <- colnames(data)[colnames(data) != negative]
+    if (is.null(prevalence)) {
+      prevalence <- sum(data[, positive]) / sum(data)
+    }
 
-}
+    sens <- sensitivity(data, positive)
+    spec <- specificity(data, negative)
+    (spec * (1 - prevalence)) /
+      (((1 - sens) * prevalence) + ((spec) * (1 - prevalence)))
+  }
 
 #' @rdname sensitivity
 #' @export
 "negPredValue.matrix" <-
-  function(data, negative = rownames(data)[-1], prevalence = NULL, ...)
-{
-  data <- as.table(data)
-  negPredValue.table(data, prevalence = prevalence)
-}
+  function(data, negative = rownames(data)[-1], prevalence = NULL, ...) {
+    data <- as.table(data)
+    negPredValue.table(data, prevalence = prevalence)
+  }

--- a/R/panel.needle.R
+++ b/R/panel.needle.R
@@ -21,38 +21,69 @@
 #' @keywords graphs
 #' @export panel.needle
 "panel.needle" <-
-  function (x, y, horizontal = TRUE, 
-            pch = if (is.null(groups)) dot.symbol$pch else sup.symbol$pch, 
-            col = if (is.null(groups)) dot.symbol$col else sup.symbol$col, 
-            lty = dot.line$lty, lwd = dot.line$lwd, col.line = dot.line$col, 
-            levels.fos = NULL, groups = NULL, ...) 
-  {
+  function(
+    x,
+    y,
+    horizontal = TRUE,
+    pch = if (is.null(groups)) dot.symbol$pch else sup.symbol$pch,
+    col = if (is.null(groups)) dot.symbol$col else sup.symbol$col,
+    lty = dot.line$lty,
+    lwd = dot.line$lwd,
+    col.line = dot.line$col,
+    levels.fos = NULL,
+    groups = NULL,
+    ...
+  ) {
     #adapted from panel.dotplot in lattice
     x <- as.numeric(x)
     y <- as.numeric(y)
     dot.line <- trellis.par.get("dot.line")
     dot.symbol <- trellis.par.get("dot.symbol")
     sup.symbol <- trellis.par.get("superpose.symbol")
-    
+
     if (horizontal) {
-      yscale <- extendrange(y, f = 0.2)   
-      if (is.null(levels.fos)) levels.fos <- floor(yscale[2]) - ceiling(yscale[1]) + 1
-      panel.abline(v = 0, col =1, lty = 1, lwd = 1)
+      yscale <- extendrange(y, f = 0.2)
+      if (is.null(levels.fos)) {
+        levels.fos <- floor(yscale[2]) - ceiling(yscale[1]) + 1
+      }
+      panel.abline(v = 0, col = 1, lty = 1, lwd = 1)
       pch <- rep(pch, length(x))
       pch <- ifelse(x == 0, NA, pch)
-      
-      for(i in seq(along.with=x)) lsegments(x[i], y[i], 0, y[i])
-      if (is.null(groups)) 
+
+      for (i in seq(along.with = x)) {
+        lsegments(x[i], y[i], 0, y[i])
+      }
+      if (is.null(groups)) {
         panel.xyplot(x = x, y = y, col = col, pch = pch, ...)
-      else panel.superpose(x = x, y = y, groups = groups, col = col, pch = pch, ...)        
-    }
-    else {
+      } else {
+        panel.superpose(
+          x = x,
+          y = y,
+          groups = groups,
+          col = col,
+          pch = pch,
+          ...
+        )
+      }
+    } else {
       xscale <- extendrange(x, f = 0.2)
-      if (is.null(levels.fos)) levels.fos <- floor(xscale[2]) - ceiling(xscale[1]) + 1
+      if (is.null(levels.fos)) {
+        levels.fos <- floor(xscale[2]) - ceiling(xscale[1]) + 1
+      }
       panel.abline(h = 0, col = col.line, lty = lty, lwd = lwd)
       pch <- rep(pch, length(x))
       pch <- ifelse(x == 0, NA, pch)
-      if (is.null(groups))panel.xyplot(x = x, y = y, col = col, pch = pch, ...)
-      else panel.superpose(x = x, y = y, groups = groups, col = col, pch = pch, ...)
+      if (is.null(groups)) {
+        panel.xyplot(x = x, y = y, col = col, pch = pch, ...)
+      } else {
+        panel.superpose(
+          x = x,
+          y = y,
+          groups = groups,
+          col = col,
+          pch = pch,
+          ...
+        )
+      }
     }
   }

--- a/R/pcaNNet.R
+++ b/R/pcaNNet.R
@@ -2,7 +2,6 @@
 # check predict method with formula interface
 # how to handle variable imp?
 
-
 #' Neural Networks with a Principal Component Step
 #'
 #' Run PCA on a dataset, then use it in a neural network model
@@ -53,7 +52,7 @@
 #' @family preprocessing
 #' @keywords neural
 #' @examples
-#' 
+#'
 #' data(BloodBrain)
 #' modelFit <- pcaNNet(
 #'   bbbDescr[, 1:10],
@@ -63,98 +62,108 @@
 #'   trace = FALSE
 #' )
 #' modelFit
-#' 
+#'
 #' predict(modelFit, bbbDescr[, 1:10])
-#' 
+#'
 #' @export pcaNNet
-pcaNNet <- function (x, ...)
-   UseMethod("pcaNNet")
+pcaNNet <- function(x, ...) {
+  UseMethod("pcaNNet")
+}
 
 
 # this is a near copy of nnet.formula
 #' @rdname pcaNNet
 #' @export
-pcaNNet.formula <- function (formula, data, weights, ...,
-                             thresh = 0.99,
-                             subset, na.action, contrasts = NULL)
-{
+pcaNNet.formula <- function(
+  formula,
+  data,
+  weights,
+  ...,
+  thresh = 0.99,
+  subset,
+  na.action,
+  contrasts = NULL
+) {
+  m <- match.call(expand.dots = FALSE)
+  if (is.matrix(eval.parent(m$data))) {
+    m$data <- as.data.frame(data, stringsAsFactors = TRUE)
+  }
+  m$... <- m$contrasts <- NULL
+  m[[1]] <- as.name("model.frame")
+  m <- eval.parent(m)
+  Terms <- attr(m, "terms")
+  x <- model.matrix(Terms, m, contrasts)
+  cons <- attr(x, "contrast")
+  xint <- match("(Intercept)", colnames(x), nomatch = 0)
+  if (xint > 0) {
+    x <- x[, -xint, drop = FALSE]
+  }
+  w <- model.weights(m)
+  if (length(w) == 0) {
+    w <- rep(1, nrow(x))
+  }
+  y <- model.response(m)
 
-    m <- match.call(expand.dots = FALSE)
-    if (is.matrix(eval.parent(m$data)))
-        m$data <- as.data.frame(data, stringsAsFactors = TRUE)
-    m$... <- m$contrasts <- NULL
-    m[[1]] <- as.name("model.frame")
-    m <- eval.parent(m)
-    Terms <- attr(m, "terms")
-    x <- model.matrix(Terms, m, contrasts)
-    cons <- attr(x, "contrast")
-    xint <- match("(Intercept)", colnames(x), nomatch = 0)
-    if (xint > 0)
-        x <- x[, -xint, drop = FALSE]
-    w <- model.weights(m)
-    if (length(w) == 0)
-        w <- rep(1, nrow(x))
-    y <- model.response(m)
-
-    res <- pcaNNet.default(x, y, weights = w, thresh = thresh, ...)
-    res$terms <- Terms
-    res$coefnames <- colnames(x)
-    res$na.action <- attr(m, "na.action")
-    res$contrasts <- cons
-    res$xlevels <- .getXlevels(Terms, m)
-    class(res) <- c("pcaNNet.formula", "pcaNNet")
-    res
+  res <- pcaNNet.default(x, y, weights = w, thresh = thresh, ...)
+  res$terms <- Terms
+  res$coefnames <- colnames(x)
+  res$na.action <- attr(m, "na.action")
+  res$contrasts <- cons
+  res$xlevels <- .getXlevels(Terms, m)
+  class(res) <- c("pcaNNet.formula", "pcaNNet")
+  res
 }
 
 #' @rdname pcaNNet
 #' @export
-pcaNNet.default <- function(x, y, thresh = 0.99, ...)
-  {
-    requireNamespaceQuietStop("nnet")
+pcaNNet.default <- function(x, y, thresh = 0.99, ...) {
+  requireNamespaceQuietStop("nnet")
 
-    # check for no variance data
-    isZV <- apply(x, 2,
-                  function(u) length(unique(u)) < 2)
-    if(any(isZV))
-      {
-        x <- x[,!isZV, drop = FALSE]
-        xNames <- colnames(x)
-      } else xNames <- NULL
-
-    # get pca
-    pp <- preProcess(x, "pca", thresh = thresh)
-    x <- predict(pp, x)
-
-    # check for factors
-
-    if(is.factor(y))
-      {
-        classLev <- levels(y)
-        y <- class2ind(y)
-      } else classLev <- NULL
-
-
-    # fit nnet
-    modelFit <- nnet::nnet(x, y, ...)
-    modelFit$lev <- classLev
-
-    # return results
-    out <- list(model = modelFit,
-                pc = pp,
-                names = xNames)
-    class(out) <- "pcaNNet"
-    out
+  # check for no variance data
+  isZV <- apply(x, 2, function(u) length(unique(u)) < 2)
+  if (any(isZV)) {
+    x <- x[, !isZV, drop = FALSE]
+    xNames <- colnames(x)
+  } else {
+    xNames <- NULL
   }
+
+  # get pca
+  pp <- preProcess(x, "pca", thresh = thresh)
+  x <- predict(pp, x)
+
+  # check for factors
+
+  if (is.factor(y)) {
+    classLev <- levels(y)
+    y <- class2ind(y)
+  } else {
+    classLev <- NULL
+  }
+
+  # fit nnet
+  modelFit <- nnet::nnet(x, y, ...)
+  modelFit$lev <- classLev
+
+  # return results
+  out <- list(model = modelFit, pc = pp, names = xNames)
+  class(out) <- "pcaNNet"
+  out
+}
 
 #' @rdname pcaNNet
 #' @export
-print.pcaNNet <- function (x, ...)
-{
+print.pcaNNet <- function(x, ...) {
   cat("Neural Network Model with PCA Pre-Processing\n\n")
 
   cat("Created from", x$pc$dim[1], "samples and", x$pc$dim[2], "variables\n")
-  cat("PCA needed", x$pc$numComp, "components to capture",
-      round(x$pc$thresh * 100, 2), "percent of the variance\n\n")
+  cat(
+    "PCA needed",
+    x$pc$numComp,
+    "components to capture",
+    round(x$pc$thresh * 100, 2),
+    "percent of the variance\n\n"
+  )
 
   print(x$model)
   cat("\n")
@@ -163,56 +172,68 @@ print.pcaNNet <- function (x, ...)
 
 #' @rdname pcaNNet
 #' @export
-predict.pcaNNet <- function(object, newdata, type = c("raw", "class", "prob"), ...)
-  {
-    requireNamespaceQuietStop("nnet")
-    if (!inherits(object, "pcaNNet"))
-      stop("object not of class \"pcaNNet\"")
-    if (missing(newdata))
-      {
-        if(is.null(object$model$lev))
-           {
-             return(fitted(object$model))
-           } else {
-             scores <- fitted(object$model)
-             classes <- colnames(scores)[apply(scores, 1, which.max)]
-             classes <- factor(as.character(classes), levels = object$model$lev)
-             if(type[1]== "raw") return(scores) else return(classes)
-           }
-      }  else {
-        if (inherits(object, "pcaNNet.formula")) {
-          newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-          rn <- row.names(newdata)
-          Terms <- delete.response(object$terms)
-          m <- model.frame(Terms, newdata, na.action = na.omit,
-                           xlev = object$xlevels)
-          if (!is.null(cl <- attr(Terms, "dataClasses")))
-            .checkMFClasses(cl, m)
-          keep <- match(row.names(m), rn)
-          x <- model.matrix(Terms, m, contrasts = object$contrasts)
-          xint <- match("(Intercept)", colnames(x), nomatch = 0)
-          if (xint > 0)
-            x <- x[, -xint, drop = FALSE]
-        }
-        else {
-          if (is.null(dim(newdata)))
-            dim(newdata) <- c(1, length(newdata))
-          x <- as.matrix(newdata)
-          if (anyNA(x))
-            stop("missing values in 'x'")
-          keep <- seq_len(nrow(x))
-          rn <- rownames(x)
-        }
-      }
-
-    if(!is.null(object$names)) x <- x[, object$names, drop = FALSE]
-
-    x <- predict(object$pc, x)
-    if(type[1] %in% c("raw", "class")) {
-      out <- predict(object$model, x, type = type[1], ...)
-    } else {
-      out <- predict(object$model, x, type = "raw", ...)
-      out <- t(apply(out, 1, function(x) x/sum(x)))
-    }
-    out
+predict.pcaNNet <- function(
+  object,
+  newdata,
+  type = c("raw", "class", "prob"),
+  ...
+) {
+  requireNamespaceQuietStop("nnet")
+  if (!inherits(object, "pcaNNet")) {
+    stop("object not of class \"pcaNNet\"")
   }
+  if (missing(newdata)) {
+    if (is.null(object$model$lev)) {
+      return(fitted(object$model))
+    } else {
+      scores <- fitted(object$model)
+      classes <- colnames(scores)[apply(scores, 1, which.max)]
+      classes <- factor(as.character(classes), levels = object$model$lev)
+      if (type[1] == "raw") return(scores) else return(classes)
+    }
+  } else {
+    if (inherits(object, "pcaNNet.formula")) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+      rn <- row.names(newdata)
+      Terms <- delete.response(object$terms)
+      m <- model.frame(
+        Terms,
+        newdata,
+        na.action = na.omit,
+        xlev = object$xlevels
+      )
+      if (!is.null(cl <- attr(Terms, "dataClasses"))) {
+        .checkMFClasses(cl, m)
+      }
+      keep <- match(row.names(m), rn)
+      x <- model.matrix(Terms, m, contrasts = object$contrasts)
+      xint <- match("(Intercept)", colnames(x), nomatch = 0)
+      if (xint > 0) {
+        x <- x[, -xint, drop = FALSE]
+      }
+    } else {
+      if (is.null(dim(newdata))) {
+        dim(newdata) <- c(1, length(newdata))
+      }
+      x <- as.matrix(newdata)
+      if (anyNA(x)) {
+        stop("missing values in 'x'")
+      }
+      keep <- seq_len(nrow(x))
+      rn <- rownames(x)
+    }
+  }
+
+  if (!is.null(object$names)) {
+    x <- x[, object$names, drop = FALSE]
+  }
+
+  x <- predict(object$pc, x)
+  if (type[1] %in% c("raw", "class")) {
+    out <- predict(object$model, x, type = type[1], ...)
+  } else {
+    out <- predict(object$model, x, type = "raw", ...)
+    out <- t(apply(out, 1, function(x) x / sum(x)))
+  }
+  out
+}

--- a/R/pcaNNet.R
+++ b/R/pcaNNet.R
@@ -189,7 +189,11 @@ predict.pcaNNet <- function(
       scores <- fitted(object$model)
       classes <- colnames(scores)[apply(scores, 1, which.max)]
       classes <- factor(as.character(classes), levels = object$model$lev)
-      if (type[1] == "raw") return(scores) else return(classes)
+      if (type[1] == "raw") {
+        return(scores)
+      } else {
+        return(classes)
+      }
     }
   } else {
     if (inherits(object, "pcaNNet.formula")) {

--- a/R/plot.train.R
+++ b/R/plot.train.R
@@ -53,7 +53,7 @@
 #' @keywords hplot
 #' @export
 #' @examplesIf !caret:::is_cran_check()
-#' 
+#'
 #' library(klaR)
 #' rdaFit <- train(
 #'   Species ~ .,
@@ -63,198 +63,299 @@
 #' )
 #' plot(rdaFit)
 #' plot(rdaFit, plotType = "level")
-#' 
+#'
 #' ggplot(rdaFit) + theme_bw()
-#' 
-#' 
+#'
+#'
 #' @export plot.train
-"plot.train" <-  function(x,
-                    plotType = "scatter",
-                    metric = x$metric[1],
-                    digits = getOption("digits") - 3,
-                    xTrans = NULL,
-                    nameInStrip = FALSE,
-                    ...)
-  {
-
-
-    ## Error trap
-    if(!(plotType %in% c("level", "scatter", "line"))) stop("plotType must be either level, scatter or line")
-
-    cutpoints <- c(0, 1.9, 2.9, 3.9, Inf)
-
-    ## define some functions
-    prettyVal <- function(u, dig, Name = NULL)
-      {
-        if(is.numeric(u))
-          {
-            if(!is.null(Name)) u <- paste(gsub(".", " ", Name, fixed = TRUE),
-                                          ": ",
-                                          format(u, digits = dig), sep = "")
-            return(factor(u))
-          } else return(if(!is.factor(u)) as.factor(u) else u)
-      }
-
-    ## Get tuning parameter info
-
-    params <- as.character(x$modelInfo$parameters$parameter)
-
-    if(grepl("adapt", x$control$method))
-      warning("When using adaptive resampling, this plot may not accurately capture the relationship between the tuning parameters and model performance.")
-
-    plotIt <- "yes"
-    if(all(params == "parameter"))
-      {
-        plotIt <- "There are no tuning parameters for this model."
-      } else {
-        dat <- x$results
-
-        ## Some exceptions for pretty printing
-        if(x$method == "nb") dat$usekernel <- factor(ifelse(dat$usekernel, "Nonparametric", "Gaussian"))
-        if(x$method == "gam") dat$select <- factor(ifelse(dat$select, "Feature Selection", "No Feature Selection"))
-        if(x$method == "qrnn") dat$bag <- factor(ifelse(dat$bag, "Bagging", "No Bagging"))
-        if(x$method == "C5.0") dat$winnow <- factor(ifelse(dat$winnow, "Winnowing", "No Winnowing"))
-##        if(x$method %in% c("M5Rules", "M5", "PART")) dat$pruned <- factor(ifelse(dat$pruned == "Yes", "Pruned", "Unpruned"))
-##        if(x$method %in% c("M5Rules", "M5")) dat$smoothed <- factor(ifelse(dat$smoothed == "Yes", "Smoothed", "Unsmoothed"))
-        if(x$method == "M5") dat$rules <- factor(ifelse(dat$rules == "Yes", "Rules", "Trees"))
-##        if(x$method == "vbmpRadial") dat$estimateTheta <- factor(ifelse(dat$estimateTheta == "Yes", "Estimate Theta", "Do Not Estimate Theta"))
-
-
-        ## Check to see which tuning parameters were varied
-
-        paramValues <- apply(dat[,params,drop = FALSE],
-                             2,
-                             function(x) length(unique(x)))
-        ##paramValues <- paramValues[order(paramValues)]
-        if(any(paramValues > 1))
-          {
-            params <- names(paramValues)[paramValues > 1]
-          } else plotIt <- "There are no tuning parameters with more than 1 value."
-      }
-
-    if(plotIt == "yes")
-      {
-        p <- length(params)
-        dat <- dat[, c(metric, params)]
-        if(p > 1) {
-          numUnique <- unlist(lapply(dat[, -1], function(x) length(unique(x))))
-          numUnique <- sort(numUnique,  decreasing = TRUE)
-          dat <- dat[, c(metric, names(numUnique))]
-          params <- names(numUnique)
-        }
-        ## The conveintion is that the first parameter (in
-        ## position #2 of dat) is plotted on the x-axis,
-        ## the second parameter is the grouping variable
-        ## and the rest are conditioning variables
-        if(!is.null(xTrans) && plotType == "scatter") dat[,2] <- xTrans(dat[,2])
-
-        ## We need to pretty-up some of the values of grouping
-        ## or conditioning variables
-
-
-        resampText <- resampName(x, FALSE)
-
-        if(plotType %in% c("line", "scatter"))
-          {
-
-            if(plotType == "scatter")
-              {
-                if(p >= 2) for(i in 3:ncol(dat))
-                  dat[,i] <- prettyVal(dat[,i], dig = digits, Name = if(i > 3) params[i-1] else  NULL)
-              } else {
-                for(i in 2:ncol(dat))
-                  dat[,i] <- prettyVal(dat[,i], dig = digits, Name = if(i > 3) params[i-1] else  NULL)
-              }
-            for(i in 2:ncol(dat)) if(is.logical(dat[,i])) dat[,i] <- factor(dat[,i])
-            if(p > 2 && nameInStrip) {
-              strip_vars <- params[-(1:2)]
-              strip_lab <- subset(x$modelInfo$parameters, parameter %in% strip_vars)$label
-              for(i in seq_along(strip_vars))
-                dat[, strip_vars[i]] <- factor(paste(strip_lab[i], dat[, strip_vars[i]], sep = ": "))
-            }
-            ## make formula
-            form <- if(p <= 2)
-              {
-                as.formula(
-                           paste(metric, "~", params[1], sep = ""))
-              } else as.formula(paste(metric, "~", params[1], "|",
-                                      paste(params[-(1:2)], collapse = "*"),
-                                      sep = ""))
-            defaultArgs <- list(x = form,
-                                data = dat,
-                                groups = if(p > 1) dat[,params[2]] else NULL)
-            if(length(list(...)) > 0) defaultArgs <- c(defaultArgs, list(...))
-            lNames <- names(defaultArgs)
-            if(!("ylab" %in% lNames))  defaultArgs$ylab <- paste(metric, resampText)
-
-            if(!("type" %in% lNames) && plotType == "scatter") defaultArgs$type <- c("g", "o")
-            if(!("type" %in% lNames) && plotType == "line") defaultArgs$type <- c("g", "o")
-            if(p > 1)
-              {
-                ## I apologize in advance for the following 3 line kludge.
-                groupCols <- 4
-                if(length(unique(dat[,3])) < 4) groupCols <- length(unique(dat[,3]))
-                if(length(unique(dat[,3])) %in% 5:6) groupCols <- 3
-
-                groupCols <- as.numeric(
-                                        cut(length(unique(dat[,3])),
-                                            cutpoints,
-                                            include.lowest = TRUE))
-
-                if(!(any(c("key", "auto.key") %in% lNames)))
-                  defaultArgs$auto.key <- list(columns = groupCols,
-                                               lines = TRUE,
-                                               title = as.character(x$modelInfo$parameter$label)[x$modelInfo$parameter$parameter == params[2]],
-                                               cex.title = 1)
-              }
-            if(!("xlab" %in% lNames)) defaultArgs$xlab <- as.character(x$modelInfo$parameter$label)[x$modelInfo$parameter$parameter == params[1]]
-
-            if(plotType == "scatter")
-              {
-                out <- do.call("xyplot", defaultArgs)
-              } else {
-                ## line plot #########################
-                out <- do.call("stripplot", defaultArgs)
-              }
-
-          }
-
-        if(plotType == "level")
-          {
-            if(p == 1) stop("There must be at least 2 tuning parameters with multiple values")
-
-            for(i in 2:ncol(dat))
-              dat[,i] <- prettyVal(dat[,i], dig = digits, Name = if(i > 3) params[i-1] else  NULL)
-            if(p > 2 && nameInStrip) {
-              strip_vars <- params[-(1:2)]
-              strip_lab <- subset(x$modelInfo$parameters, parameter %in% strip_vars)$label
-              for(i in seq_along(strip_vars))
-                dat[, strip_vars[i]] <- factor(paste(strip_lab[i], dat[, strip_vars[i]], sep = ": "))
-            }
-            ## make formula
-            form <- if(p <= 2)
-              {
-                as.formula(paste(metric, "~", params[1], "*", params[2], sep = ""))
-              } else as.formula(paste(metric, "~", params[1], "*", params[2], "|",
-                                      paste(params[-(1:2)], collapse = "*"),
-                                      sep = ""))
-            defaultArgs <- list(x = form, data = dat)
-            if(length(list(...)) > 0) defaultArgs <- c(defaultArgs, list(...))
-            lNames <- names(defaultArgs)
-            if(!("sub" %in% lNames)) defaultArgs$sub <- paste(metric, resampText)
-
-            if(!("xlab" %in% lNames)) defaultArgs$xlab <- as.character(x$modelInfo$parameter$label)[x$modelInfo$parameter$parameter == params[1]]
-            if(!("ylab" %in% lNames)) defaultArgs$ylab <- as.character(x$modelInfo$parameter$label)[x$modelInfo$parameter$parameter == params[2]]
-
-
-
-            out <- do.call("levelplot", defaultArgs)
-          }
-
-      } else stop(plotIt)
-
-    out
-
-
+"plot.train" <- function(
+  x,
+  plotType = "scatter",
+  metric = x$metric[1],
+  digits = getOption("digits") - 3,
+  xTrans = NULL,
+  nameInStrip = FALSE,
+  ...
+) {
+  ## Error trap
+  if (!(plotType %in% c("level", "scatter", "line"))) {
+    stop("plotType must be either level, scatter or line")
   }
 
+  cutpoints <- c(0, 1.9, 2.9, 3.9, Inf)
+
+  ## define some functions
+  prettyVal <- function(u, dig, Name = NULL) {
+    if (is.numeric(u)) {
+      if (!is.null(Name)) {
+        u <- paste(
+          gsub(".", " ", Name, fixed = TRUE),
+          ": ",
+          format(u, digits = dig),
+          sep = ""
+        )
+      }
+      return(factor(u))
+    } else {
+      return(if (!is.factor(u)) as.factor(u) else u)
+    }
+  }
+
+  ## Get tuning parameter info
+
+  params <- as.character(x$modelInfo$parameters$parameter)
+
+  if (grepl("adapt", x$control$method)) {
+    warning(
+      "When using adaptive resampling, this plot may not accurately capture the relationship between the tuning parameters and model performance."
+    )
+  }
+
+  plotIt <- "yes"
+  if (all(params == "parameter")) {
+    plotIt <- "There are no tuning parameters for this model."
+  } else {
+    dat <- x$results
+
+    ## Some exceptions for pretty printing
+    if (x$method == "nb") {
+      dat$usekernel <- factor(ifelse(
+        dat$usekernel,
+        "Nonparametric",
+        "Gaussian"
+      ))
+    }
+    if (x$method == "gam") {
+      dat$select <- factor(ifelse(
+        dat$select,
+        "Feature Selection",
+        "No Feature Selection"
+      ))
+    }
+    if (x$method == "qrnn") {
+      dat$bag <- factor(ifelse(dat$bag, "Bagging", "No Bagging"))
+    }
+    if (x$method == "C5.0") {
+      dat$winnow <- factor(ifelse(dat$winnow, "Winnowing", "No Winnowing"))
+    }
+    ##        if(x$method %in% c("M5Rules", "M5", "PART")) dat$pruned <- factor(ifelse(dat$pruned == "Yes", "Pruned", "Unpruned"))
+    ##        if(x$method %in% c("M5Rules", "M5")) dat$smoothed <- factor(ifelse(dat$smoothed == "Yes", "Smoothed", "Unsmoothed"))
+    if (x$method == "M5") {
+      dat$rules <- factor(ifelse(dat$rules == "Yes", "Rules", "Trees"))
+    }
+    ##        if(x$method == "vbmpRadial") dat$estimateTheta <- factor(ifelse(dat$estimateTheta == "Yes", "Estimate Theta", "Do Not Estimate Theta"))
+
+    ## Check to see which tuning parameters were varied
+
+    paramValues <- apply(dat[, params, drop = FALSE], 2, function(x) {
+      length(unique(x))
+    })
+    ##paramValues <- paramValues[order(paramValues)]
+    if (any(paramValues > 1)) {
+      params <- names(paramValues)[paramValues > 1]
+    } else {
+      plotIt <- "There are no tuning parameters with more than 1 value."
+    }
+  }
+
+  if (plotIt == "yes") {
+    p <- length(params)
+    dat <- dat[, c(metric, params)]
+    if (p > 1) {
+      numUnique <- unlist(lapply(dat[, -1], function(x) length(unique(x))))
+      numUnique <- sort(numUnique, decreasing = TRUE)
+      dat <- dat[, c(metric, names(numUnique))]
+      params <- names(numUnique)
+    }
+    ## The conveintion is that the first parameter (in
+    ## position #2 of dat) is plotted on the x-axis,
+    ## the second parameter is the grouping variable
+    ## and the rest are conditioning variables
+    if (!is.null(xTrans) && plotType == "scatter") {
+      dat[, 2] <- xTrans(dat[, 2])
+    }
+
+    ## We need to pretty-up some of the values of grouping
+    ## or conditioning variables
+
+    resampText <- resampName(x, FALSE)
+
+    if (plotType %in% c("line", "scatter")) {
+      if (plotType == "scatter") {
+        if (p >= 2) {
+          for (i in 3:ncol(dat)) {
+            dat[, i] <- prettyVal(
+              dat[, i],
+              dig = digits,
+              Name = if (i > 3) params[i - 1] else NULL
+            )
+          }
+        }
+      } else {
+        for (i in 2:ncol(dat)) {
+          dat[, i] <- prettyVal(
+            dat[, i],
+            dig = digits,
+            Name = if (i > 3) params[i - 1] else NULL
+          )
+        }
+      }
+      for (i in 2:ncol(dat)) {
+        if (is.logical(dat[, i])) dat[, i] <- factor(dat[, i])
+      }
+      if (p > 2 && nameInStrip) {
+        strip_vars <- params[-(1:2)]
+        strip_lab <- subset(
+          x$modelInfo$parameters,
+          parameter %in% strip_vars
+        )$label
+        for (i in seq_along(strip_vars)) {
+          dat[, strip_vars[i]] <- factor(paste(
+            strip_lab[i],
+            dat[, strip_vars[i]],
+            sep = ": "
+          ))
+        }
+      }
+      ## make formula
+      form <- if (p <= 2) {
+        as.formula(
+          paste(metric, "~", params[1], sep = "")
+        )
+      } else {
+        as.formula(paste(
+          metric,
+          "~",
+          params[1],
+          "|",
+          paste(params[-(1:2)], collapse = "*"),
+          sep = ""
+        ))
+      }
+      defaultArgs <- list(
+        x = form,
+        data = dat,
+        groups = if (p > 1) dat[, params[2]] else NULL
+      )
+      if (length(list(...)) > 0) {
+        defaultArgs <- c(defaultArgs, list(...))
+      }
+      lNames <- names(defaultArgs)
+      if (!("ylab" %in% lNames)) {
+        defaultArgs$ylab <- paste(metric, resampText)
+      }
+
+      if (!("type" %in% lNames) && plotType == "scatter") {
+        defaultArgs$type <- c("g", "o")
+      }
+      if (!("type" %in% lNames) && plotType == "line") {
+        defaultArgs$type <- c("g", "o")
+      }
+      if (p > 1) {
+        ## I apologize in advance for the following 3 line kludge.
+        groupCols <- 4
+        if (length(unique(dat[, 3])) < 4) {
+          groupCols <- length(unique(dat[, 3]))
+        }
+        if (length(unique(dat[, 3])) %in% 5:6) {
+          groupCols <- 3
+        }
+
+        groupCols <- as.numeric(
+          cut(length(unique(dat[, 3])), cutpoints, include.lowest = TRUE)
+        )
+
+        if (!(any(c("key", "auto.key") %in% lNames))) {
+          defaultArgs$auto.key <- list(
+            columns = groupCols,
+            lines = TRUE,
+            title = as.character(x$modelInfo$parameter$label)[
+              x$modelInfo$parameter$parameter == params[2]
+            ],
+            cex.title = 1
+          )
+        }
+      }
+      if (!("xlab" %in% lNames)) {
+        defaultArgs$xlab <- as.character(x$modelInfo$parameter$label)[
+          x$modelInfo$parameter$parameter == params[1]
+        ]
+      }
+
+      if (plotType == "scatter") {
+        out <- do.call("xyplot", defaultArgs)
+      } else {
+        ## line plot #########################
+        out <- do.call("stripplot", defaultArgs)
+      }
+    }
+
+    if (plotType == "level") {
+      if (p == 1) {
+        stop("There must be at least 2 tuning parameters with multiple values")
+      }
+
+      for (i in 2:ncol(dat)) {
+        dat[, i] <- prettyVal(
+          dat[, i],
+          dig = digits,
+          Name = if (i > 3) params[i - 1] else NULL
+        )
+      }
+      if (p > 2 && nameInStrip) {
+        strip_vars <- params[-(1:2)]
+        strip_lab <- subset(
+          x$modelInfo$parameters,
+          parameter %in% strip_vars
+        )$label
+        for (i in seq_along(strip_vars)) {
+          dat[, strip_vars[i]] <- factor(paste(
+            strip_lab[i],
+            dat[, strip_vars[i]],
+            sep = ": "
+          ))
+        }
+      }
+      ## make formula
+      form <- if (p <= 2) {
+        as.formula(paste(metric, "~", params[1], "*", params[2], sep = ""))
+      } else {
+        as.formula(paste(
+          metric,
+          "~",
+          params[1],
+          "*",
+          params[2],
+          "|",
+          paste(params[-(1:2)], collapse = "*"),
+          sep = ""
+        ))
+      }
+      defaultArgs <- list(x = form, data = dat)
+      if (length(list(...)) > 0) {
+        defaultArgs <- c(defaultArgs, list(...))
+      }
+      lNames <- names(defaultArgs)
+      if (!("sub" %in% lNames)) {
+        defaultArgs$sub <- paste(metric, resampText)
+      }
+
+      if (!("xlab" %in% lNames)) {
+        defaultArgs$xlab <- as.character(x$modelInfo$parameter$label)[
+          x$modelInfo$parameter$parameter == params[1]
+        ]
+      }
+      if (!("ylab" %in% lNames)) {
+        defaultArgs$ylab <- as.character(x$modelInfo$parameter$label)[
+          x$modelInfo$parameter$parameter == params[2]
+        ]
+      }
+
+      out <- do.call("levelplot", defaultArgs)
+    }
+  } else {
+    stop(plotIt)
+  }
+
+  out
+}

--- a/R/plot.train.R
+++ b/R/plot.train.R
@@ -201,7 +201,9 @@
         }
       }
       for (i in 2:ncol(dat)) {
-        if (is.logical(dat[, i])) dat[, i] <- factor(dat[, i])
+        if (is.logical(dat[, i])) {
+          dat[, i] <- factor(dat[, i])
+        }
       }
       if (p > 2 && nameInStrip) {
         strip_vars <- params[-(1:2)]
@@ -218,12 +220,12 @@
         }
       }
       ## make formula
-      form <- if (p <= 2) {
-        as.formula(
+      if (p <= 2) {
+        form <- as.formula(
           paste(metric, "~", params[1], sep = "")
         )
       } else {
-        as.formula(paste(
+        form <- as.formula(paste(
           metric,
           "~",
           params[1],
@@ -317,10 +319,17 @@
         }
       }
       ## make formula
-      form <- if (p <= 2) {
-        as.formula(paste(metric, "~", params[1], "*", params[2], sep = ""))
+      if (p <= 2) {
+        form <- as.formula(paste(
+          metric,
+          "~",
+          params[1],
+          "*",
+          params[2],
+          sep = ""
+        ))
       } else {
-        as.formula(paste(
+        form <- as.formula(paste(
           metric,
           "~",
           params[1],

--- a/R/plot.varImp.train.R
+++ b/R/plot.varImp.train.R
@@ -26,52 +26,73 @@
 #' @export
 
 "plot.varImp.train" <-
-function(x, top = dim(x$importance)[1],  ...)
-{  
-   plotObj <- sortImp(x, top)
-          
-   if(ncol(plotObj) == 2) {
-      plotObj <- plotObj[,1,drop = FALSE]
+  function(x, top = dim(x$importance)[1], ...) {
+    plotObj <- sortImp(x, top)
+
+    if (ncol(plotObj) == 2) {
+      plotObj <- plotObj[, 1, drop = FALSE]
       names(plotObj) <- "Importance"
-   }
-             
-   featureNames <- rownames(plotObj)         
-   outcomeNames <- colnames(plotObj)
-   
-   if(ncol(plotObj) > 1) {            
+    }
+
+    featureNames <- rownames(plotObj)
+    outcomeNames <- colnames(plotObj)
+
+    if (ncol(plotObj) > 1) {
       stackedData <- stack(plotObj)
-      stackedData$Feature <- factor(rep(featureNames, length(outcomeNames)),
-                                    levels = rev(featureNames))      
-      names(stackedData) <- c("Importance", "Class", "Feature")      
-   } else {
+      stackedData$Feature <- factor(
+        rep(featureNames, length(outcomeNames)),
+        levels = rev(featureNames)
+      )
+      names(stackedData) <- c("Importance", "Class", "Feature")
+    } else {
       stackedData <- plotObj
-      stackedData$Feature <- factor(rep(featureNames, length(outcomeNames)),
-                                    levels = rev(featureNames))            
+      stackedData$Feature <- factor(
+        rep(featureNames, length(outcomeNames)),
+        levels = rev(featureNames)
+      )
       names(stackedData) <- c("Importance", "Feature")
-   }
-   
-   formulaText <- ifelse(ncol(plotObj)> 1, 
-                         "Feature ~ Importance|Class", "
-                         Feature ~ Importance")
-   
-   if(x$model == "pam")
-   {
-     impSign <- factor(ifelse(stackedData$Importance > 0, "Positive", "Negative"),
-                       levels = c("Positive", "Negative"))
-     stackedData$Importance <- abs(stackedData$Importance)
-     impPlot <- dotplot(as.formula(formulaText), stackedData,
-                        groups = impSign,
-                        panel = panel.needle, ...)   
-   } else {
-     impPlot <- dotplot(as.formula(formulaText), stackedData,
-                        panel = panel.needle, ...)
-   }
-   impPlot
-}
+    }
+
+    formulaText <- ifelse(
+      ncol(plotObj) > 1,
+      "Feature ~ Importance|Class",
+      "
+                         Feature ~ Importance"
+    )
+
+    if (x$model == "pam") {
+      impSign <- factor(
+        ifelse(stackedData$Importance > 0, "Positive", "Negative"),
+        levels = c("Positive", "Negative")
+      )
+      stackedData$Importance <- abs(stackedData$Importance)
+      impPlot <- dotplot(
+        as.formula(formulaText),
+        stackedData,
+        groups = impSign,
+        panel = panel.needle,
+        ...
+      )
+    } else {
+      impPlot <- dotplot(
+        as.formula(formulaText),
+        stackedData,
+        panel = panel.needle,
+        ...
+      )
+    }
+    impPlot
+  }
 
 #' @rdname plot.varImp.train
 #' @export
-ggplot.varImp.train <- function (data, mapping = NULL, top = dim(data$importance)[1], ..., environment = NULL)  {
+ggplot.varImp.train <- function(
+  data,
+  mapping = NULL,
+  top = dim(data$importance)[1],
+  ...,
+  environment = NULL
+) {
   plotObj <- sortImp(data, top)
   if (ncol(plotObj) == 2) {
     plotObj <- plotObj[, 1, drop = FALSE]
@@ -81,23 +102,28 @@ ggplot.varImp.train <- function (data, mapping = NULL, top = dim(data$importance
   outcomeNames <- colnames(plotObj)
   if (ncol(plotObj) > 1) {
     stackedData <- stack(plotObj)
-    stackedData$Feature <- factor(rep(featureNames, length(outcomeNames)), 
-                                  levels = rev(featureNames))
+    stackedData$Feature <- factor(
+      rep(featureNames, length(outcomeNames)),
+      levels = rev(featureNames)
+    )
     names(stackedData) <- c("Importance", "Class", "Feature")
-    ## to avoid R CMD check warnings: 
-#     ggplot.varImp.train: no visible binding for global variable 'Feature'
-#     ggplot.varImp.train: no visible binding for global variable 'Importance'
+    ## to avoid R CMD check warnings:
+    #     ggplot.varImp.train: no visible binding for global variable 'Feature'
+    #     ggplot.varImp.train: no visible binding for global variable 'Importance'
     Feature <- Importance <- NULL
-    out <-  ggplot(stackedData, aes(x = Feature, y = Importance))+ 
-      geom_bar(stat = "identity") + facet_wrap(~Class) + 
+    out <- ggplot(stackedData, aes(x = Feature, y = Importance)) +
+      geom_bar(stat = "identity") +
+      facet_wrap(~Class) +
       coord_flip()
   } else {
     stackedData <- plotObj
-    stackedData$Feature <- factor(rep(featureNames, length(outcomeNames)), 
-                                  levels = rev(featureNames))
+    stackedData$Feature <- factor(
+      rep(featureNames, length(outcomeNames)),
+      levels = rev(featureNames)
+    )
     names(stackedData) <- c("Importance", "Feature")
-    out <-  ggplot(stackedData, aes(x = Feature, y = Importance))+ 
-      geom_bar(stat = "identity") + 
+    out <- ggplot(stackedData, aes(x = Feature, y = Importance)) +
+      geom_bar(stat = "identity") +
       coord_flip()
   }
   out

--- a/R/plotClassProbs.R
+++ b/R/plotClassProbs.R
@@ -92,15 +92,17 @@ plotClassProbs <- function(
   }
 
   if (any(names(object) == "object") && useObjects) {
-    if (length(unique(stackProbs$object)) > 1) keepVars <- c(keepVars, "object")
+    if (length(unique(stackProbs$object)) > 1) {
+      keepVars <- c(keepVars, "object")
+    }
   }
 
   if (plotType == "histogram") {
-    form <- if (length(obsLevels) == 2) {
-      form <- if (length(keepVars) > 0) {
-        paste("~ Probability|", paste(keepVars, collapse = "*"))
+    if (length(obsLevels) == 2) {
+      if (length(keepVars) > 0) {
+        form <- paste("~ Probability|", paste(keepVars, collapse = "*"))
       } else {
-        "~ Probability"
+        form <- "~ Probability"
       }
       form <- as.formula(form)
       out <- histogram(
@@ -110,20 +112,20 @@ plotClassProbs <- function(
         ...
       )
     } else {
-      form <- if (length(keepVars) > 0) {
-        paste("~ Probability|Class*", paste(keepVars, collapse = "*"))
+      if (length(keepVars) > 0) {
+        form <- paste("~ Probability|Class*", paste(keepVars, collapse = "*"))
       } else {
-        "~ Probability|Class"
+        form <- "~ Probability|Class"
       }
       form <- as.formula(form)
       out <- histogram(form, data = stackProbs, ...)
     }
   } else {
     keepVars <- keepVars[keepVars != "Observed"]
-    form <- if (length(keepVars) > 0) {
-      paste("~ Probability|", paste(keepVars, collapse = "*"))
+    if (length(keepVars) > 0) {
+      form <- paste("~ Probability|", paste(keepVars, collapse = "*"))
     } else {
-      "~ Probability"
+      form <- "~ Probability"
     }
     form <- as.formula(form)
 

--- a/R/plotClassProbs.R
+++ b/R/plotClassProbs.R
@@ -21,19 +21,19 @@
 #' @author Max Kuhn
 #' @keywords hplot
 #' @examplesIf !caret:::is_cran_check()
-#' 
+#'
 #' data(mdrr)
 #' set.seed(90)
 #' inTrain <- createDataPartition(mdrrClass, p = .5)[[1]]
-#' 
+#'
 #' trainData <- mdrrDescr[inTrain, 1:20]
 #' testData <- mdrrDescr[-inTrain, 1:20]
-#' 
+#'
 #' trainY <- mdrrClass[inTrain]
 #' testY <- mdrrClass[-inTrain]
-#' 
+#'
 #' ctrl <- trainControl(method = "cv")
-#' 
+#'
 #' nbFit1 <- train(
 #'   trainData,
 #'   trainY,
@@ -41,7 +41,7 @@
 #'   trControl = ctrl,
 #'   tuneGrid = data.frame(usekernel = TRUE, fL = 0, adjust = 1)
 #' )
-#' 
+#'
 #' nbFit2 <- train(
 #'   trainData,
 #'   trainY,
@@ -49,11 +49,11 @@
 #'   trControl = ctrl,
 #'   tuneGrid = data.frame(usekernel = FALSE, fL = 0, adjust = 1)
 #' )
-#' 
+#'
 #' models <- list(para = nbFit2, nonpara = nbFit1)
-#' 
+#'
 #' predProbs <- extractProb(models, testX = testData, testY = testY)
-#' 
+#'
 #' plotClassProbs(predProbs, useObjects = TRUE)
 #' plotClassProbs(predProbs, subset = object == "para" & dataType == "Test")
 #' plotClassProbs(
@@ -62,61 +62,72 @@
 #'   plotType = "densityplot",
 #'   auto.key = list(columns = 2)
 #' )
-#' 
+#'
 #' @export plotClassProbs
-plotClassProbs <- function(object,
-                           plotType = "histogram",
-                           useObjects = FALSE,
-                           ...)
-{
+plotClassProbs <- function(
+  object,
+  plotType = "histogram",
+  useObjects = FALSE,
+  ...
+) {
   obsLevels <- levels(object$obs)
 
-
-  stackProbs <- melt(object, id.vars = c("obs", "model", "object", "dataType"),
-                     measure.vars = if(length(obsLevels) == 2) obsLevels[1] else obsLevels)
+  stackProbs <- melt(
+    object,
+    id.vars = c("obs", "model", "object", "dataType"),
+    measure.vars = if (length(obsLevels) == 2) obsLevels[1] else obsLevels
+  )
   names(stackProbs)[names(stackProbs) == "variable"] <- "Class"
   names(stackProbs)[names(stackProbs) == "value"] <- "Probability"
   names(stackProbs)[names(stackProbs) == "obs"] <- "Observed"
   stackProbs$Observed <- paste("Data:", as.character(stackProbs$Observed))
   stackProbs$Class <- paste("Prob:", as.character(stackProbs$Class))
-  
+
   keepVars <- "Observed"
-  if(length(unique(stackProbs$dataType)) > 1) keepVars <- c(keepVars, "dataType")
-  if(length(unique(stackProbs$model)) > 1) keepVars <- c(keepVars, "model")     
+  if (length(unique(stackProbs$dataType)) > 1) {
+    keepVars <- c(keepVars, "dataType")
+  }
+  if (length(unique(stackProbs$model)) > 1) {
+    keepVars <- c(keepVars, "model")
+  }
 
-  if(any(names(object) == "object") && useObjects)
-    {
-      if(length(unique(stackProbs$object)) > 1) keepVars <- c(keepVars, "object")
-    }
+  if (any(names(object) == "object") && useObjects) {
+    if (length(unique(stackProbs$object)) > 1) keepVars <- c(keepVars, "object")
+  }
 
-  if(plotType == "histogram")
-    {
-      form <- if(length(obsLevels) == 2)
-        {
-          form <- if(length(keepVars) > 0) paste("~ Probability|", paste(keepVars, collapse = "*")) else "~ Probability"
-          form <- as.formula(form)
-          out <- histogram(form,
-                           data = stackProbs,
-                           xlab = paste("Probability of", obsLevels[1]),
-                           ...)
-          
-        } else {
-          form <- if(length(keepVars) > 0) paste("~ Probability|Class*", paste(keepVars, collapse = "*")) else "~ Probability|Class"
-                    form <- as.formula(form)
-          out <- histogram(form,
-                           data = stackProbs,
-                           ...)
-        }
-      
-
-      
-    } else {
-      keepVars <- keepVars[keepVars != "Observed"]
-      form  <- if(length(keepVars) > 0) paste("~ Probability|", paste(keepVars, collapse = "*")) else "~ Probability"
+  if (plotType == "histogram") {
+    form <- if (length(obsLevels) == 2) {
+      form <- if (length(keepVars) > 0) {
+        paste("~ Probability|", paste(keepVars, collapse = "*"))
+      } else {
+        "~ Probability"
+      }
       form <- as.formula(form)
-
-      out <- densityplot(form, data = stackProbs, groups = Observed, ...)
-      
+      out <- histogram(
+        form,
+        data = stackProbs,
+        xlab = paste("Probability of", obsLevels[1]),
+        ...
+      )
+    } else {
+      form <- if (length(keepVars) > 0) {
+        paste("~ Probability|Class*", paste(keepVars, collapse = "*"))
+      } else {
+        "~ Probability|Class"
+      }
+      form <- as.formula(form)
+      out <- histogram(form, data = stackProbs, ...)
     }
+  } else {
+    keepVars <- keepVars[keepVars != "Observed"]
+    form <- if (length(keepVars) > 0) {
+      paste("~ Probability|", paste(keepVars, collapse = "*"))
+    } else {
+      "~ Probability"
+    }
+    form <- as.formula(form)
+
+    out <- densityplot(form, data = stackProbs, groups = Observed, ...)
+  }
   out
 }

--- a/R/plotObsVsPred.R
+++ b/R/plotObsVsPred.R
@@ -21,9 +21,9 @@
 #' @author Max Kuhn
 #' @keywords hplot
 #' @examplesIf !caret:::is_cran_check()
-#' 
+#'
 #' library(mlbench)
-#' 
+#'
 #' # regression example
 #' data(BostonHousing)
 #' rpartFit <- train(
@@ -37,90 +37,107 @@
 #'   BostonHousing$medv[1:100],
 #'   "pls"
 #' )
-#' 
+#'
 #' predVals <- extractPrediction(
 #'   list(rpartFit, plsFit),
 #'   testX = BostonHousing[101:200, -c(4, 14)],
 #'   testY = BostonHousing$medv[101:200],
 #'   unkX = BostonHousing[201:300, -c(4, 14)]
 #' )
-#' 
+#'
 #' plotObsVsPred(predVals)
-#' 
+#'
 #' #classification example
 #' data(Satellite)
 #' numSamples <- dim(Satellite)[1]
 #' set.seed(716)
-#' 
+#'
 #' varIndex <- 1:numSamples
-#' 
+#'
 #' trainSamples <- sample(varIndex, 150)
-#' 
+#'
 #' varIndex <- (1:numSamples)[-trainSamples]
 #' testSamples <- sample(varIndex, 100)
-#' 
+#'
 #' varIndex <- (1:numSamples)[-c(testSamples, trainSamples)]
 #' unkSamples <- sample(varIndex, 50)
-#' 
+#'
 #' trainX <- Satellite[trainSamples, -37]
 #' trainY <- Satellite[trainSamples, 37]
-#' 
+#'
 #' testX <- Satellite[testSamples, -37]
 #' testY <- Satellite[testSamples, 37]
-#' 
+#'
 #' unkX <- Satellite[unkSamples, -37]
-#' 
+#'
 #' knnFit <- train(trainX, trainY, "knn")
 #' rpartFit <- train(trainX, trainY, "rpart")
-#' 
+#'
 #' predTargets <- extractPrediction(
 #'   list(knnFit, rpartFit),
 #'   testX = testX,
 #'   testY = testY,
 #'   unkX = unkX
 #' )
-#' 
+#'
 #' plotObsVsPred(predTargets)
-#' 
+#'
 #' @export plotObsVsPred
-plotObsVsPred <- function(object, equalRanges = TRUE, ...)
-{
-  
-   object <- object[object$dataType != "Unknown",]
-   object$dataType <- factor(object$dataType)
+plotObsVsPred <- function(object, equalRanges = TRUE, ...) {
+  object <- object[object$dataType != "Unknown", ]
+  object$dataType <- factor(object$dataType)
 
-   if(is.factor(object$obs))
-   {
-      agreement <- object$obs == object$pred
-      accuracyTable <- by(agreement, list(model = object$model, data = object$dataType), mean)
-      accuracyDF <- data.frame(unclass(accuracyTable))
-      accuracyStacked <- stack(accuracyDF)
-      accuracyStacked$model <- rep(dimnames(accuracyDF)[[1]], dim(accuracyDF)[2])
-      names(accuracyStacked) <- c("Accuracy", "Data", "Model")
-      accuracyStacked$Data <- factor(
-         ifelse(accuracyStacked$Data == "Training", "Training (uncorrected)", 
-         as.character(accuracyStacked$Data)))
-      out <- dotplot(Model ~ Accuracy, accuracyStacked, groups = accuracyStacked$Data, ...)      
-   } else {
-      
-      if(equalRanges)
-      {
-         xLimits <- yLimits <- extendrange(c(object$obs, object$pred))      
-      } else {
-         xLimits <- extendrange(object$obs)      
-         yLimits <- extendrange(object$pred)            
-      }
-      
-      out <- xyplot(obs ~ pred|model * dataType, object, 
-         xlim = xLimits, ylim = yLimits,
-         panel = function(x, y, groups, subscripts, ...)
-         {      
-            panel.xyplot(x, y,  cex = 0.6)
-            panel.abline(0, 1, col = trellis.par.get("superpose.line")$col[1], lty = 2)            
-            panel.loess(x, y,  span = 0.75)
-         },
-         xlab = "Predicted", ylab = "Observed", ...)
-   }
-   out
+  if (is.factor(object$obs)) {
+    agreement <- object$obs == object$pred
+    accuracyTable <- by(
+      agreement,
+      list(model = object$model, data = object$dataType),
+      mean
+    )
+    accuracyDF <- data.frame(unclass(accuracyTable))
+    accuracyStacked <- stack(accuracyDF)
+    accuracyStacked$model <- rep(dimnames(accuracyDF)[[1]], dim(accuracyDF)[2])
+    names(accuracyStacked) <- c("Accuracy", "Data", "Model")
+    accuracyStacked$Data <- factor(
+      ifelse(
+        accuracyStacked$Data == "Training",
+        "Training (uncorrected)",
+        as.character(accuracyStacked$Data)
+      )
+    )
+    out <- dotplot(
+      Model ~ Accuracy,
+      accuracyStacked,
+      groups = accuracyStacked$Data,
+      ...
+    )
+  } else {
+    if (equalRanges) {
+      xLimits <- yLimits <- extendrange(c(object$obs, object$pred))
+    } else {
+      xLimits <- extendrange(object$obs)
+      yLimits <- extendrange(object$pred)
+    }
 
+    out <- xyplot(
+      obs ~ pred | model * dataType,
+      object,
+      xlim = xLimits,
+      ylim = yLimits,
+      panel = function(x, y, groups, subscripts, ...) {
+        panel.xyplot(x, y, cex = 0.6)
+        panel.abline(
+          0,
+          1,
+          col = trellis.par.get("superpose.line")$col[1],
+          lty = 2
+        )
+        panel.loess(x, y, span = 0.75)
+      },
+      xlab = "Predicted",
+      ylab = "Observed",
+      ...
+    )
+  }
+  out
 }

--- a/R/plsda.R
+++ b/R/plsda.R
@@ -52,137 +52,166 @@
 #' @seealso [pls::plsr()], [spls::spls()]
 #' @keywords models
 #' @examplesIf !caret:::is_cran_check()
-#' 
+#'
 #' data(mdrr)
 #' set.seed(1)
 #' inTrain <- sample(seq(along.with = mdrrClass), 450)
-#' 
+#'
 #' nzv <- nearZeroVar(mdrrDescr)
 #' filteredDescr <- mdrrDescr[, -nzv]
-#' 
+#'
 #' training <- filteredDescr[inTrain, ]
 #' test <- filteredDescr[-inTrain, ]
 #' trainMDRR <- mdrrClass[inTrain]
 #' testMDRR <- mdrrClass[-inTrain]
-#' 
+#'
 #' preProcValues <- preProcess(training)
-#' 
+#'
 #' trainDescr <- predict(preProcValues, training)
 #' testDescr <- predict(preProcValues, test)
-#' 
+#'
 #' useSoftmax <- plsda(trainDescr, trainMDRR, ncomp = 5)
-#' 
+#'
 #' confusionMatrix(predict(useSoftmax, testDescr), testMDRR)
-#' 
+#'
 #' histogram(
 #'   ~ predict(useSoftmax, testDescr, type = "prob")[, "Active", ] | testMDRR,
 #'   xlab = "Active Prob",
 #'   xlim = c(-.1, 1.1)
 #' )
-#' 
+#'
 #' ## different sized objects are returned
 #' length(predict(useSoftmax, testDescr))
 #' dim(predict(useSoftmax, testDescr, ncomp = 1:3))
 #' dim(predict(useSoftmax, testDescr, type = "prob"))
 #' dim(predict(useSoftmax, testDescr, type = "prob", ncomp = 1:3))
-#' 
+#'
 #' ## Using spls:
 #' ## (As of 11/09, the spls package now has a similar function with
 #' ## the same name. To avoid conflicts, use caret:::splsda to
 #' ## get this version)
-#' 
+#'
 #' splsFit <- caret:::splsda(trainDescr, trainMDRR, K = 5, eta = .9)
-#' 
+#'
 #' confusionMatrix(caret:::predict.splsda(splsFit, testDescr), testMDRR)
-#' 
+#'
 #' @export plsda
-plsda <- function (x, ...)
+plsda <- function(x, ...) {
   UseMethod("plsda")
+}
 
 #' @rdname plsda
 #' @export
-predict.plsda <- function(object, newdata = NULL, ncomp = NULL, type = "class", ...){
+predict.plsda <- function(
+  object,
+  newdata = NULL,
+  ncomp = NULL,
+  type = "class",
+  ...
+) {
   requireNamespaceQuietStop('pls')
-  if(is.null(ncomp))
-    if(!is.null(object$ncomp)) ncomp <- object$ncomp else stop("specify ncomp")
+  if (is.null(ncomp)) {
+    if (!is.null(object$ncomp)) ncomp <- object$ncomp else stop("specify ncomp")
+  }
 
-  if(!is.null(newdata)) {
-    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
+  if (!is.null(newdata)) {
+    if (!is.matrix(newdata)) newdata <- as.matrix(newdata)
   }
 
   ## make sure that the prediction function from pls is used
   class(object) <- "mvr"
-  tmpPred <- predict(object, newdata = newdata)[,,ncomp,drop = FALSE]
+  tmpPred <- predict(object, newdata = newdata)[,, ncomp, drop = FALSE]
 
-  if(type == "raw") return(tmpPred)
+  if (type == "raw") {
+    return(tmpPred)
+  }
 
-  if(is.null(object$probModel)) {
+  if (is.null(object$probModel)) {
     ## use softmax
-    switch(type,
+    switch(
+      type,
 
-           class = {
-             if(length(dim(tmpPred)) < 3) {
-               ##only requested one component
-               out <- object$obsLevels[apply(tmpPred, 1, which.max)]
-               out <- factor(out, levels = object$obsLevels)
-             } else {
-               ## more than one component
-               tmpOut <- matrix("", nrow = dim(tmpPred)[1], ncol = dim(tmpPred)[3])
-               for(i in 1:dim(tmpPred)[3]) {
-                 tmpOut[,i] <- object$obsLevels[apply(tmpPred[,,i,drop=FALSE], 1, which.max)]
-               }
-               out <- as.data.frame(tmpOut, stringsAsFactors = TRUE)
-               out <- as.data.frame(
-                 lapply(out, function(x, y) factor(x, levels = y),
-                        y = object$obsLevels),
-                 stringsAsFactors = TRUE
-               )
-               names(out) <- paste("ncomp", ncomp, sep = "")
-               rownames(out) <- rownames(newdata)
-               if(length(ncomp) == 1) out <- out[,1]
-             }
-           },
-           prob = {
-             ## fix prob names
-             if(length(dim(tmpPred)) < 3) {
-               out <- t(apply(tmpPred, 1, function(data) exp(data)/sum(exp(data))))
-             } else {
-               ## more than one component
-               out <- tmpPred * NA
-               for(i in 1:dim(tmpPred)[3]) {
-                 out[,,i] <- t(apply(tmpPred[,,i,drop=FALSE], 1, function(data) exp(data)/sum(exp(data))))
-               }
-             }
-           })
+      class = {
+        if (length(dim(tmpPred)) < 3) {
+          ##only requested one component
+          out <- object$obsLevels[apply(tmpPred, 1, which.max)]
+          out <- factor(out, levels = object$obsLevels)
+        } else {
+          ## more than one component
+          tmpOut <- matrix("", nrow = dim(tmpPred)[1], ncol = dim(tmpPred)[3])
+          for (i in 1:dim(tmpPred)[3]) {
+            tmpOut[, i] <- object$obsLevels[apply(
+              tmpPred[,, i, drop = FALSE],
+              1,
+              which.max
+            )]
+          }
+          out <- as.data.frame(tmpOut, stringsAsFactors = TRUE)
+          out <- as.data.frame(
+            lapply(
+              out,
+              function(x, y) factor(x, levels = y),
+              y = object$obsLevels
+            ),
+            stringsAsFactors = TRUE
+          )
+          names(out) <- paste("ncomp", ncomp, sep = "")
+          rownames(out) <- rownames(newdata)
+          if (length(ncomp) == 1) out <- out[, 1]
+        }
+      },
+      prob = {
+        ## fix prob names
+        if (length(dim(tmpPred)) < 3) {
+          out <- t(apply(tmpPred, 1, function(data) exp(data) / sum(exp(data))))
+        } else {
+          ## more than one component
+          out <- tmpPred * NA
+          for (i in 1:dim(tmpPred)[3]) {
+            out[,, i] <- t(apply(
+              tmpPred[,, i, drop = FALSE],
+              1,
+              function(data) exp(data) / sum(exp(data))
+            ))
+          }
+        }
+      }
+    )
   } else {
     ## Bayes rule
 
     requireNamespaceQuietStop("klaR")
     tmp <- vector(mode = "list", length = length(ncomp))
-    for(i in seq(along.with = ncomp)) {
-      tmp[[i]] <- predict(object$probModel[[ ncomp[i] ]],
-                          as.data.frame(tmpPred[,-length(object$obsLevels),i]), stringsAsFactors = TRUE)
+    for (i in seq(along.with = ncomp)) {
+      tmp[[i]] <- predict(
+        object$probModel[[ncomp[i]]],
+        as.data.frame(tmpPred[, -length(object$obsLevels), i]),
+        stringsAsFactors = TRUE
+      )
     }
 
-    if(type == "class") {
-      out <- t(do.call("rbind",
-                       lapply(tmp, function(x) as.character(x$class))))
+    if (type == "class") {
+      out <- t(do.call("rbind", lapply(tmp, function(x) as.character(x$class))))
       rownames(out) <- names(tmp[[1]]$class)
       colnames(out) <- paste("ncomp", ncomp, sep = "")
       out <- as.data.frame(out, stringsAsFactors = TRUE)
       out <- as.data.frame(
-        lapply(out, function(x, y) factor(x, levels = y),
-               y = object$obsLevels),
+        lapply(out, function(x, y) factor(x, levels = y), y = object$obsLevels),
         stringsAsFactors = TRUE
       )
-      if(length(ncomp) == 1) out <- out[,1]
+      if (length(ncomp) == 1) out <- out[, 1]
     } else {
-      out <- array(dim = c(dim(tmp[[1]]$posterior), length(ncomp)),
-                   dimnames = list(
-                     rownames(tmp[[1]]$posterior),
-                     colnames(tmp[[1]]$posterior),
-                     paste("ncomp", ncomp, sep = "")))
-      for(i in seq(along.with = ncomp)) out[,,i] <- tmp[[i]]$posterior
+      out <- array(
+        dim = c(dim(tmp[[1]]$posterior), length(ncomp)),
+        dimnames = list(
+          rownames(tmp[[1]]$posterior),
+          colnames(tmp[[1]]$posterior),
+          paste("ncomp", ncomp, sep = "")
+        )
+      )
+      for (i in seq(along.with = ncomp)) {
+        out[,, i] <- tmp[[i]]$posterior
+      }
     }
   }
   out
@@ -190,40 +219,59 @@ predict.plsda <- function(object, newdata = NULL, ncomp = NULL, type = "class", 
 
 #' @rdname plsda
 #' @export
-plsda.default <- function(x, y, ncomp = 2, probMethod = "softmax", prior = NULL, ...) {
+plsda.default <- function(
+  x,
+  y,
+  ncomp = 2,
+  probMethod = "softmax",
+  prior = NULL,
+  ...
+) {
   requireNamespaceQuietStop('pls')
 
   funcCall <- match.call(expand.dots = TRUE)
 
-  if(!is.matrix(x)) x <- as.matrix(x)
-  if(length(ncomp) > 1) {
+  if (!is.matrix(x)) {
+    x <- as.matrix(x)
+  }
+  if (length(ncomp) > 1) {
     ncomp <- max(ncomp)
     warning(paste(
       "A value single ncomp must be specified.",
       "max(ncomp) was used.",
-      "Predictions can be obtained for values <= ncomp"))
+      "Predictions can be obtained for values <= ncomp"
+    ))
   }
 
-  if(probMethod == "softmax") {
-    if(!is.null(prior)) warning("Priors are ignored unless probMethod = \"Bayes\"")
+  if (probMethod == "softmax") {
+    if (!is.null(prior)) {
+      warning("Priors are ignored unless probMethod = \"Bayes\"")
+    }
   }
 
-
-  if(is.factor(y)) {
+  if (is.factor(y)) {
     obsLevels <- levels(y)
     oldY <- y
     y <- class2ind(y)
   } else {
-    if(is.matrix(y)) {
+    if (is.matrix(y)) {
       test <- apply(y, 1, sum)
-      if(any(test != 1)) stop("the rows of y must be 0/1 and sum to 1")
+      if (any(test != 1)) {
+        stop("the rows of y must be 0/1 and sum to 1")
+      }
       obsLevels <- colnames(y)
-      if(is.null(obsLevels)) stop("the y matrix must have column names")
+      if (is.null(obsLevels)) {
+        stop("the y matrix must have column names")
+      }
       oldY <- obsLevels[apply(y, 1, which.max)]
-    } else stop("y must be a matrix or a factor")
+    } else {
+      stop("y must be a matrix or a factor")
+    }
   }
 
-  if(!is.matrix(x)) x <- as.matrix(x)
+  if (!is.matrix(x)) {
+    x <- as.matrix(x)
+  }
 
   tmpData <- data.frame(n = paste("row", seq_len(nrow(y)), sep = ""))
   tmpData$y <- y
@@ -233,7 +281,7 @@ plsda.default <- function(x, y, ncomp = 2, probMethod = "softmax", prior = NULL,
 
   out$obsLevels <- obsLevels
   out$probMethod <- probMethod
-  if(probMethod == "Bayes") {
+  if (probMethod == "Bayes") {
     requireNamespaceQuietStop('klaR')
     makeModels <- function(x, y, pri) {
       probModel <- klaR::NaiveBayes(x, y, prior = pri, usekernel = TRUE)
@@ -246,10 +294,12 @@ plsda.default <- function(x, y, ncomp = 2, probMethod = "softmax", prior = NULL,
     train <- predict(out, as.matrix(tmpData$x), ncomp = 1:ncomp)
     ## Get the raw model predictions, but leave one behind since the
     ## final class probs sum to one
-    train <- train[, -length(obsLevels),, drop = FALSE]
+    train <- train[, -length(obsLevels), , drop = FALSE]
 
     out$probModel <- apply(train, 3, makeModels, y = oldY, pri = prior)
-  } else out$probModel <- NULL
+  } else {
+    out$probModel <- NULL
+  }
 
   ##out$call <- funcCall
   class(out) <- c("plsda", class(out))
@@ -257,29 +307,44 @@ plsda.default <- function(x, y, ncomp = 2, probMethod = "softmax", prior = NULL,
 }
 
 #' @export
-print.plsda <- function (x, ...) {
+print.plsda <- function(x, ...) {
   ## minor change to print.mvr
-  switch(x$method,
-         kernelpls = {
-           regr = "Partial least squares"
-           alg = "kernel"
-         }, simpls = {
-           regr = "Partial least squares"
-           alg = "simpls"
-         }, oscorespls = {
-           regr = "Partial least squares"
-           alg = "orthogonal scores"
-         }, svdpc = {
-           regr = "Principal component"
-           alg = "singular value decomposition"
-         }, stop("Unknown fit method."))
+  switch(
+    x$method,
+    kernelpls = {
+      regr = "Partial least squares"
+      alg = "kernel"
+    },
+    simpls = {
+      regr = "Partial least squares"
+      alg = "simpls"
+    },
+    oscorespls = {
+      regr = "Partial least squares"
+      alg = "orthogonal scores"
+    },
+    svdpc = {
+      regr = "Principal component"
+      alg = "singular value decomposition"
+    },
+    stop("Unknown fit method.")
+  )
   cat(regr, "classification, fitted with the", alg, "algorithm.")
-  if (!is.null(x$validation))
-    cat("\nCross-validated using", length(x$validation$segments),
-        attr(x$validation$segments, "type"), "segments.")
+  if (!is.null(x$validation)) {
+    cat(
+      "\nCross-validated using",
+      length(x$validation$segments),
+      attr(x$validation$segments, "type"),
+      "segments."
+    )
+  }
 
-  switch(x$probMethod,
-         softmax = cat("\nThe softmax function was used to compute class probabilities.\n"),
-         Bayes = cat("\nBayes rule was used to compute class probabilities.\n"))
+  switch(
+    x$probMethod,
+    softmax = cat(
+      "\nThe softmax function was used to compute class probabilities.\n"
+    ),
+    Bayes = cat("\nBayes rule was used to compute class probabilities.\n")
+  )
   invisible(x)
 }

--- a/R/plsda.R
+++ b/R/plsda.R
@@ -111,11 +111,17 @@ predict.plsda <- function(
 ) {
   requireNamespaceQuietStop('pls')
   if (is.null(ncomp)) {
-    if (!is.null(object$ncomp)) ncomp <- object$ncomp else stop("specify ncomp")
+    if (!is.null(object$ncomp)) {
+      ncomp <- object$ncomp
+    } else {
+      stop("specify ncomp")
+    }
   }
 
   if (!is.null(newdata)) {
-    if (!is.matrix(newdata)) newdata <- as.matrix(newdata)
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
   }
 
   ## make sure that the prediction function from pls is used
@@ -157,7 +163,9 @@ predict.plsda <- function(
           )
           names(out) <- paste("ncomp", ncomp, sep = "")
           rownames(out) <- rownames(newdata)
-          if (length(ncomp) == 1) out <- out[, 1]
+          if (length(ncomp) == 1) {
+            out <- out[, 1]
+          }
         }
       },
       prob = {
@@ -199,7 +207,9 @@ predict.plsda <- function(
         lapply(out, function(x, y) factor(x, levels = y), y = object$obsLevels),
         stringsAsFactors = TRUE
       )
-      if (length(ncomp) == 1) out <- out[, 1]
+      if (length(ncomp) == 1) {
+        out <- out[, 1]
+      }
     } else {
       out <- array(
         dim = c(dim(tmp[[1]]$posterior), length(ncomp)),

--- a/R/posPredValue.R
+++ b/R/posPredValue.R
@@ -1,70 +1,82 @@
 #' @rdname sensitivity
 #' @export
-posPredValue <- 
-  function(data, ...){
+posPredValue <-
+  function(data, ...) {
     UseMethod("posPredValue")
   }
 
 #' @rdname sensitivity
 #' @export
 "posPredValue.default" <-
-  function(data, reference, positive = levels(reference)[1], prevalence = NULL, ...)
-{
-  if(!is.factor(reference) || !is.factor(data)) 
-    stop("inputs must be factors")
-  
-  if(length(unique(c(levels(reference), levels(data)))) != 2)
-    stop("input data must have the same two levels")
-  
-  lvls <- levels(data) 
-  if(is.null(prevalence)) prevalence <- mean(reference == positive)
-  sens <- sensitivity(data, reference, positive)
-  spec <- specificity(data, reference, lvls[lvls != positive])
-  (sens * prevalence)/((sens*prevalence) + ((1-spec)*(1-prevalence)))
+  function(
+    data,
+    reference,
+    positive = levels(reference)[1],
+    prevalence = NULL,
+    ...
+  ) {
+    if (!is.factor(reference) || !is.factor(data)) {
+      stop("inputs must be factors")
+    }
 
-}
+    if (length(unique(c(levels(reference), levels(data)))) != 2) {
+      stop("input data must have the same two levels")
+    }
+
+    lvls <- levels(data)
+    if (is.null(prevalence)) {
+      prevalence <- mean(reference == positive)
+    }
+    sens <- sensitivity(data, reference, positive)
+    spec <- specificity(data, reference, lvls[lvls != positive])
+    (sens * prevalence) /
+      ((sens * prevalence) + ((1 - spec) * (1 - prevalence)))
+  }
 
 #' @rdname sensitivity
 #' @export
 "posPredValue.table" <-
-  function(data, positive = rownames(data)[1], prevalence = NULL, ...)
-{
-  ## "truth" in columns, predictions in rows
-  if(!all.equal(nrow(data), ncol(data))) stop("the table must have nrow = ncol")
-  if(!all.equal(rownames(data), colnames(data))) stop("the table must the same groups in the same order")
+  function(data, positive = rownames(data)[1], prevalence = NULL, ...) {
+    ## "truth" in columns, predictions in rows
+    if (!all.equal(nrow(data), ncol(data))) {
+      stop("the table must have nrow = ncol")
+    }
+    if (!all.equal(rownames(data), colnames(data))) {
+      stop("the table must the same groups in the same order")
+    }
 
-  if(nrow(data) > 2)
-    {
+    if (nrow(data) > 2) {
       tmp <- data
       data <- matrix(NA, 2, 2)
-      
+
       colnames(data) <- rownames(data) <- c("pos", "neg")
       posCol <- which(colnames(tmp) %in% positive)
       negCol <- which(!(colnames(tmp) %in% positive))
-      
+
       data[1, 1] <- sum(tmp[posCol, posCol])
       data[1, 2] <- sum(tmp[posCol, negCol])
-      data[2, 1] <- sum(tmp[negCol, posCol])      
+      data[2, 1] <- sum(tmp[negCol, posCol])
       data[2, 2] <- sum(tmp[negCol, negCol])
       data <- as.table(data)
       positive <- "pos"
       rm(tmp)
     }
 
-  negative <- colnames(data)[colnames(data) != positive]
-  if(is.null(prevalence)) prevalence <- sum(data[, positive])/sum(data)
-  
-  sens <- sensitivity(data, positive)
-  spec <- specificity(data, negative)
-    (sens * prevalence)/((sens*prevalence) + ((1-spec)*(1-prevalence)))
+    negative <- colnames(data)[colnames(data) != positive]
+    if (is.null(prevalence)) {
+      prevalence <- sum(data[, positive]) / sum(data)
+    }
 
-}
+    sens <- sensitivity(data, positive)
+    spec <- specificity(data, negative)
+    (sens * prevalence) /
+      ((sens * prevalence) + ((1 - spec) * (1 - prevalence)))
+  }
 
 #' @rdname sensitivity
 #' @export
 "posPredValue.matrix" <-
-  function(data, positive = rownames(data)[1], prevalence = NULL, ...)
-{
-  data <- as.table(data)
-  posPredValue.table(data, prevalence = prevalence)
-}
+  function(data, positive = rownames(data)[1], prevalence = NULL, ...) {
+    data <- as.table(data)
+    posPredValue.table(data, prevalence = prevalence)
+  }

--- a/R/postResample.R
+++ b/R/postResample.R
@@ -84,11 +84,11 @@
 #' @family performance
 #' @keywords utilities
 #' @examples
-#' 
+#'
 #' predicted <- matrix(rnorm(50), ncol = 5)
 #' observed <- rnorm(10)
 #' apply(predicted, 2, postResample, obs = observed)
-#' 
+#'
 #' classes <- c("class1", "class2")
 #' set.seed(1)
 #' dat <- data.frame(
@@ -97,85 +97,96 @@
 #'   class1 = runif(50)
 #' )
 #' dat$class2 <- 1 - dat$class1
-#' 
+#'
 #' defaultSummary(dat, lev = classes)
 #' twoClassSummary(dat, lev = classes)
 #' prSummary(dat, lev = classes)
 #' mnLogLoss(dat, lev = classes)
-#' 
+#'
 #' @export postResample
-postResample <- function(pred, obs)
-{
-
+postResample <- function(pred, obs) {
   isNA <- is.na(pred)
   pred <- pred[!isNA]
   obs <- obs[!isNA]
 
-  if (!is.factor(obs) && is.numeric(obs))
-    {
-      if(length(obs) + length(pred) == 0)
-        {
-          out <- rep(NA, 3)
-        } else {
-          if(length(unique(pred)) < 2 || length(unique(obs)) < 2)
-            {
-              resamplCor <- NA
-            } else {
-              resamplCor <- try(cor(pred, obs, use = "pairwise.complete.obs"), silent = TRUE)
-              if (inherits(resamplCor, "try-error")) resamplCor <- NA
-            }
-          mse <- mean((pred - obs)^2)
-          mae <- mean(abs(pred - obs))
-
-          out <- c(sqrt(mse), resamplCor^2, mae)
-        }
-      names(out) <- c("RMSE", "Rsquared", "MAE")
+  if (!is.factor(obs) && is.numeric(obs)) {
+    if (length(obs) + length(pred) == 0) {
+      out <- rep(NA, 3)
     } else {
-      if(length(obs) + length(pred) == 0)
-        {
-          out <- rep(NA, 2)
-        } else {
-          pred <- factor(pred, levels = levels(obs))
-          requireNamespaceQuietStop("e1071")
-          out <- unlist(e1071::classAgreement(table(obs, pred)))[c("diag", "kappa")]
-        }
-      names(out) <- c("Accuracy", "Kappa")
+      if (length(unique(pred)) < 2 || length(unique(obs)) < 2) {
+        resamplCor <- NA
+      } else {
+        resamplCor <- try(
+          cor(pred, obs, use = "pairwise.complete.obs"),
+          silent = TRUE
+        )
+        if (inherits(resamplCor, "try-error")) resamplCor <- NA
+      }
+      mse <- mean((pred - obs)^2)
+      mae <- mean(abs(pred - obs))
+
+      out <- c(sqrt(mse), resamplCor^2, mae)
     }
-  if(any(is.nan(out))) out[is.nan(out)] <- NA
+    names(out) <- c("RMSE", "Rsquared", "MAE")
+  } else {
+    if (length(obs) + length(pred) == 0) {
+      out <- rep(NA, 2)
+    } else {
+      pred <- factor(pred, levels = levels(obs))
+      requireNamespaceQuietStop("e1071")
+      out <- unlist(e1071::classAgreement(table(obs, pred)))[c("diag", "kappa")]
+    }
+    names(out) <- c("Accuracy", "Kappa")
+  }
+  if (any(is.nan(out))) {
+    out[is.nan(out)] <- NA
+  }
   out
 }
 
 
 #' @rdname postResample
 #' @export
-twoClassSummary <- function (data, lev = NULL, model = NULL) {
-  if(length(lev) > 2) {
-    stop(paste("Your outcome has", length(lev),
-               "levels. The twoClassSummary() function isn't appropriate."))
+twoClassSummary <- function(data, lev = NULL, model = NULL) {
+  if (length(lev) > 2) {
+    stop(paste(
+      "Your outcome has",
+      length(lev),
+      "levels. The twoClassSummary() function isn't appropriate."
+    ))
   }
   requireNamespaceQuietStop('pROC')
   if (!all(levels(data[, "pred"]) == lev)) {
     stop("levels of observed and predicted data do not match")
   }
-  rocObject <- try(pROC::roc(data$obs, data[, lev[1]], direction = ">", quiet = TRUE), silent = TRUE)
-  rocAUC <- if(inherits(rocObject, "try-error")) NA else rocObject$auc
-  out <- c(rocAUC,
-           sensitivity(data[, "pred"], data[, "obs"], lev[1]),
-           specificity(data[, "pred"], data[, "obs"], lev[2]))
+  rocObject <- try(
+    pROC::roc(data$obs, data[, lev[1]], direction = ">", quiet = TRUE),
+    silent = TRUE
+  )
+  rocAUC <- if (inherits(rocObject, "try-error")) NA else rocObject$auc
+  out <- c(
+    rocAUC,
+    sensitivity(data[, "pred"], data[, "obs"], lev[1]),
+    specificity(data[, "pred"], data[, "obs"], lev[2])
+  )
   names(out) <- c("ROC", "Sens", "Spec")
   out
 }
 
 #' @rdname postResample
 #' @export
-mnLogLoss <- function(data, lev = NULL, model = NULL){
-  if(is.null(lev)) stop("'lev' cannot be NULL")
-  if(!all(lev %in% colnames(data)))
+mnLogLoss <- function(data, lev = NULL, model = NULL) {
+  if (is.null(lev)) {
+    stop("'lev' cannot be NULL")
+  }
+  if (!all(lev %in% colnames(data))) {
     stop("'data' should have columns consistent with 'lev'")
-  if(!all(sort(lev) %in% sort(levels(data$obs))))
+  }
+  if (!all(sort(lev) %in% sort(levels(data$obs)))) {
     stop("'data$obs' should have levels consistent with 'lev'")
+  }
 
-  dataComplete <- data[complete.cases(data),]
+  dataComplete <- data[complete.cases(data), ]
   probs <- as.matrix(dataComplete[, lev, drop = FALSE])
 
   logLoss <- ModelMetrics::mlogLoss(dataComplete$obs, probs)
@@ -184,14 +195,15 @@ mnLogLoss <- function(data, lev = NULL, model = NULL){
 
 #' @rdname postResample
 #' @export
-multiClassSummary <- function(data, lev = NULL, model = NULL){
+multiClassSummary <- function(data, lev = NULL, model = NULL) {
   #Check data
-  if (!all(levels(data[, "pred"]) == levels(data[, "obs"])))
+  if (!all(levels(data[, "pred"]) == levels(data[, "obs"]))) {
     stop("levels of observed and predicted data do not match")
+  }
 
   has_class_probs <- all(lev %in% colnames(data))
 
-  if(has_class_probs) {
+  if (has_class_probs) {
     ## Overall multinomial loss
     lloss <- mnLogLoss(data = data, lev = lev, model = model)
 
@@ -200,27 +212,31 @@ multiClassSummary <- function(data, lev = NULL, model = NULL){
 
     #Calculate custom one-vs-all ROC curves for each class
     prob_stats <-
-      lapply(levels(data[, "pred"]),
-             function(x){
-               #Grab one-vs-all data for the class
-               obs  <- ifelse(data[,"obs"] == x, 1, 0)
-               prob <- data[,x]
-               roc_auc <- try(pROC::roc(obs, data[,x], direction = "<", quiet = TRUE), silent = TRUE)
-               roc_auc <- if (inherits(roc_auc, "try-error")) NA else roc_auc$auc
-               pr_auc <- try(MLmetrics::PRAUC(y_pred = data[,x], y_true = obs),
-                             silent = TRUE)
-               if(inherits(pr_auc, "try-error"))
-                 pr_auc <- NA
-               res <- c(ROC = roc_auc, AUC = pr_auc)
-               return(res)
-               })
+      lapply(levels(data[, "pred"]), function(x) {
+        #Grab one-vs-all data for the class
+        obs <- ifelse(data[, "obs"] == x, 1, 0)
+        prob <- data[, x]
+        roc_auc <- try(
+          pROC::roc(obs, data[, x], direction = "<", quiet = TRUE),
+          silent = TRUE
+        )
+        roc_auc <- if (inherits(roc_auc, "try-error")) NA else roc_auc$auc
+        pr_auc <- try(
+          MLmetrics::PRAUC(y_pred = data[, x], y_true = obs),
+          silent = TRUE
+        )
+        if (inherits(pr_auc, "try-error")) {
+          pr_auc <- NA
+        }
+        res <- c(ROC = roc_auc, AUC = pr_auc)
+        return(res)
+      })
     prob_stats <- do.call("rbind", prob_stats)
     prob_stats <- colMeans(prob_stats, na.rm = TRUE)
   }
 
   #Calculate confusion matrix-based statistics
-  CM <- confusionMatrix(data[, "pred"], data[, "obs"],
-                        mode = "everything")
+  CM <- confusionMatrix(data[, "pred"], data[, "obs"], mode = "everything")
 
   #Aggregate and average class-wise stats
   #Todo: add weights
@@ -234,34 +250,56 @@ multiClassSummary <- function(data, lev = NULL, model = NULL){
 
   # Aggregate overall stats
   overall_stats <-
-    if (has_class_probs)
-      c(CM$overall,
+    if (has_class_probs) {
+      c(
+        CM$overall,
         logLoss = as.numeric(lloss),
         AUC = unname(prob_stats["ROC"]),
-        prAUC = unname(prob_stats["AUC"]))
-  else
-    CM$overall
-
+        prAUC = unname(prob_stats["AUC"])
+      )
+    } else {
+      CM$overall
+    }
 
   # Combine overall with class-wise stats and remove some stats we don't want
   stats <- c(overall_stats, class_stats)
-  stats <- stats[! names(stats) %in% c('AccuracyNull', "AccuracyLower", "AccuracyUpper",
-                                       "AccuracyPValue", "McnemarPValue",
-                                       'Mean Prevalence', 'Mean Detection Prevalence')]
+  stats <- stats[
+    !names(stats) %in%
+      c(
+        'AccuracyNull',
+        "AccuracyLower",
+        "AccuracyUpper",
+        "AccuracyPValue",
+        "McnemarPValue",
+        'Mean Prevalence',
+        'Mean Detection Prevalence'
+      )
+  ]
 
   # Clean names
   names(stats) <- gsub('[[:blank:]]+', '_', names(stats))
 
   # Change name ordering to place most useful first
   # May want to remove some of these eventually
-  stat_list <- c("Accuracy", "Kappa", "Mean_F1",
-                 "Mean_Sensitivity", "Mean_Specificity",
-                 "Mean_Pos_Pred_Value", "Mean_Neg_Pred_Value",
-                 "Mean_Precision", "Mean_Recall",
-                 "Mean_Detection_Rate",
-                 "Mean_Balanced_Accuracy")
-  if(has_class_probs) stat_list <- c("logLoss", "AUC", "prAUC", stat_list)
-  if (length(levels(data[, "pred"])) == 2) stat_list <- gsub("^Mean_", "", stat_list)
+  stat_list <- c(
+    "Accuracy",
+    "Kappa",
+    "Mean_F1",
+    "Mean_Sensitivity",
+    "Mean_Specificity",
+    "Mean_Pos_Pred_Value",
+    "Mean_Neg_Pred_Value",
+    "Mean_Precision",
+    "Mean_Recall",
+    "Mean_Detection_Rate",
+    "Mean_Balanced_Accuracy"
+  )
+  if (has_class_probs) {
+    stat_list <- c("logLoss", "AUC", "prAUC", stat_list)
+  }
+  if (length(levels(data[, "pred"])) == 2) {
+    stat_list <- gsub("^Mean_", "", stat_list)
+  }
 
   stats <- stats[c(stat_list)]
 

--- a/R/postResample.R
+++ b/R/postResample.R
@@ -120,7 +120,9 @@ postResample <- function(pred, obs) {
           cor(pred, obs, use = "pairwise.complete.obs"),
           silent = TRUE
         )
-        if (inherits(resamplCor, "try-error")) resamplCor <- NA
+        if (inherits(resamplCor, "try-error")) {
+          resamplCor <- NA
+        }
       }
       mse <- mean((pred - obs)^2)
       mae <- mean(abs(pred - obs))
@@ -163,7 +165,11 @@ twoClassSummary <- function(data, lev = NULL, model = NULL) {
     pROC::roc(data$obs, data[, lev[1]], direction = ">", quiet = TRUE),
     silent = TRUE
   )
-  rocAUC <- if (inherits(rocObject, "try-error")) NA else rocObject$auc
+  if (inherits(rocObject, "try-error")) {
+    rocAUC <- NA
+  } else {
+    rocAUC <- rocObject$auc
+  }
   out <- c(
     rocAUC,
     sensitivity(data[, "pred"], data[, "obs"], lev[1]),
@@ -220,7 +226,11 @@ multiClassSummary <- function(data, lev = NULL, model = NULL) {
           pROC::roc(obs, data[, x], direction = "<", quiet = TRUE),
           silent = TRUE
         )
-        roc_auc <- if (inherits(roc_auc, "try-error")) NA else roc_auc$auc
+        if (inherits(roc_auc, "try-error")) {
+          roc_auc <- NA
+        } else {
+          roc_auc <- roc_auc$auc
+        }
         pr_auc <- try(
           MLmetrics::PRAUC(y_pred = data[, x], y_true = obs),
           silent = TRUE
@@ -249,17 +259,16 @@ multiClassSummary <- function(data, lev = NULL, model = NULL) {
   }
 
   # Aggregate overall stats
-  overall_stats <-
-    if (has_class_probs) {
-      c(
-        CM$overall,
-        logLoss = as.numeric(lloss),
-        AUC = unname(prob_stats["ROC"]),
-        prAUC = unname(prob_stats["AUC"])
-      )
-    } else {
-      CM$overall
-    }
+  if (has_class_probs) {
+    overall_stats <- c(
+      CM$overall,
+      logLoss = as.numeric(lloss),
+      AUC = unname(prob_stats["ROC"]),
+      prAUC = unname(prob_stats["AUC"])
+    )
+  } else {
+    overall_stats <- CM$overall
+  }
 
   # Combine overall with class-wise stats and remove some stats we don't want
   stats <- c(overall_stats, class_stats)

--- a/R/preProcess.R
+++ b/R/preProcess.R
@@ -252,7 +252,11 @@ preProcess.default <- function(
   ## we would center *and* scale before the ICA step, so let's adjust the "scale" method too
   if (any(names(method) == "ica")) {
     theDots <- list(...)
-    row.norm <- if (is.null(list(...)$row.norm)) FALSE else list(...)$row.norm
+    if (is.null(list(...)$row.norm)) {
+      row.norm <- FALSE
+    } else {
+      row.norm <- list(...)$row.norm
+    }
   }
 
   ## check for zero-variance predictors
@@ -408,7 +412,11 @@ preProcess.default <- function(
       cat(" applying them to training data\n")
     }
     if (length(bc) != length(method$BoxCox)) {
-      method$BoxCox <- if (length(bc) == 0) NULL else names(bc)
+      if (length(bc) == 0) {
+        method$BoxCox <- NULL
+      } else {
+        method$BoxCox <- names(bc)
+      }
     }
     for (i in method$BoxCox) {
       x[, i] <- predict(bc[[i]], x[, i])
@@ -622,7 +630,9 @@ preProcess.default <- function(
     bagModels <- as.list(method$bagImpute)
     names(bagModels) <- method$bagImpute
     bagModels <- lapply(bagModels, bagImp, x = x)
-    if (verbose) cat(" done\n")
+    if (verbose) {
+      cat(" done\n")
+    }
   } else {
     bagModels <- NULL
   }
@@ -648,7 +658,9 @@ preProcess.default <- function(
       )
       medianValue[is.na(medianValue)] <- 0
     }
-    if (verbose) cat(" done\n")
+    if (verbose) {
+      cat(" done\n")
+    }
   } else {
     medianValue <- NULL
   }
@@ -877,10 +889,10 @@ predict.preProcess <- function(object, newdata, ...) {
 
   if (any(names(object$method) == "medianImpute") && any(!cc)) {
     missingVars <- apply(newdata, 2, function(x) anyNA(x))
-    missingVars <- if (is.null(names(missingVars))) {
-      which(missingVars)
+    if (is.null(names(missingVars))) {
+      missingVars <- which(missingVars)
     } else {
-      names(missingVars)[missingVars]
+      missingVars <- names(missingVars)[missingVars]
     }
     for (v in missingVars) {
       newdata[is.na(newdata[, v]), v] <- object$median[v]
@@ -889,10 +901,10 @@ predict.preProcess <- function(object, newdata, ...) {
 
   if (any(names(object$method) == "pca")) {
     pca_cols <- newdata[, object$method$pca, drop = FALSE]
-    pca_cols <- if (is.matrix(pca_cols)) {
-      pca_cols %*% object$rotation
+    if (is.matrix(pca_cols)) {
+      pca_cols <- pca_cols %*% object$rotation
     } else {
-      as.matrix(pca_cols) %*% object$rotation
+      pca_cols <- as.matrix(pca_cols) %*% object$rotation
     }
     if (ncol(pca_cols) == 1) {
       colnames(pca_cols) <- "PC1"
@@ -1013,7 +1025,9 @@ print.preProcess <- function(x, ...) {
       lmbda <- unlist(lapply(x$bc, function(x) x$lambda))
       naLmbda <- sum(is.na(lmbda))
       cat(paste(round(lmbda[!is.na(lmbda)], 2), collapse = ", "))
-      if (naLmbda > 0) cat(" (#NA: ", naLmbda, ")\n", sep = "")
+      if (naLmbda > 0) {
+        cat(" (#NA: ", naLmbda, ")\n", sep = "")
+      }
     } else {
       print(summary(unlist(lapply(x$bc, function(x) x$lambda))))
     }
@@ -1026,7 +1040,9 @@ print.preProcess <- function(x, ...) {
     if (length(lmbda) < 11) {
       naLmbda <- sum(is.na(lmbda))
       cat(paste(round(lmbda[!is.na(lmbda)], 2), collapse = ", "))
-      if (naLmbda > 0) cat(" (#NA: ", naLmbda, ")\n", sep = "")
+      if (naLmbda > 0) {
+        cat(" (#NA: ", naLmbda, ")\n", sep = "")
+      }
     } else {
       print(summary(lmbda))
     }
@@ -1367,7 +1383,9 @@ check_for_wildcards <- function(opts, verbose = TRUE) {
         opts[[i]] <- opts[[i]][opts[[i]] != "_PC_"]
       }
     }
-    if (verbose) cat("\n")
+    if (verbose) {
+      cat("\n")
+    }
   }
   ic_wc <- unlist(lapply(opts, function(x) any(x == "_IC_")))
   if (any(ic_wc)) {
@@ -1391,7 +1409,9 @@ check_for_wildcards <- function(opts, verbose = TRUE) {
         opts[[i]] <- opts[[i]][opts[[i]] != "_IC_"]
       }
     }
-    if (verbose) cat("\n")
+    if (verbose) {
+      cat("\n")
+    }
   }
 
   pc_wc <- unlist(lapply(opts, function(x) any(x == "_PC_")))

--- a/R/preProcess.R
+++ b/R/preProcess.R
@@ -197,15 +197,15 @@ getRangeBounds <- function(pp) {
 #' @family preprocessing
 #' @keywords utilities
 #' @examplesIf !caret:::is_cran_check()
-#' 
+#'
 #' data(BloodBrain)
 #' # one variable has one unique value
 #' preProc <- preProcess(bbbDescr)
-#' 
+#'
 #' preProc <- preProcess(bbbDescr[1:100, -3])
 #' training <- predict(preProc, bbbDescr[1:100, -3])
 #' test <- predict(preProc, bbbDescr[101:208, -3])
-#' 
+#'
 #' @export preProcess
 preProcess <- function(x, ...) UseMethod("preProcess")
 
@@ -1249,7 +1249,8 @@ pre_process_options <- function(opts, vars) {
   }
 
   if (
-    any(methods %in% "range") && any(methods %in% c("center", "scale", "BoxCox"))
+    any(methods %in% "range") &&
+      any(methods %in% c("center", "scale", "BoxCox"))
   ) {
     stop(
       "Centering, scaling and/or Box-Cox transformations are inconsistent with scaling to a range"

--- a/R/prec_rec.R
+++ b/R/prec_rec.R
@@ -57,10 +57,10 @@
 #' @family performance
 #' @keywords manip
 #' @examples
-#' 
+#'
 #' ###################
 #' ## Data in Table 2 of Powers (2007)
-#' 
+#'
 #' lvs <- c("Relevant", "Irrelevant")
 #' tbl_2_1_pred <- factor(rep(lvs, times = c(42, 58)), levels = lvs)
 #' tbl_2_1_truth <- factor(
@@ -68,34 +68,38 @@
 #'   levels = lvs
 #' )
 #' tbl_2_1 <- table(tbl_2_1_pred, tbl_2_1_truth)
-#' 
+#'
 #' precision(tbl_2_1)
 #' precision(data = tbl_2_1_pred, reference = tbl_2_1_truth, relevant = "Relevant")
 #' recall(tbl_2_1)
 #' recall(data = tbl_2_1_pred, reference = tbl_2_1_truth, relevant = "Relevant")
-#' 
+#'
 #' tbl_2_2_pred <- factor(rep(lvs, times = c(76, 24)), levels = lvs)
 #' tbl_2_2_truth <- factor(
 #'   c(rep(lvs, times = c(56, 20)), rep(lvs, times = c(12, 12))),
 #'   levels = lvs
 #' )
 #' tbl_2_2 <- table(tbl_2_2_pred, tbl_2_2_truth)
-#' 
+#'
 #' precision(tbl_2_2)
 #' precision(data = tbl_2_2_pred, reference = tbl_2_2_truth, relevant = "Relevant")
 #' recall(tbl_2_2)
 #' recall(data = tbl_2_2_pred, reference = tbl_2_2_truth, relevant = "Relevant")
-#' 
+#'
 #' @export recall
 recall <- function(data, ...) UseMethod("recall")
 
 #' @rdname recall
 #' @export
-"recall.table" <- function(data, relevant = rownames(data)[1], ...){
-  if(!all.equal(nrow(data), ncol(data))) stop("the table must have nrow = ncol")
-  if(!all.equal(rownames(data), colnames(data))) stop("the table must the same groups in the same order")
+"recall.table" <- function(data, relevant = rownames(data)[1], ...) {
+  if (!all.equal(nrow(data), ncol(data))) {
+    stop("the table must have nrow = ncol")
+  }
+  if (!all.equal(rownames(data), colnames(data))) {
+    stop("the table must the same groups in the same order")
+  }
 
-  if(nrow(data) > 2) {
+  if (nrow(data) > 2) {
     tmp <- data
     data <- matrix(NA, 2, 2)
 
@@ -119,12 +123,19 @@ recall <- function(data, ...) UseMethod("recall")
 
 #' @rdname recall
 #' @export
-recall.default <- function(data, reference, relevant = levels(reference)[1],
-                           na.rm = TRUE, ...) {
-  if (!is.factor(reference) || !is.factor(data))
+recall.default <- function(
+  data,
+  reference,
+  relevant = levels(reference)[1],
+  na.rm = TRUE,
+  ...
+) {
+  if (!is.factor(reference) || !is.factor(data)) {
     stop("input data must be a factor")
-  if (length(unique(c(levels(reference), levels(data)))) != 2)
+  }
+  if (length(unique(c(levels(reference), levels(data)))) != 2) {
     stop("input data must have the same two levels")
+  }
   if (na.rm) {
     cc <- complete.cases(data) & complete.cases(reference)
     if (any(!cc)) {
@@ -142,12 +153,19 @@ precision <- function(data, ...) UseMethod("precision")
 
 #' @rdname recall
 #' @export
-precision.default <- function(data, reference, relevant = levels(reference)[1],
-                              na.rm = TRUE, ...) {
-  if (!is.factor(reference) || !is.factor(data))
+precision.default <- function(
+  data,
+  reference,
+  relevant = levels(reference)[1],
+  na.rm = TRUE,
+  ...
+) {
+  if (!is.factor(reference) || !is.factor(data)) {
     stop("input data must be a factor")
-  if (length(unique(c(levels(reference), levels(data)))) != 2)
+  }
+  if (length(unique(c(levels(reference), levels(data)))) != 2) {
     stop("input data must have the same two levels")
+  }
   if (na.rm) {
     cc <- complete.cases(data) & complete.cases(reference)
     if (any(!cc)) {
@@ -161,11 +179,13 @@ precision.default <- function(data, reference, relevant = levels(reference)[1],
 
 #' @rdname recall
 #' @export
-precision.table <- function (data, relevant = rownames(data)[1], ...) {
-  if (!all.equal(nrow(data), ncol(data)))
+precision.table <- function(data, relevant = rownames(data)[1], ...) {
+  if (!all.equal(nrow(data), ncol(data))) {
     stop("the table must have nrow = ncol")
-  if (!all.equal(rownames(data), colnames(data)))
+  }
+  if (!all.equal(rownames(data), colnames(data))) {
     stop("the table must the same groups in the same order")
+  }
   if (nrow(data) > 2) {
     tmp <- data
     data <- matrix(NA, 2, 2)
@@ -183,7 +203,7 @@ precision.table <- function (data, relevant = rownames(data)[1], ...) {
   }
   numer <- data[relevant, relevant]
   denom <- sum(data[relevant, ])
-  spec <- ifelse(denom > 0, numer/denom, NA)
+  spec <- ifelse(denom > 0, numer / denom, NA)
   spec
 }
 
@@ -193,12 +213,20 @@ F_meas <- function(data, ...) UseMethod("F_meas")
 
 #' @rdname recall
 #' @export
-F_meas.default <- function(data, reference, relevant = levels(reference)[1],
-                           beta = 1,  na.rm = TRUE, ...) {
-  if (!is.factor(reference) || !is.factor(data))
+F_meas.default <- function(
+  data,
+  reference,
+  relevant = levels(reference)[1],
+  beta = 1,
+  na.rm = TRUE,
+  ...
+) {
+  if (!is.factor(reference) || !is.factor(data)) {
     stop("input data must be a factor")
-  if (length(unique(c(levels(reference), levels(data)))) != 2)
+  }
+  if (length(unique(c(levels(reference), levels(data)))) != 2) {
     stop("input data must have the same two levels")
+  }
   if (na.rm) {
     cc <- complete.cases(data) & complete.cases(reference)
     if (any(!cc)) {
@@ -212,39 +240,66 @@ F_meas.default <- function(data, reference, relevant = levels(reference)[1],
 
 #' @rdname recall
 #' @export
-F_meas.table <- function (data, relevant = rownames(data)[1], beta = 1, ...) {
+F_meas.table <- function(data, relevant = rownames(data)[1], beta = 1, ...) {
   prec <- precision.table(data, relevant = relevant)
   rec <- recall.table(data, relevant = relevant)
-  (1+beta^2)*prec*rec/((beta^2 * prec)+rec)
+  (1 + beta^2) * prec * rec / ((beta^2 * prec) + rec)
 }
 
 #' @rdname postResample
 #' @export
-prSummary <- function (data, lev = NULL, model = NULL)  {
-
+prSummary <- function(data, lev = NULL, model = NULL) {
   requireNamespaceQuietStop("MLmetrics")
-  if (length(levels(data$obs)) > 2)
-    stop(paste("Your outcome has", length(levels(data$obs)),
-               "levels. `prSummary`` function isn't appropriate.",
-         call. = FALSE))
-  if (!all(levels(data[, "pred"]) == levels(data[, "obs"])))
-    stop("Levels of observed and predicted data do not match.",
-         call. = FALSE)
-  if (!lev[1] %in% colnames(data))
-    stop(paste("Class probabilities are needed to score models using the",
-               "area under the PR curve. Set `classProbs = TRUE`",
-               "in the trainControl() function."),
-         call. = FALSE)
+  if (length(levels(data$obs)) > 2) {
+    stop(paste(
+      "Your outcome has",
+      length(levels(data$obs)),
+      "levels. `prSummary`` function isn't appropriate.",
+      call. = FALSE
+    ))
+  }
+  if (!all(levels(data[, "pred"]) == levels(data[, "obs"]))) {
+    stop("Levels of observed and predicted data do not match.", call. = FALSE)
+  }
+  if (!lev[1] %in% colnames(data)) {
+    stop(
+      paste(
+        "Class probabilities are needed to score models using the",
+        "area under the PR curve. Set `classProbs = TRUE`",
+        "in the trainControl() function."
+      ),
+      call. = FALSE
+    )
+  }
 
   pr_auc <-
-    try(MLmetrics::PRAUC(y_pred = data[, lev[1]],
-                         y_true = ifelse(data$obs == lev[1], 1, 0)),
-        silent = TRUE)
-  if(inherits(pr_auc, "try-error"))
+    try(
+      MLmetrics::PRAUC(
+        y_pred = data[, lev[1]],
+        y_true = ifelse(data$obs == lev[1], 1, 0)
+      ),
+      silent = TRUE
+    )
+  if (inherits(pr_auc, "try-error")) {
     pr_auc <- NA
+  }
 
-  c(AUC = pr_auc,
-    Precision = precision.default(data = data$pred, reference = data$obs, relevant = lev[1]),
-    Recall = recall.default(data = data$pred, reference = data$obs, relevant = lev[1]),
-    F = F_meas.default(data = data$pred, reference = data$obs, relevant = lev[1]))
+  c(
+    AUC = pr_auc,
+    Precision = precision.default(
+      data = data$pred,
+      reference = data$obs,
+      relevant = lev[1]
+    ),
+    Recall = recall.default(
+      data = data$pred,
+      reference = data$obs,
+      relevant = lev[1]
+    ),
+    F = F_meas.default(
+      data = data$pred,
+      reference = data$obs,
+      relevant = lev[1]
+    )
+  )
 }

--- a/R/predict.PLS.R
+++ b/R/predict.PLS.R
@@ -1,55 +1,68 @@
-
 #' @export
-predict.PLS <- function(object, newdata,
-   ncomp = NULL,
-   type = ifelse(object$isRegression, "response", "class"), ...)
-{
+predict.PLS <- function(
+  object,
+  newdata,
+  ncomp = NULL,
+  type = ifelse(object$isRegression, "response", "class"),
+  ...
+) {
+  if (is.null(ncomp) && !is.null(object$bestIter$.ncomp)) {
+    ncomp <- object$bestIter$.ncomp
+  }
 
-   if(is.null(ncomp) && !is.null(object$bestIter$.ncomp)) ncomp <- object$bestIter$.ncomp
+  if (is.null(ncomp)) {
+    stop("the number of components must be given")
+  }
 
-   if(is.null(ncomp)) stop("the number of components must be given")
+  # adapted from the pls package
+  if (object$isRegression && c(type %in% c("class", "prob"))) {
+    stop("cannot get a class estimate if the original y was not a factor")
+  }
 
-   # adapted from the pls package
-   if(object$isRegression && c(type %in% c("class", "prob")))
-      stop("cannot get a class estimate if the original y was not a factor")
+  if (!(type %in% c("response", "class", "prob"))) {
+    stop("type must be either response, class or prob")
+  }
 
-   if(!(type %in% c("response", "class", "prob")))
-      stop("type must be either response, class or prob")
+  if (missing(newdata)) {
+    newdata <- object$x
+  }
+  if (!is.matrix(newdata)) {
+    newdata <- as.matrix(newdata)
+  }
 
-   if(missing(newdata)) newdata <- object$x
-   if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
+  # from coef.mvr in pls package
+  B <- object$coefficients[,, 1:ncomp, drop = FALSE]
+  dB <- dim(B)
+  dB[1] <- dB[1] + 1
+  dnB <- dimnames(B)
+  dnB[[1]] <- c("(Intercept)", dnB[[1]])
+  BInt <- array(dim = dB, dimnames = dnB)
+  BInt[-1, , ] <- B
+  for (i in seq(along.with = 1:ncomp)) {
+    BInt[1, , i] <- object$Ymeans - object$Xmeans %*% B[,, i]
+  }
+  B <- BInt
+  # stop
 
-   # from coef.mvr in pls package
-   B <- object$coefficients[, , 1:ncomp, drop = FALSE]
-   dB <- dim(B)
-   dB[1] <- dB[1] + 1
-   dnB <- dimnames(B)
-   dnB[[1]] <- c("(Intercept)", dnB[[1]])
-   BInt <- array(dim = dB, dimnames = dnB)
-   BInt[-1, , ] <- B
-   for (i in seq(along.with = 1:ncomp)) BInt[1, , i] <- object$Ymeans - object$Xmeans %*% B[, , i]
-   B <- BInt
-   # stop
+  # from predict.mvr in pls package
+  dPred <- dim(B)
+  dPred[1] <- dim(newdata)[1]
+  dnPred <- dimnames(B)
+  dnPred[1] <- dimnames(newdata)[1]
+  pred <- array(dim = dPred, dimnames = dnPred)
+  predY <- sweep(newdata %*% B[-1, , ncomp], 2, B[1, , ncomp], "+")
+  # stop
 
-   # from predict.mvr in pls package
-   dPred <- dim(B)
-   dPred[1] <- dim(newdata)[1]
-   dnPred <- dimnames(B)
-   dnPred[1] <- dimnames(newdata)[1]
-   pred <- array(dim = dPred, dimnames = dnPred)
-   predY <- sweep(newdata %*% B[-1, , ncomp], 2, B[1, , ncomp], "+")
-   # stop
+  out <- switch(
+    type,
+    response = predY,
+    class = {
+      classNum <- apply(predY, 1, which.max)
+      factor(object$yLevels[classNum], levels = object$yLevels)
+    },
+    # use softmax technique here
+    prob = t(apply(predY, 1, function(data) exp(data) / sum(exp(data))))
+  )
 
-   out <- switch(
-      type,
-      response = predY,
-      class =
-         {
-            classNum <- apply(predY, 1, which.max)
-            factor(object$yLevels[classNum], levels = object$yLevels)
-         },
-      # use softmax technique here
-      prob =  t(apply(predY, 1, function(data) exp(data)/sum(exp(data)))))
-
-   out
+  out
 }

--- a/R/predict.train.R
+++ b/R/predict.train.R
@@ -80,34 +80,34 @@ predict.list <- function(object, ...) {
 #' @family train
 #' @keywords manip
 #' @examplesIf !caret:::is_cran_check()
-#' 
+#'
 #'    \dontrun{
-#' 
+#'
 #' knnFit <- train(
 #'   Species ~ .,
 #'   data = iris,
 #'   method = "knn",
 #'   trControl = trainControl(method = "cv")
 #' )
-#' 
+#'
 #' rdaFit <- train(
 #'   Species ~ .,
 #'   data = iris,
 #'   method = "rda",
 #'   trControl = trainControl(method = "cv")
 #' )
-#' 
+#'
 #' predict(knnFit)
 #' predict(knnFit, type = "prob")
-#' 
+#'
 #' bothModels <- list(knn = knnFit, tree = rdaFit)
-#' 
+#'
 #' predict(bothModels)
-#' 
+#'
 #' extractPrediction(bothModels, testX = iris[1:10, -5])
 #' extractProb(bothModels, testX = iris[1:10, -5])
 #'   }
-#' 
+#'
 #' @export predict.train
 #' @export
 predict.train <- function(

--- a/R/predictionFunction.R
+++ b/R/predictionFunction.R
@@ -1,12 +1,20 @@
 #' @rdname caret-internal
 #' @export
-predictionFunction <- function(method, modelFit, newdata, preProc = NULL, param = NULL)
-{
-  if(!is.null(newdata) && !is.null(preProc)) newdata <- predict(preProc, newdata)
-  out <- method$predict(modelFit = modelFit, 
-                        newdata = newdata, 
-                        submodels = param)
+predictionFunction <- function(
+  method,
+  modelFit,
+  newdata,
+  preProc = NULL,
+  param = NULL
+) {
+  if (!is.null(newdata) && !is.null(preProc)) {
+    newdata <- predict(preProc, newdata)
+  }
+  out <- method$predict(
+    modelFit = modelFit,
+    newdata = newdata,
+    submodels = param
+  )
   ## TODO convert to character with classification
-  out 
+  out
 }
-

--- a/R/predictors.R
+++ b/R/predictors.R
@@ -22,57 +22,66 @@
 #' @return a character string of predictors or `NA`.
 #' @keywords models
 #' @export predictors
-"predictors" <- function(x, ...){
-    UseMethod("predictors")
-  }
+"predictors" <- function(x, ...) {
+  UseMethod("predictors")
+}
 
 #' @export
 predictors.train <- function(x, ...) {
-  if(is.null(x$modelInfo)) {
+  if (is.null(x$modelInfo)) {
     code <- getModelInfo(x$method, regex = FALSE)[[1]]
-  } else code <- x$modelInfo
-  if(!is.null(code$predictors)){
+  } else {
+    code <- x$modelInfo
+  }
+  if (!is.null(code$predictors)) {
     checkInstall(code$library)
-    for(i in seq(along.with = code$library))
+    for (i in seq(along.with = code$library)) {
       do.call("requireNamespaceQuietStop", list(package = code$library[i]))
+    }
     out <- code$predictors(x$finalModel, ...)
   } else {
-    if(hasTerms(x)) {
+    if (hasTerms(x)) {
       out <- predictors(x$terms, ...)
-    } else out <- NA
+    } else {
+      out <- NA
+    }
   }
   out
-  }
+}
 
 #' @export
 predictors.default <- function(x, ...) {
   cls <- model2method(class(x)[1])
-  if(cls == "gam")  cls <- if(any(names(x) == "optimizer")) "gam" else "gamLoess"
+  if (cls == "gam") {
+    cls <- if (any(names(x) == "optimizer")) "gam" else "gamLoess"
+  }
   code <- getModelInfo(cls, regex = FALSE)[[1]]
-  if(!is.null(code)) {
-    if(!is.null(code$predictors)){
+  if (!is.null(code)) {
+    if (!is.null(code$predictors)) {
       checkInstall(code$library)
-      for(i in seq(along.with = code$library))
+      for (i in seq(along.with = code$library)) {
         do.call("requireNamespaceQuietStop", list(package = code$library[i]))
+      }
       out <- code$predictors(x, ...)
     } else {
-      if(hasTerms(x)) {
+      if (hasTerms(x)) {
         out <- predictors(x$terms, ...)
-      } else out <- NA
+      } else {
+        out <- NA
+      }
     }
   } else {
-    out <- if(hasTerms(x)) predictors(x$terms) else NA
+    out <- if (hasTerms(x)) predictors(x$terms) else NA
   }
   out
 }
 
 #' @rdname caret-internal
 #' @export
-hasTerms <- function(x)
-  {
-    objNames <- c(names(x), slotNames(x))
-    "terms" %in% tolower(objNames)
-  }
+hasTerms <- function(x) {
+  objNames <- c(names(x), slotNames(x))
+  "terms" %in% tolower(objNames)
+}
 
 ## basicVars tries to detect the actual variable that are used
 ## when a formula might include other terms (such as interactions)
@@ -84,35 +93,34 @@ hasTerms <- function(x)
 ## > basicVars(x, y)
 ## [1] "crim" "zn"   "age"
 
-basicVars <- function(x, y)
-  {
-    hasVar <- rep(NA, length(x))
-    for(i in seq(along.with = x))
-      hasVar[i] <- length(grep(x[i], y, fixed = TRUE)) > 0
-    x[hasVar]
+basicVars <- function(x, y) {
+  hasVar <- rep(NA, length(x))
+  for (i in seq(along.with = x)) {
+    hasVar[i] <- length(grep(x[i], y, fixed = TRUE)) > 0
   }
+  x[hasVar]
+}
 
 #' @export
-predictors.terms <- function(x, ...)
-  {
-    if(is.null(x)) return(NA)
-    everything <- all.vars(x)
-    yName <- as.character(x[[2]])
-    everything[!(everything %in% yName)]
+predictors.terms <- function(x, ...) {
+  if (is.null(x)) {
+    return(NA)
   }
+  everything <- all.vars(x)
+  yName <- as.character(x[[2]])
+  everything[!(everything %in% yName)]
+}
 
 #' @export
-predictors.formula <- function(x, ...)
-  {
-    everything <- all.vars(x)
-    yName <- as.character(x[[2]])
-    everything[!(everything %in% yName)]
-  }
+predictors.formula <- function(x, ...) {
+  everything <- all.vars(x)
+  yName <- as.character(x[[2]])
+  everything[!(everything %in% yName)]
+}
 
 #' @export
-predictors.list <- function(x, ...)
-  {
-    out <- lapply(x, predictors)
-    names(out) <- names(x)
-    out
-  }
+predictors.list <- function(x, ...) {
+  out <- lapply(x, predictors)
+  names(out) <- names(x)
+  out
+}

--- a/R/predictors.R
+++ b/R/predictors.R
@@ -53,7 +53,11 @@ predictors.train <- function(x, ...) {
 predictors.default <- function(x, ...) {
   cls <- model2method(class(x)[1])
   if (cls == "gam") {
-    cls <- if (any(names(x) == "optimizer")) "gam" else "gamLoess"
+    if (any(names(x) == "optimizer")) {
+      cls <- "gam"
+    } else {
+      cls <- "gamLoess"
+    }
   }
   code <- getModelInfo(cls, regex = FALSE)[[1]]
   if (!is.null(code)) {
@@ -71,7 +75,11 @@ predictors.default <- function(x, ...) {
       }
     }
   } else {
-    out <- if (hasTerms(x)) predictors(x$terms) else NA
+    if (hasTerms(x)) {
+      out <- predictors(x$terms)
+    } else {
+      out <- NA
+    }
   }
   out
 }

--- a/R/print.mars.R
+++ b/R/print.mars.R
@@ -1,16 +1,30 @@
 #' @export
-print.bmars <- function (x, ...)
-{
-    cat("\nCall:\n", deparse(x$call), "\n\n", sep = "")
-    if(!is.null(x$x))cat("Data:\n   # variables:\t", dim(x$x)[2], "\n   # samples:\t", dim(x$x)[1], "\n")
+print.bmars <- function(x, ...) {
+  cat("\nCall:\n", deparse(x$call), "\n\n", sep = "")
+  if (!is.null(x$x)) {
     cat(
-      "\nModel:",
-      "\n   B:        \t", x$B,
-      "\n   degree:   \t", x$fit[[1]]$degree,
-      "\n   nk:       \t", x$fit[[1]]$nk,
-      "\n   penalty:  \t", x$fit[[1]]$penalty,
-      "\n   threshold:\t", x$fit[[1]]$thresh, "\n")
+      "Data:\n   # variables:\t",
+      dim(x$x)[2],
+      "\n   # samples:\t",
+      dim(x$x)[1],
+      "\n"
+    )
+  }
+  cat(
+    "\nModel:",
+    "\n   B:        \t",
+    x$B,
+    "\n   degree:   \t",
+    x$fit[[1]]$degree,
+    "\n   nk:       \t",
+    x$fit[[1]]$nk,
+    "\n   penalty:  \t",
+    x$fit[[1]]$penalty,
+    "\n   threshold:\t",
+    x$fit[[1]]$thresh,
+    "\n"
+  )
 
-    cat("\n")
-    invisible(x)
+  cat("\n")
+  invisible(x)
 }

--- a/R/print.train.R
+++ b/R/print.train.R
@@ -1,15 +1,18 @@
-stringFunc <- function (x)  {
-  if (!is.character(x)) x <- format(x)
+stringFunc <- function(x) {
+  if (!is.character(x)) {
+    x <- format(x)
+  }
   numElements <- length(x)
   out <- if (length(x) > 0) {
     switch(min(numElements, 3), x, paste(x, collapse = " and "), {
       x <- paste0(x, c(rep(",", numElements - 2), " and", ""))
       paste(x, collapse = " ")
     })
-  } else ""
+  } else {
+    ""
+  }
   out
 }
-
 
 
 #' Print Method for the train Class
@@ -34,15 +37,15 @@ stringFunc <- function (x)  {
 #' @seealso [train()]
 #' @family train
 #' @keywords print
-#' @export  
+#' @export
 #' @examplesIf !caret:::is_cran_check()
-#' 
+#'
 #' data(iris)
 #' TrainData <- iris[, 1:4]
 #' TrainClasses <- iris[, 5]
-#' 
+#'
 #' options(digits = 3)
-#' 
+#'
 #' library(klaR)
 #' rdaFit <- train(
 #'   TrainData,
@@ -52,170 +55,210 @@ stringFunc <- function (x)  {
 #' )
 #' rdaFit
 #' print(rdaFit, showSD = TRUE)
-#' 
+#'
 #' @export print.train
 
 "print.train" <-
-  function(x,
-           printCall = FALSE,
-           details = FALSE,
-           selectCol = FALSE,
-           showSD = FALSE,
-           ...) {
+  function(
+    x,
+    printCall = FALSE,
+    details = FALSE,
+    selectCol = FALSE,
+    showSD = FALSE,
+    ...
+  ) {
+    if (!is.null(x$modelInfo$label)) {
+      cat(x$modelInfo$label, "\n\n")
+    }
+    if (printCall) {
+      printCall(x$call)
+    }
 
-    if(!is.null(x$modelInfo$label)) cat(x$modelInfo$label, "\n\n")
-    if(printCall) printCall(x$call)
-
-    if(!is.null(x$trainingData)) {
+    if (!is.null(x$trainingData)) {
       chDim <- dim(x$trainingData)
       chDim[2] <- chDim[2] - 1
-      if(x$modelType == "Classification") {
+      if (x$modelType == "Classification") {
         lev <- levels(x)
-        if(is.character(lev)) chDim <- c(chDim, length(lev))
-      } else lev <- NULL
+        if (is.character(lev)) chDim <- c(chDim, length(lev))
+      } else {
+        lev <- NULL
+      }
       chDim <- format(chDim)
       cat(chDim[1], " samples", sep = "")
-      if(!is.null(x$control$indexFinal))
-        cat(",", length(x$control$indexFinal), "used for final model\n") else
-          cat("\n")
-      cat(chDim[2],
-          " predictor", ifelse(chDim[2] > 1, "s\n", "\n"),
-          sep = "")
-      if(is.character(lev)){
-        cat(chDim[3],
-            "classes:",
-            paste("'", lev, "'", sep = "", collapse = ", "),
-            "\n")
+      if (!is.null(x$control$indexFinal)) {
+        cat(",", length(x$control$indexFinal), "used for final model\n")
+      } else {
+        cat("\n")
+      }
+      cat(chDim[2], " predictor", ifelse(chDim[2] > 1, "s\n", "\n"), sep = "")
+      if (is.character(lev)) {
+        cat(
+          chDim[3],
+          "classes:",
+          paste("'", lev, "'", sep = "", collapse = ", "),
+          "\n"
+        )
       }
       cat("\n")
     }
 
-    if(!is.null(x$preProc)){
+    if (!is.null(x$preProc)) {
       pp_list(x$preProc$method)
     } else {
-      if(inherits(x, "train.recipe")) {
+      if (inherits(x, "train.recipe")) {
         step_names <- function(x) gsub("^step_", "", class(x)[1])
         steps_used <- unlist(lapply(x$recipe$steps, step_names))
         ppText <- paste("Recipe steps:", paste(steps_used, collapse = ", "))
         cat(truncateText(ppText), "\n")
-      } else cat("No pre-processing\n")
+      } else {
+        cat("No pre-processing\n")
+      }
     }
 
-    if(!is.null(x$control$index)) {
+    if (!is.null(x$control$index)) {
       resampleN <- unlist(lapply(x$control$index, length))
       numResamp <- length(resampleN)
 
       resampText <- resampName(x)
 
       cat("Resampling:", resampText, "\n")
-      if(x$control$method != "none") {
+      if (x$control$method != "none") {
         outLabel <- x$metric
 
         resampleN <- as.character(resampleN)
-        if(numResamp > 5) resampleN <- c(resampleN[1:6], "...")
+        if (numResamp > 5) {
+          resampleN <- c(resampleN[1:6], "...")
+        }
         cat("Summary of sample sizes:", paste(resampleN, collapse = ", "), "\n")
       }
     }
-    if(!is.null(x$control$sampling)) {
+    if (!is.null(x$control$sampling)) {
       cat("Addtional sampling using ")
-      cat(switch(x$control$sampling$name,
-                 down = "down-sampling",
-                 up = "up-sampling",
-                 smote = "SMOTE",
-                 rose = "ROSE",
-                 custom = "a custom function"))
-      if(!is.null(x$preProc)) {
-        if(x$control$sampling$first)
-          cat(" prior to pre-processing") else
-            cat(" after to pre-processing")
+      cat(switch(
+        x$control$sampling$name,
+        down = "down-sampling",
+        up = "up-sampling",
+        smote = "SMOTE",
+        rose = "ROSE",
+        custom = "a custom function"
+      ))
+      if (!is.null(x$preProc)) {
+        if (x$control$sampling$first) {
+          cat(" prior to pre-processing")
+        } else {
+          cat(" after to pre-processing")
+        }
       }
       cat("\n\n")
     }
 
-    if(x$control$method != "none") {
-
+    if (x$control$method != "none") {
       tuneAcc <- x$results
 
       tuneAcc <- tuneAcc[, names(tuneAcc) != "parameter"]
 
       cat("Resampling results")
-      if(dim(tuneAcc)[1] > 1) cat(" across tuning parameters")
-      if(showSD) cat(" (values below are 'mean (sd)')")
+      if (dim(tuneAcc)[1] > 1) {
+        cat(" across tuning parameters")
+      }
+      if (showSD) {
+        cat(" (values below are 'mean (sd)')")
+      }
       cat(":\n\n")
 
-      if(dim(tuneAcc)[1] > 1) {
-
+      if (dim(tuneAcc)[1] > 1) {
         numParam <- length(x$bestTune)
 
         finalTune <- x$bestTune
 
         optValues <- paste(names(finalTune), "=", format(finalTune, ...))
-        optString <- paste0("The final ",
-                            ifelse(numParam > 1, "values", "value"),
-                            " used for the model ",
-                            ifelse(numParam > 1, "were ", "was "),
-                            stringFunc(optValues),
-                            ".")
-
+        optString <- paste0(
+          "The final ",
+          ifelse(numParam > 1, "values", "value"),
+          " used for the model ",
+          ifelse(numParam > 1, "were ", "was "),
+          stringFunc(optValues),
+          "."
+        )
 
         finalTune$Selected <- "*"
 
         ## See https://stat.ethz.ch/pipermail/r-help/2016-July/440230.html
-        if(any(names(tuneAcc) %in% "method"))
+        if (any(names(tuneAcc) %in% "method")) {
           names(tuneAcc)[names(tuneAcc) %in% "method"] <- ".method"
-        if(any(names(finalTune) %in% "method"))
+        }
+        if (any(names(finalTune) %in% "method")) {
           names(finalTune)[names(finalTune) %in% "method"] <- ".method"
+        }
 
         tuneAcc <- merge(tuneAcc, finalTune, all.x = TRUE)
 
-        if(any(names(tuneAcc) %in% ".method"))
+        if (any(names(tuneAcc) %in% ".method")) {
           names(tuneAcc)[names(tuneAcc) %in% ".method"] <- "method"
+        }
 
         tuneAcc$Selected[is.na(tuneAcc$Selected)] <- ""
-
-      } else optString <- ""
+      } else {
+        optString <- ""
+      }
 
       sdCols <- grep("SD$", colnames(tuneAcc))
-      if(showSD) {
-        sdCheck <- unlist(lapply(tuneAcc[, sdCols, drop = FALSE],
-                                 function(u) all(is.na(u))))
-        if(any(sdCheck)) {
+      if (showSD) {
+        sdCheck <- unlist(lapply(tuneAcc[, sdCols, drop = FALSE], function(u) {
+          all(is.na(u))
+        }))
+        if (any(sdCheck)) {
           rmCols <- names(sdCheck)[sdCheck]
           tuneAcc <- tuneAcc[, !(names(tuneAcc) %in% rmCols)]
         }
       } else {
-        if(length(sdCols) > 0) tuneAcc <- tuneAcc[, -sdCols, drop = FALSE]
+        if (length(sdCols) > 0) tuneAcc <- tuneAcc[, -sdCols, drop = FALSE]
       }
 
       params <- names(x$bestTune)
 
-      if(!all(params == "parameter")){
-        numVals <- apply(tuneAcc[, params, drop = FALSE], 2, function(x) length(unique(x)))
-        if(any(numVals < 2)) {
+      if (!all(params == "parameter")) {
+        numVals <- apply(tuneAcc[, params, drop = FALSE], 2, function(x) {
+          length(unique(x))
+        })
+        if (any(numVals < 2)) {
           constString <- NULL
-          for(i in seq(along.with = numVals)) {
-            if(numVals[i] == 1)
-              constString <- c(constString,
-                               paste0("Tuning parameter '",
-                                      names(numVals)[i],
-                                      "' was held constant at a value of ",
-                                      stringFunc(tuneAcc[1,names(numVals)[i]])))
+          for (i in seq(along.with = numVals)) {
+            if (numVals[i] == 1) {
+              constString <- c(
+                constString,
+                paste0(
+                  "Tuning parameter '",
+                  names(numVals)[i],
+                  "' was held constant at a value of ",
+                  stringFunc(tuneAcc[1, names(numVals)[i]])
+                )
+              )
+            }
           }
           discard <- names(numVals)[which(numVals == 1)]
           tuneAcc <- tuneAcc[, !(names(tuneAcc) %in% discard), drop = FALSE]
+        } else {
+          constString <- NULL
+        }
+      } else {
+        constString <- NULL
+      }
 
-        } else constString <- NULL
-      } else constString <- NULL
-
-      tuneAcc <- tuneAcc[,!grepl("Apparent$|Optimism$", names(tuneAcc)), drop = FALSE]
+      tuneAcc <- tuneAcc[,
+        !grepl("Apparent$|Optimism$", names(tuneAcc)),
+        drop = FALSE
+      ]
       colnames(tuneAcc)[colnames(tuneAcc) == ".B"] <- "Resamples"
       nms <- names(tuneAcc)[names(tuneAcc) %in% params]
       sort_args <- vector(mode = "list", length = length(nms))
-      for(i in seq(along.with = nms)) {
+      for (i in seq(along.with = nms)) {
         sort_args[[i]] <- tuneAcc[, nms[i]]
       }
       tune_ord <- do.call("order", sort_args)
-      if(!is.null(tune_ord)) tuneAcc <- tuneAcc[tune_ord,,drop = FALSE]
+      if (!is.null(tune_ord)) {
+        tuneAcc <- tuneAcc[tune_ord, , drop = FALSE]
+      }
 
       theDots <- list(...)
       theDots$x <- tuneAcc
@@ -224,106 +267,147 @@ stringFunc <- function (x)  {
       printMat <- as.matrix(printMat)
       rownames(printMat) <- rep("", dim(printMat)[1])
 
-      if(showSD){
+      if (showSD) {
         sdCols <- grep("SD$", colnames(printMat), value = TRUE)
         sd_dat <- printMat[, sdCols, drop = FALSE]
         printMat <- printMat[, !(colnames(printMat) %in% sdCols), drop = FALSE]
-        for(col_name in sdCols) {
+        for (col_name in sdCols) {
           not_sd <- gsub("SD$", "", col_name)
-          if(any(colnames(printMat) == not_sd)) {
-            printMat[, not_sd] <- paste0(printMat[, not_sd], " (",
-                                         sd_dat[, col_name], ")")
+          if (any(colnames(printMat) == not_sd)) {
+            printMat[, not_sd] <- paste0(
+              printMat[, not_sd],
+              " (",
+              sd_dat[, col_name],
+              ")"
+            )
           }
         }
       }
-      if(!selectCol) printMat <- printMat[, colnames(printMat) != "Selected", drop = FALSE]
+      if (!selectCol) {
+        printMat <- printMat[, colnames(printMat) != "Selected", drop = FALSE]
+      }
 
       print(printMat, quote = FALSE, print.gap = 2)
 
       cat("\n")
 
-      if(!is.null(constString)){
+      if (!is.null(constString)) {
         cat(truncateText(paste(constString, collapse = "\n")))
         cat("\n")
       }
 
-
-      if(dim(tuneAcc)[1] > 1) {
-        if(is.null(x$update)) {
+      if (dim(tuneAcc)[1] > 1) {
+        if (is.null(x$update)) {
           met <- paste(x$metric, "was used to select the optimal model using")
-          if(is.function(x$control$selectionFunction)) {
+          if (is.function(x$control$selectionFunction)) {
             met <- paste(met, " a custom selection rule.\n")
           } else {
-
-            met <- paste(met,
-                         switch(x$control$selectionFunction,
-                                best = paste(
-                                  "the",
-                                  ifelse(x$maximize, "largest", "smallest"),
-                                  "value.\n"),
-                                oneSE = " the one SE rule.\n",
-                                tolerance = " a tolerance rule.\n"))
+            met <- paste(
+              met,
+              switch(
+                x$control$selectionFunction,
+                best = paste(
+                  "the",
+                  ifelse(x$maximize, "largest", "smallest"),
+                  "value.\n"
+                ),
+                oneSE = " the one SE rule.\n",
+                tolerance = " a tolerance rule.\n"
+              )
+            )
           }
         } else {
-          met <- paste("The tuning", ifelse(ncol(x$bestTune) > 1, "parameters", "parameter"),
-                       "was set manually.\n")
-
+          met <- paste(
+            "The tuning",
+            ifelse(ncol(x$bestTune) > 1, "parameters", "parameter"),
+            "was set manually.\n"
+          )
         }
         cat(truncateText(met))
       }
 
       cat(truncateText(optString))
-      if(nzchar(optString)) cat("\n")
-    } else printMat <- NULL
+      if (nzchar(optString)) cat("\n")
+    } else {
+      printMat <- NULL
+    }
 
-    if(details) {
-      if(!(x$method %in% c("gbm", "treebag", "nb", "lvq", "knn"))) {
+    if (details) {
+      if (!(x$method %in% c("gbm", "treebag", "nb", "lvq", "knn"))) {
         cat("\n----------------------------------------------------------\n")
         cat("\nThe final model:\n\n")
-        switch(x$method,
-               lm =, nnet =, multinom =, pls =, earth =,
-               lmStepAIC =,
-               bagEarth =, bagFDA = print(summary(x$finalModel)),
-               rpart =, ctree =, ctree2=, cforest =,
-               glmboost =, gamboost =, blackboost =,
-               ada =, randomForest =, pcaNNet =,
-               svmradial =, svmpoly =,
-               svmRadial =, svmPoly =,
-               rvmRadial =, rvmPoly =,
-               lssvmRadial =, lssvmPoly =,
-               gaussprRadial =, gaussprPoly =,
-               enet =, lasso =, LMT =, JRip =,
-               lda =, rda =, pamr =, gpls =, J48 =,
-               ppr = print(x$finalModel),
-               fda =  {
-                 print(x$finalModel)
-                 cat("\n Summary of Terms\n\n")
-                 print(x$finalModel$fit)
-
-               })
+        switch(
+          x$method,
+          lm = ,
+          nnet = ,
+          multinom = ,
+          pls = ,
+          earth = ,
+          lmStepAIC = ,
+          bagEarth = ,
+          bagFDA = print(summary(x$finalModel)),
+          rpart = ,
+          ctree = ,
+          ctree2 = ,
+          cforest = ,
+          glmboost = ,
+          gamboost = ,
+          blackboost = ,
+          ada = ,
+          randomForest = ,
+          pcaNNet = ,
+          svmradial = ,
+          svmpoly = ,
+          svmRadial = ,
+          svmPoly = ,
+          rvmRadial = ,
+          rvmPoly = ,
+          lssvmRadial = ,
+          lssvmPoly = ,
+          gaussprRadial = ,
+          gaussprPoly = ,
+          enet = ,
+          lasso = ,
+          LMT = ,
+          JRip = ,
+          lda = ,
+          rda = ,
+          pamr = ,
+          gpls = ,
+          J48 = ,
+          ppr = print(x$finalModel),
+          fda = {
+            print(x$finalModel)
+            cat("\n Summary of Terms\n\n")
+            print(x$finalModel$fit)
+          }
+        )
       }
     }
     invisible(printMat)
   }
 
 
-truncateText <- function(x){
-  if(length(x) > 1) x <- paste(x, collapse = "")
+truncateText <- function(x) {
+  if (length(x) > 1) {
+    x <- paste(x, collapse = "")
+  }
   w <- options("width")$width
-  if(nchar(x) <= w) return(x)
+  if (nchar(x) <= w) {
+    return(x)
+  }
 
   cont <- TRUE
   out <- x
-  while(cont){
+  while (cont) {
     tmp <- out[length(out)]
     tmp2 <- substring(tmp, 1, w)
 
     spaceIndex <- gregexpr("[[:space:]]", tmp2)[[1]]
     stopIndex <- spaceIndex[length(spaceIndex) - 1] - 1
-    tmp <- c(substring(tmp2, 1, stopIndex),
-             substring(tmp, stopIndex + 1))
-    out <- if(length(out) == 1) tmp else c(out[1:(length(x)-1)], tmp)
-    if(all(nchar(out) <= w)) cont <- FALSE
+    tmp <- c(substring(tmp2, 1, stopIndex), substring(tmp, stopIndex + 1))
+    out <- if (length(out) == 1) tmp else c(out[1:(length(x) - 1)], tmp)
+    if (all(nchar(out) <= w)) cont <- FALSE
   }
 
   paste(out, collapse = "\n")
@@ -331,24 +415,37 @@ truncateText <- function(x){
 
 
 pp_list <- function(x) {
-  if(is.list(x)) {
+  if (is.list(x)) {
     pp <- unlist(lapply(x, length))
     pp <- pp[pp > 0]
-    if(length(pp) > 0) {
+    if (length(pp) > 0) {
       names(pp) <- gsub("BoxCox", "Box-Cox transformation", names(pp))
       names(pp) <- gsub("YeoJohnson", "Yeo-Johnson transformation", names(pp))
       names(pp) <- gsub("expoTrans", "exponential transformation", names(pp))
       names(pp) <- gsub("scale", "scaled", names(pp))
       names(pp) <- gsub("center", "centered", names(pp))
-      names(pp) <- gsub("pca", "principal component signal extraction", names(pp))
-      names(pp) <- gsub("ica", "independent component signal extraction", names(pp))
+      names(pp) <- gsub(
+        "pca",
+        "principal component signal extraction",
+        names(pp)
+      )
+      names(pp) <- gsub(
+        "ica",
+        "independent component signal extraction",
+        names(pp)
+      )
       names(pp) <- gsub("spatialSign", "spatial sign transformation", names(pp))
       names(pp) <- gsub("knnImpute", "nearest neighbor imputation", names(pp))
       names(pp) <- gsub("bagImpute", "bagged tree imputation", names(pp))
       names(pp) <- gsub("medianImpute", "median imputation", names(pp))
       names(pp) <- gsub("range", "re-scaling to [0, 1]", names(pp))
-    } else pp <- "None"
-    ppText <- paste("Pre-processing:", paste0(names(pp),  " (", pp, ")", collapse = ", "))
+    } else {
+      pp <- "None"
+    }
+    ppText <- paste(
+      "Pre-processing:",
+      paste0(names(pp), " (", pp, ")", collapse = ", ")
+    )
     cat(truncateText(ppText), "\n")
   } else {
     pp <- x
@@ -365,7 +462,9 @@ pp_list <- function(x) {
     pp <- gsub("medianImpute", "median imputation", pp)
     pp <- gsub("range", "re-scaling to [0, 1]", pp)
 
-    if(length(pp) == 0) pp <- "None"
+    if (length(pp) == 0) {
+      pp <- "None"
+    }
 
     ppText <- paste("Pre-processing:", paste(pp, collapse = ", "))
     cat(truncateText(ppText), "\n")

--- a/R/print.train.R
+++ b/R/print.train.R
@@ -3,13 +3,13 @@ stringFunc <- function(x) {
     x <- format(x)
   }
   numElements <- length(x)
-  out <- if (length(x) > 0) {
-    switch(min(numElements, 3), x, paste(x, collapse = " and "), {
+  if (length(x) > 0) {
+    out <- switch(min(numElements, 3), x, paste(x, collapse = " and "), {
       x <- paste0(x, c(rep(",", numElements - 2), " and", ""))
       paste(x, collapse = " ")
     })
   } else {
-    ""
+    out <- ""
   }
   out
 }
@@ -79,7 +79,9 @@ stringFunc <- function(x) {
       chDim[2] <- chDim[2] - 1
       if (x$modelType == "Classification") {
         lev <- levels(x)
-        if (is.character(lev)) chDim <- c(chDim, length(lev))
+        if (is.character(lev)) {
+          chDim <- c(chDim, length(lev))
+        }
       } else {
         lev <- NULL
       }
@@ -212,7 +214,9 @@ stringFunc <- function(x) {
           tuneAcc <- tuneAcc[, !(names(tuneAcc) %in% rmCols)]
         }
       } else {
-        if (length(sdCols) > 0) tuneAcc <- tuneAcc[, -sdCols, drop = FALSE]
+        if (length(sdCols) > 0) {
+          tuneAcc <- tuneAcc[, -sdCols, drop = FALSE]
+        }
       }
 
       params <- names(x$bestTune)
@@ -327,7 +331,9 @@ stringFunc <- function(x) {
       }
 
       cat(truncateText(optString))
-      if (nzchar(optString)) cat("\n")
+      if (nzchar(optString)) {
+        cat("\n")
+      }
     } else {
       printMat <- NULL
     }
@@ -406,8 +412,14 @@ truncateText <- function(x) {
     spaceIndex <- gregexpr("[[:space:]]", tmp2)[[1]]
     stopIndex <- spaceIndex[length(spaceIndex) - 1] - 1
     tmp <- c(substring(tmp2, 1, stopIndex), substring(tmp, stopIndex + 1))
-    out <- if (length(out) == 1) tmp else c(out[1:(length(x) - 1)], tmp)
-    if (all(nchar(out) <= w)) cont <- FALSE
+    if (length(out) == 1) {
+      out <- tmp
+    } else {
+      out <- c(out[1:(length(x) - 1)], tmp)
+    }
+    if (all(nchar(out) <= w)) {
+      cont <- FALSE
+    }
   }
 
   paste(out, collapse = "\n")

--- a/R/print.varImp.train.R
+++ b/R/print.varImp.train.R
@@ -1,22 +1,34 @@
 #' @export
 "print.varImp.train" <-
-function(x, top = min(20, dim(x$importance)[1]), digits = max(3, getOption("digits") - 3), ...)
-{
-   cat(x$model, "variable importance\n\n")
+  function(
+    x,
+    top = min(20, dim(x$importance)[1]),
+    digits = max(3, getOption("digits") - 3),
+    ...
+  ) {
+    cat(x$model, "variable importance\n\n")
 
-   printObj <- sortImp(x, top)
+    printObj <- sortImp(x, top)
 
-   if(dim(x$importance)[2] > 2)
-     cat("  variables are sorted by maximum importance across the classes\n")
-     
-   if(top < dim(x$importance)[1]) 
-      cat("  only ", top, " most important variables shown (out of ", dim(x$importance)[1], ")\n\n", sep = "")
-    
-   if(dim(printObj)[2] == 2)
-   {
-      printObj <- printObj[,1,drop = FALSE]
+    if (dim(x$importance)[2] > 2) {
+      cat("  variables are sorted by maximum importance across the classes\n")
+    }
+
+    if (top < dim(x$importance)[1]) {
+      cat(
+        "  only ",
+        top,
+        " most important variables shown (out of ",
+        dim(x$importance)[1],
+        ")\n\n",
+        sep = ""
+      )
+    }
+
+    if (dim(printObj)[2] == 2) {
+      printObj <- printObj[, 1, drop = FALSE]
       names(printObj) <- "Importance"
-   }
-   print(printObj, digits = digits, ...)
-   invisible(x)
-}
+    }
+    print(printObj, digits = digits, ...)
+    invisible(x)
+  }

--- a/R/probFunction.R
+++ b/R/probFunction.R
@@ -20,7 +20,9 @@ probFunction <- function(
   )
   if (!is.data.frame(classProb) && is.null(param)) {
     classProb <- as.data.frame(classProb, stringsAsFactors = TRUE)
-    if (!is.null(obsLevels)) classprob <- classProb[, obsLevels]
+    if (!is.null(obsLevels)) {
+      classprob <- classProb[, obsLevels]
+    }
   }
   classProb
 }

--- a/R/probFunction.R
+++ b/R/probFunction.R
@@ -1,18 +1,26 @@
 #' @rdname caret-internal
 #' @export
-probFunction <- function(method, modelFit, newdata = NULL, preProc = NULL, param = NULL)
-{
-  if(!is.null(newdata) && !is.null(preProc)) newdata <- predict(preProc, newdata)
+probFunction <- function(
+  method,
+  modelFit,
+  newdata = NULL,
+  preProc = NULL,
+  param = NULL
+) {
+  if (!is.null(newdata) && !is.null(preProc)) {
+    newdata <- predict(preProc, newdata)
+  }
 
   obsLevels <- levels(modelFit)
 
-  classProb <- method$prob(modelFit = modelFit,
-                           newdata = newdata,
-                           submodels = param)
-  if(!is.data.frame(classProb) && is.null(param))
-  {
+  classProb <- method$prob(
+    modelFit = modelFit,
+    newdata = newdata,
+    submodels = param
+  )
+  if (!is.data.frame(classProb) && is.null(param)) {
     classProb <- as.data.frame(classProb, stringsAsFactors = TRUE)
-    if(!is.null(obsLevels)) classprob <- classProb[, obsLevels]
+    if (!is.null(obsLevels)) classprob <- classProb[, obsLevels]
   }
   classProb
 }

--- a/R/reg_sims.R
+++ b/R/reg_sims.R
@@ -1,131 +1,219 @@
-
-make_noise <- function(n, noiseVars = 0, 
-                       corrVars = 0, corrType = "AR1", corrValue = 0,
-                       binary = FALSE) {
+make_noise <- function(
+  n,
+  noiseVars = 0,
+  corrVars = 0,
+  corrType = "AR1",
+  corrValue = 0,
+  binary = FALSE
+) {
   requireNamespaceQuietStop("MASS")
-  if(noiseVars > 0) {
+  if (noiseVars > 0) {
     tmpData <- matrix(rnorm(n * noiseVars), ncol = noiseVars)
     colnames(tmpData) <- well_numbered("Noise", noiseVars)
   }
-  if(corrVars > 0) {
+  if (corrVars > 0) {
     loadNamespace("MASS")
-    if(corrType == "exch") {
-      vc <- matrix(corrValue, ncol = corrVars,  nrow = corrVars)
+    if (corrType == "exch") {
+      vc <- matrix(corrValue, ncol = corrVars, nrow = corrVars)
       diag(vc) <- 1
     }
-    if(corrType == "AR1") {
+    if (corrType == "AR1") {
       vcValues <- corrValue^(seq(0, corrVars - 1, by = 1))
       vc <- toeplitz(vcValues)
-    }    
+    }
     tmpData2 <- MASS::mvrnorm(n, mu = rep(0, corrVars), Sigma = vc)
     colnames(tmpData2) <- well_numbered("Corr", corrVars)
-  }  
-  if(noiseVars == 0 && corrVars  > 0) out <- tmpData2
-  if(noiseVars  > 0 && corrVars == 0) out <- tmpData
-  if(noiseVars  > 0 && corrVars  > 0) out <- cbind(tmpData, tmpData2)
-  if(binary) out <- ifelse(out > 0, 1, 0)
+  }
+  if (noiseVars == 0 && corrVars > 0) {
+    out <- tmpData2
+  }
+  if (noiseVars > 0 && corrVars == 0) {
+    out <- tmpData
+  }
+  if (noiseVars > 0 && corrVars > 0) {
+    out <- cbind(tmpData, tmpData2)
+  }
+  if (binary) {
+    out <- ifelse(out > 0, 1, 0)
+  }
   as.data.frame(out, stringsAsFactors = TRUE)
 }
 
 #' @rdname twoClassSim
 #' @export
-SLC14_1 <- function(n = 100, noiseVars = 0, 
-                    corrVars = 0, corrType = "AR1", corrValue = 0) {
-  
-  dat <- matrix(rnorm(n*20, sd = 3), ncol = 20)
-  
-  foo <- function(x) x[1] + sin(x[2]) + log(abs(x[3])) + x[4]^2 + x[5]*x[6] + 
-    ifelse(x[7]*x[8]*x[9] < 0, 1, 0) +
-    ifelse(x[10] > 0, 1, 0) + x[11]*ifelse(x[11] > 0, 1, 0) + 
-    sqrt(abs(x[12])) + cos(x[13]) + 2*x[14] + abs(x[15]) + 
-    ifelse(x[16] < -1, 1, 0) + x[17]*ifelse(x[17] < -1, 1, 0) -
-    2 * x[18] - x[19]*x[20]
-  
+SLC14_1 <- function(
+  n = 100,
+  noiseVars = 0,
+  corrVars = 0,
+  corrType = "AR1",
+  corrValue = 0
+) {
+  dat <- matrix(rnorm(n * 20, sd = 3), ncol = 20)
+
+  foo <- function(x) {
+    x[1] +
+      sin(x[2]) +
+      log(abs(x[3])) +
+      x[4]^2 +
+      x[5] * x[6] +
+      ifelse(x[7] * x[8] * x[9] < 0, 1, 0) +
+      ifelse(x[10] > 0, 1, 0) +
+      x[11] * ifelse(x[11] > 0, 1, 0) +
+      sqrt(abs(x[12])) +
+      cos(x[13]) +
+      2 * x[14] +
+      abs(x[15]) +
+      ifelse(x[16] < -1, 1, 0) +
+      x[17] * ifelse(x[17] < -1, 1, 0) -
+      2 * x[18] -
+      x[19] * x[20]
+  }
+
   dat <- as.data.frame(dat, stringsAsFactors = TRUE)
   colnames(dat) <- well_numbered("Var", ncol(dat))
-  if(noiseVars > 0 || corrVars > 0) 
-    dat <- cbind(dat, make_noise(n = n, 
-                                 noiseVars = noiseVars, 
-                                 corrVars = corrVars, 
-                                 corrType = corrType, 
-                                 corrValue = corrValue))
-  
+  if (noiseVars > 0 || corrVars > 0) {
+    dat <- cbind(
+      dat,
+      make_noise(
+        n = n,
+        noiseVars = noiseVars,
+        corrVars = corrVars,
+        corrType = corrType,
+        corrValue = corrValue
+      )
+    )
+  }
+
   dat$y <- apply(dat[, 1:20], 1, foo) + rnorm(n, sd = 3)
   dat
 }
 
 #' @rdname twoClassSim
 #' @export
-SLC14_2 <- function(n = 100, noiseVars = 0, 
-                    corrVars = 0, corrType = "AR1", corrValue = 0) {
-  
-  dat <- matrix(rnorm(n*200, sd = 4), ncol = 200)
+SLC14_2 <- function(
+  n = 100,
+  noiseVars = 0,
+  corrVars = 0,
+  corrType = "AR1",
+  corrValue = 0
+) {
+  dat <- matrix(rnorm(n * 200, sd = 4), ncol = 200)
   dat <- as.data.frame(dat, stringsAsFactors = TRUE)
   colnames(dat) <- well_numbered("Var", ncol(dat))
-  
-  if(noiseVars > 0 || corrVars > 0) 
-    dat <- cbind(dat, make_noise(n = n, 
-                                 noiseVars = noiseVars, 
-                                 corrVars = corrVars, 
-                                 corrType = corrType, 
-                                 corrValue = corrValue))
-  
-  dat$y <- apply(dat[, 1:200], 1, function(x) sum(log(abs(x)))) + rnorm(n, sd = 5)  - 1
+
+  if (noiseVars > 0 || corrVars > 0) {
+    dat <- cbind(
+      dat,
+      make_noise(
+        n = n,
+        noiseVars = noiseVars,
+        corrVars = corrVars,
+        corrType = corrType,
+        corrValue = corrValue
+      )
+    )
+  }
+
+  dat$y <- apply(dat[, 1:200], 1, function(x) sum(log(abs(x)))) +
+    rnorm(n, sd = 5) -
+    1
   dat
 }
 
 #' @rdname twoClassSim
 #' @export
-LPH07_1 <- function(n = 100, noiseVars = 0, 
-                    corrVars = 0, corrType = "AR1", corrValue = 0, factors = FALSE, class = FALSE) {
-  
-  dat <- matrix(rbinom(n*10, size = 1, prob = 0.4), ncol = 10)
+LPH07_1 <- function(
+  n = 100,
+  noiseVars = 0,
+  corrVars = 0,
+  corrType = "AR1",
+  corrValue = 0,
+  factors = FALSE,
+  class = FALSE
+) {
+  dat <- matrix(rbinom(n * 10, size = 1, prob = 0.4), ncol = 10)
   dat <- as.data.frame(dat, stringsAsFactors = TRUE)
   colnames(dat) <- well_numbered("Var", ncol(dat))
-  foo <- function(w) 2*w[1]*w[10] + 4*w[2]*w[7] + 3*w[4]*w[5] -
-    5*w[6]*w[10] + 3*w[8]*w[9] + w[1]*w[2]*w[4] -
-    2*w[7]*(1-w[6])*w[2]*w[9] -
-    4*(1 - w[10])*w[1]*(1-w[4])
-  if(noiseVars > 0 || corrVars > 0) 
-    dat <- cbind(dat, make_noise(n = n, 
-                                 noiseVars = noiseVars, 
-                                 corrVars = corrVars, 
-                                 corrType = corrType, 
-                                 corrValue = corrValue,
-                                 binary = TRUE))
+  foo <- function(w) {
+    2 *
+      w[1] *
+      w[10] +
+      4 * w[2] * w[7] +
+      3 * w[4] * w[5] -
+      5 * w[6] * w[10] +
+      3 * w[8] * w[9] +
+      w[1] * w[2] * w[4] -
+      2 * w[7] * (1 - w[6]) * w[2] * w[9] -
+      4 * (1 - w[10]) * w[1] * (1 - w[4])
+  }
+  if (noiseVars > 0 || corrVars > 0) {
+    dat <- cbind(
+      dat,
+      make_noise(
+        n = n,
+        noiseVars = noiseVars,
+        corrVars = corrVars,
+        corrType = corrType,
+        corrValue = corrValue,
+        binary = TRUE
+      )
+    )
+  }
 
-  if(class) {   
-    dat$y <- apply(dat[, 1:10], 1, foo) 
+  if (class) {
+    dat$y <- apply(dat[, 1:10], 1, foo)
     dat$Class <- runif(nrow(dat)) <= binomial()$linkinv(dat$y)
     dat$Class <- factor(ifelse(dat$Class, "Class1", "Class2"))
     dat$y <- NULL
-  } else dat$y <- apply(dat[, 1:10], 1, foo) + rnorm(n)
-  
-  if(factors) 
-    for(i in grep("(^Var)|(^Noise)", names(dat), value = TRUE))
-      dat[,i] <- factor(paste0("val", dat[,i]))
-  
-  
+  } else {
+    dat$y <- apply(dat[, 1:10], 1, foo) + rnorm(n)
+  }
+
+  if (factors) {
+    for (i in grep("(^Var)|(^Noise)", names(dat), value = TRUE)) {
+      dat[, i] <- factor(paste0("val", dat[, i]))
+    }
+  }
+
   dat
 }
 
 #' @rdname twoClassSim
 #' @export
-LPH07_2 <- function(n = 100, noiseVars = 0, 
-                    corrVars = 0, corrType = "AR1", corrValue = 0) {
-  
-  dat <- matrix(rnorm(n*20, sd = 4), ncol = 20)
+LPH07_2 <- function(
+  n = 100,
+  noiseVars = 0,
+  corrVars = 0,
+  corrType = "AR1",
+  corrValue = 0
+) {
+  dat <- matrix(rnorm(n * 20, sd = 4), ncol = 20)
   dat <- as.data.frame(dat, stringsAsFactors = TRUE)
   colnames(dat) <- well_numbered("Var", ncol(dat))
-  foo <- function(x) x[1]*x[2] + x[10]^2 - x[3]*x[17] -
-    x[15]*x[4] + x[9]*x[5] + x[19] - x[20]^2 + x[9]*x[8]
-  if(noiseVars > 0 || corrVars > 0) 
-    dat <- cbind(dat, make_noise(n = n, 
-                                 noiseVars = noiseVars, 
-                                 corrVars = corrVars, 
-                                 corrType = corrType, 
-                                 corrValue = corrValue))
-  
+  foo <- function(x) {
+    x[1] *
+      x[2] +
+      x[10]^2 -
+      x[3] * x[17] -
+      x[15] * x[4] +
+      x[9] * x[5] +
+      x[19] -
+      x[20]^2 +
+      x[9] * x[8]
+  }
+  if (noiseVars > 0 || corrVars > 0) {
+    dat <- cbind(
+      dat,
+      make_noise(
+        n = n,
+        noiseVars = noiseVars,
+        corrVars = corrVars,
+        corrType = corrType,
+        corrValue = corrValue
+      )
+    )
+  }
+
   dat$y <- apply(dat[, 1:20], 1, foo) + rnorm(n, sd = 4)
   dat
 }

--- a/R/resampleHist.R
+++ b/R/resampleHist.R
@@ -20,50 +20,52 @@
 #'   [stripplot.train()]
 #' @keywords hplot
 #' @examplesIf !caret:::is_cran_check()
-#' 
+#'
 #' data(iris)
 #' TrainData <- iris[, 1:4]
 #' TrainClasses <- iris[, 5]
-#' 
+#'
 #' knnFit <- train(TrainData, TrainClasses, "knn")
-#' 
+#'
 #' resampleHist(knnFit)
-#' 
+#'
 #' @export resampleHist
-resampleHist <- function(object, type = "density", ...)
-{
-  if(object$control$method == "oob") stop("out-of-bag error rate was selected. This plot cannot be created")
-  if(is.null(object$resample)) stop("No resample values were found. This plot cannot be created")
-
+resampleHist <- function(object, type = "density", ...) {
+  if (object$control$method == "oob") {
+    stop("out-of-bag error rate was selected. This plot cannot be created")
+  }
+  if (is.null(object$resample)) {
+    stop("No resample values were found. This plot cannot be created")
+  }
 
   resample <- object$resample
   tuneNames <- as.character(object$modelInfo$parameter$parameter)
-  if(any(names(resample) %in% tuneNames))
-    {
-      bestTune <- object$bestTune
-      colnames(bestTune) <- gsub("^\\.", "", colnames(bestTune))
-      resample <- merge(bestTune, resample)        
-      resample <- resample[, !(names(resample) %in% tuneNames), drop = FALSE]
-
-    }
+  if (any(names(resample) %in% tuneNames)) {
+    bestTune <- object$bestTune
+    colnames(bestTune) <- gsub("^\\.", "", colnames(bestTune))
+    resample <- merge(bestTune, resample)
+    resample <- resample[, !(names(resample) %in% tuneNames), drop = FALSE]
+  }
   results <- melt(resample, id.vars = "Resample")
-  
-  if(type == "density")
-    {
-      out <- densityplot(~ value|variable, 
-                         data = results, 
-                         scales = list(relation = "free"),
-                         xlab = "",
-                         as.table = TRUE,
-                         ...)  
 
-    } else {
-      out <- histogram(~ value|variable, 
-                       data = results, 
-                       scales = list(relation = "free"),
-                       as.table = TRUE,         
-                       xlab = "",
-                       ...)    
-    }
+  if (type == "density") {
+    out <- densityplot(
+      ~ value | variable,
+      data = results,
+      scales = list(relation = "free"),
+      xlab = "",
+      as.table = TRUE,
+      ...
+    )
+  } else {
+    out <- histogram(
+      ~ value | variable,
+      data = results,
+      scales = list(relation = "free"),
+      as.table = TRUE,
+      xlab = "",
+      ...
+    )
+  }
   out
 }

--- a/R/resampleSummary.R
+++ b/R/resampleSummary.R
@@ -22,77 +22,89 @@
 #' @seealso [postResample()]
 #' @keywords utilities
 #' @examples
-#' 
+#'
 #' resampleSummary(rnorm(10), matrix(rnorm(50), ncol = 5))
-#' 
+#'
 #' @export resampleSummary
-resampleSummary <- function(obs, resampled, index = NULL, keepData = TRUE)
-{
-   numPred <- apply(resampled, 2, function(u) sum(!is.na(u)))
-   # for everything but LOO, we should get multiple predictions per resample
-   if(all(numPred >= 2))
-      {
-           
-         # calculate performance metrics for each resample
-         performanceStats <- apply(
-            resampled, 
-            2, 
-            postResample, 
-            obs = obs)
-            
-         #summarize resample dists
-         out <- c(
-            apply(performanceStats, 1, mean, na.rm = TRUE), 
-            apply(performanceStats, 1, sd, na.rm = TRUE))
-            
-         # optionally returen the data in "vertical" format
-         # to conserve space remove the many missing values
-         if(keepData)
-         {
-            # stack has issues when there are a lot of missing values,
-            # so we'll use lapply to stack the columns of resampled
-            if(is.factor(obs))
-            {
-               outResample <- data.frame(
-                  obs = rep(obs, dim(resampled)[2]),
-                  pred = factor(unlist(lapply(resampled, as.character)), 
-                     levels = levels(obs)),
-                  group = paste(
-                     "Resample", 
-                     rep(
-                        1:dim(resampled)[2], 
-                        each = dim(resampled)[1], sep = "")))
-            } else {
-               outResample <- data.frame(
-                  obs = rep(obs, dim(resampled)[2]),
-                  pred = unlist(lapply(resampled, I)), 
-                  group = paste(
-                     "Resample", 
-                     rep(
-                        1:dim(resampled)[2], 
-                        each = dim(resampled)[1], sep = "")))     
-            }
-        } else outResample <- NULL
-        
-      } else {  
-      
+resampleSummary <- function(obs, resampled, index = NULL, keepData = TRUE) {
+  numPred <- apply(resampled, 2, function(u) sum(!is.na(u)))
+  # for everything but LOO, we should get multiple predictions per resample
+  if (all(numPred >= 2)) {
+    # calculate performance metrics for each resample
+    performanceStats <- apply(
+      resampled,
+      2,
+      postResample,
+      obs = obs
+    )
 
-         pred <- apply(resampled, 2, function(u) u[!is.na(u)])
-         if(is.factor(obs)) pred <- factor(as.character(pred), levels = levels(obs))
-         
-         tmp <- postResample(pred, obs)
-         tmp2 <- tmp * 0
-         
-         out <- c(
-            tmp, 
-            tmp * 0) 
-        
-         outResample <- data.frame(
-            obs = obs,
-            pred = pred,
-            group = "Resample1")
+    #summarize resample dists
+    out <- c(
+      apply(performanceStats, 1, mean, na.rm = TRUE),
+      apply(performanceStats, 1, sd, na.rm = TRUE)
+    )
+
+    # optionally returen the data in "vertical" format
+    # to conserve space remove the many missing values
+    if (keepData) {
+      # stack has issues when there are a lot of missing values,
+      # so we'll use lapply to stack the columns of resampled
+      if (is.factor(obs)) {
+        outResample <- data.frame(
+          obs = rep(obs, dim(resampled)[2]),
+          pred = factor(
+            unlist(lapply(resampled, as.character)),
+            levels = levels(obs)
+          ),
+          group = paste(
+            "Resample",
+            rep(
+              1:dim(resampled)[2],
+              each = dim(resampled)[1],
+              sep = ""
+            )
+          )
+        )
+      } else {
+        outResample <- data.frame(
+          obs = rep(obs, dim(resampled)[2]),
+          pred = unlist(lapply(resampled, I)),
+          group = paste(
+            "Resample",
+            rep(
+              1:dim(resampled)[2],
+              each = dim(resampled)[1],
+              sep = ""
+            )
+          )
+        )
       }
-      
-   if(keepData) outResample <- outResample[!is.na(outResample$pred),] 
-   list(metrics = out, data = outResample)
+    } else {
+      outResample <- NULL
+    }
+  } else {
+    pred <- apply(resampled, 2, function(u) u[!is.na(u)])
+    if (is.factor(obs)) {
+      pred <- factor(as.character(pred), levels = levels(obs))
+    }
+
+    tmp <- postResample(pred, obs)
+    tmp2 <- tmp * 0
+
+    out <- c(
+      tmp,
+      tmp * 0
+    )
+
+    outResample <- data.frame(
+      obs = obs,
+      pred = pred,
+      group = "Resample1"
+    )
+  }
+
+  if (keepData) {
+    outResample <- outResample[!is.na(outResample$pred), ]
+  }
+  list(metrics = out, data = outResample)
 }

--- a/R/resampleWrapper.R
+++ b/R/resampleWrapper.R
@@ -1,19 +1,17 @@
 #' @rdname caret-internal
 #' @export
-resampleWrapper <- function(x, ind) 
-{
-   out <- rep(NA, dim(x$data)[1])
-   trainData <- x$data
-   x$data <- x$data[ind,]
-   tmpModelFit <- do.call(createModel, x)
-   outBagData <- trainData[-ind, ]        
-   outBagData$.outcome <- NULL
-   
-   out[-ind] <- if(is.factor(x$data$.outcome))
-   {
-      as.character(predictionFunction(x$method, tmpModelFit, outBagData))
-   } else {
-      predictionFunction(x$method, tmpModelFit, outBagData)
-   }   
-   out
+resampleWrapper <- function(x, ind) {
+  out <- rep(NA, dim(x$data)[1])
+  trainData <- x$data
+  x$data <- x$data[ind, ]
+  tmpModelFit <- do.call(createModel, x)
+  outBagData <- trainData[-ind, ]
+  outBagData$.outcome <- NULL
+
+  out[-ind] <- if (is.factor(x$data$.outcome)) {
+    as.character(predictionFunction(x$method, tmpModelFit, outBagData))
+  } else {
+    predictionFunction(x$method, tmpModelFit, outBagData)
+  }
+  out
 }

--- a/R/resampleWrapper.R
+++ b/R/resampleWrapper.R
@@ -8,10 +8,14 @@ resampleWrapper <- function(x, ind) {
   outBagData <- trainData[-ind, ]
   outBagData$.outcome <- NULL
 
-  out[-ind] <- if (is.factor(x$data$.outcome)) {
-    as.character(predictionFunction(x$method, tmpModelFit, outBagData))
+  if (is.factor(x$data$.outcome)) {
+    out[-ind] <- as.character(predictionFunction(
+      x$method,
+      tmpModelFit,
+      outBagData
+    ))
   } else {
-    predictionFunction(x$method, tmpModelFit, outBagData)
+    out[-ind] <- predictionFunction(x$method, tmpModelFit, outBagData)
   }
   out
 }

--- a/R/resamples.R
+++ b/R/resamples.R
@@ -182,7 +182,11 @@ resamples.default <- function(x, modelNames = names(x), ...) {
         names(rs_values[[mod]])[names(rs_values[[mod]]) %in% pNames],
         sep = "~"
       )
-    out <- if (mod == 1) rs_values[[mod]] else merge(out, rs_values[[mod]])
+    if (mod == 1) {
+      out <- rs_values[[mod]]
+    } else {
+      out <- merge(out, rs_values[[mod]])
+    }
   }
 
   timings <- do.call("rbind", lapply(x, getTimes))
@@ -689,10 +693,10 @@ xyplot.resamples <- function(
   }
 
   if (is.null(models)) {
-    models <- if (what %in% c("tTime", "mTime", "pTime")) {
-      x$models
+    if (what %in% c("tTime", "mTime", "pTime")) {
+      models <- x$models
     } else {
-      x$models[1:2]
+      models <- x$models[1:2]
     }
   }
   if (length(metric) != 1) {
@@ -958,10 +962,10 @@ densityplot.resamples <- function(
   plotData <- subset(plotData, Model %in% models & Metric %in% metric)
 
   metricVals <- unique(plotData$Metric)
-  plotForm <- if (length(metricVals) > 1) {
-    as.formula(~ value | Metric)
+  if (length(metricVals) > 1) {
+    plotForm <- as.formula(~ value | Metric)
   } else {
-    as.formula(~value)
+    plotForm <- as.formula(~value)
   }
   densityplot(
     plotForm,
@@ -992,10 +996,10 @@ bwplot.resamples <- function(
   avPerf <- avPerf[order(avPerf$Median), ]
   plotData$Model <- factor(as.character(plotData$Model), levels = avPerf$Model)
   metricVals <- unique(plotData$Metric)
-  plotForm <- if (length(metricVals) > 1) {
-    as.formula(Model ~ value | Metric)
+  if (length(metricVals) > 1) {
+    plotForm <- as.formula(Model ~ value | Metric)
   } else {
-    as.formula(Model ~ value)
+    plotForm <- as.formula(Model ~ value)
   }
   bwplot(
     plotForm,
@@ -1057,10 +1061,10 @@ dotplot.resamples <- function(
   avPerf <- avPerf[order(avPerf$Median), ]
   results$Model <- factor(as.character(results$Model), levels = avPerf$Model)
   metricVals <- unique(results$Metric)
-  plotForm <- if (length(metricVals) > 1) {
-    as.formula(Model ~ value | Metric)
+  if (length(metricVals) > 1) {
+    plotForm <- as.formula(Model ~ value | Metric)
   } else {
-    as.formula(Model ~ value)
+    plotForm <- as.formula(Model ~ value)
   }
   dotplot(
     plotForm,
@@ -1332,10 +1336,10 @@ densityplot.diff.resamples <- function(x, data, metric = x$metric, ...) {
   plotData$ind <- gsub(".diff.", " - ", plotData$ind, fixed = TRUE)
   plotData <- subset(plotData, Metric %in% metric)
   metricVals <- unique(plotData$Metric)
-  plotForm <- if (length(metricVals) > 1) {
-    as.formula(~ values | Metric)
+  if (length(metricVals) > 1) {
+    plotForm <- as.formula(~ values | Metric)
   } else {
-    as.formula(~values)
+    plotForm <- as.formula(~values)
   }
 
   densityplot(
@@ -1357,10 +1361,10 @@ bwplot.diff.resamples <- function(x, data, metric = x$metric, ...) {
   plotData$ind <- gsub(".diff.", " - ", plotData$ind, fixed = TRUE)
   plotData <- subset(plotData, Metric %in% metric)
   metricVals <- unique(plotData$Metric)
-  plotForm <- if (length(metricVals) > 1) {
-    as.formula(ind ~ values | Metric)
+  if (length(metricVals) > 1) {
+    plotForm <- as.formula(ind ~ values | Metric)
   } else {
-    as.formula(ind ~ values)
+    plotForm <- as.formula(ind ~ values)
   }
 
   bwplot(
@@ -1473,10 +1477,10 @@ levelplot.diff.resamples <- function(
       for (j in seq(along.with = x$models)) {
         if (i < j) {
           index <- index + 1
-          temp[i, j] <- if (what == "pvalues") {
-            x$statistics[[h]][index][[1]]$p.value
+          if (what == "pvalues") {
+            temp[i, j] <- x$statistics[[h]][index][[1]]$p.value
           } else {
-            x$statistics[[h]][index][[1]]$estimate
+            temp[i, j] <- x$statistics[[h]][index][[1]]$estimate
           }
           temp[j, i] <- temp[i, j]
         }

--- a/R/resamples.R
+++ b/R/resamples.R
@@ -57,18 +57,18 @@
 #' @family resampling
 #' @keywords models
 #' @examplesIf !caret:::is_cran_check()
-#' 
+#'
 #' load(url("http://topepo.github.io/caret/exampleModels.RData"))
-#' 
+#'
 #' resamps <- resamples(list(
 #'   CART = rpartFit,
 #'   CondInfTree = ctreeFit,
 #'   MARS = earthFit
 #' ))
-#' 
+#'
 #' resamps
 #' summary(resamps)
-#' 
+#'
 #' @export resamples
 "resamples" <- function(x, ...) UseMethod("resamples")
 
@@ -354,27 +354,27 @@ modelCor <- function(x, metric = x$metric[1], ...) {
 #'   plotting in multivariate data analysis," J. Chemometrics, 17: 503-511
 #' @keywords hplot
 #' @examplesIf !caret:::is_cran_check()
-#' 
+#'
 #' load(url("http://topepo.github.io/caret/exampleModels.RData"))
-#' 
+#'
 #' resamps <- resamples(list(
 #'   CART = rpartFit,
 #'   CondInfTree = ctreeFit,
 #'   MARS = earthFit
 #' ))
 #' resampPCA <- prcomp(resamps)
-#' 
+#'
 #' resampPCA
-#' 
+#'
 #' plot(resampPCA, what = "scree")
-#' 
+#'
 #' plot(resampPCA, what = "components")
-#' 
+#'
 #' plot(resampPCA, what = "components", dims = 2, auto.key = list(columns = 3))
-#' 
+#'
 #' clustered <- cluster(resamps)
 #' plot(clustered)
-#' 
+#'
 #' @export
 prcomp.resamples <- function(x, metric = x$metrics[1], ...) {
   if (length(metric) != 1) {
@@ -642,33 +642,33 @@ print.summary.resamples <- function(x, ...) {
 #' Statistics, Tech. Rep (2008) vol. 30
 #' @keywords hplot
 #' @examplesIf !caret:::is_cran_check()
-#' 
+#'
 #' load(url("http://topepo.github.io/caret/exampleModels.RData"))
-#' 
+#'
 #' resamps <- resamples(list(
 #'   CART = rpartFit,
 #'   CondInfTree = ctreeFit,
 #'   MARS = earthFit
 #' ))
-#' 
+#'
 #' dotplot(
 #'   resamps,
 #'   scales = list(x = list(relation = "free")),
 #'   between = list(x = 2)
 #' )
-#' 
+#'
 #' bwplot(resamps, metric = "RMSE")
-#' 
+#'
 #' densityplot(resamps, auto.key = list(columns = 3), pch = "|")
-#' 
+#'
 #' xyplot(resamps, models = c("CART", "MARS"), metric = "RMSE")
-#' 
+#'
 #' splom(resamps, metric = "RMSE")
 #' splom(resamps, variables = "metrics")
-#' 
+#'
 #' parallelplot(resamps, metric = "RMSE")
-#' 
-#' 
+#'
+#'
 #' @export
 xyplot.resamples <- function(
   x,
@@ -1238,23 +1238,23 @@ ggplot.resamples <-
 #' Statistics, Tech. Rep (2008) vol. 30
 #' @keywords models
 #' @examplesIf !caret:::is_cran_check()
-#' 
+#'
 #' load(url("http://topepo.github.io/caret/exampleModels.RData"))
-#' 
+#'
 #' resamps <- resamples(list(
 #'   CART = rpartFit,
 #'   CondInfTree = ctreeFit,
 #'   MARS = earthFit
 #' ))
-#' 
+#'
 #' difs <- diff(resamps)
-#' 
+#'
 #' difs
-#' 
+#'
 #' summary(difs)
-#' 
+#'
 #' compare_models(rpartFit, ctreeFit)
-#' 
+#'
 #' @export
 diff.resamples <- function(
   x,
@@ -1558,25 +1558,25 @@ print.summary.diff.resamples <- function(x, ...) {
 #'   [lattice::densityplot()], [lattice::xyplot()], [lattice::splom()]
 #' @keywords hplot
 #' @examplesIf !caret:::is_cran_check()
-#' 
+#'
 #' load(url("http://topepo.github.io/caret/exampleModels.RData"))
-#' 
+#'
 #' resamps <- resamples(list(
 #'   CART = rpartFit,
 #'   CondInfTree = ctreeFit,
 #'   MARS = earthFit
 #' ))
 #' difs <- diff(resamps)
-#' 
+#'
 #' dotplot(difs)
-#' 
+#'
 #' densityplot(difs, metric = "RMSE", auto.key = TRUE, pch = "|")
-#' 
+#'
 #' bwplot(difs, metric = "RMSE")
-#' 
+#'
 #' levelplot(difs, what = "differences")
-#' 
-#' 
+#'
+#'
 #' @export
 dotplot.diff.resamples <- function(x, data = NULL, metric = x$metric[1], ...) {
   if (length(metric) > 1) {
@@ -1687,4 +1687,3 @@ compare_models <- function(a, b, metric = a$metric[1]) {
   diffs <- diff(rs, metric = metric[1])
   diffs$statistics[[1]][[1]]
 }
-

--- a/R/rfe.R
+++ b/R/rfe.R
@@ -255,7 +255,11 @@ rfe <- function(x, ...) UseMethod("rfe")
     }
 
     ## Set or check the seeds when needed
-    totalSize <- if (any(sizes == ncol(x))) length(sizes) else length(sizes) + 1
+    if (any(sizes == ncol(x))) {
+      totalSize <- length(sizes)
+    } else {
+      totalSize <- length(sizes) + 1
+    }
     if (is.null(rfeControl$seeds)) {
       seeds <- vector(mode = "list", length = length(rfeControl$index))
       seeds <- lapply(seeds, function(x) {
@@ -554,7 +558,9 @@ rfeIter <- function(
         modelPred <- as.data.frame(modelPred, stringsAsFactors = TRUE)
         ## in the case where the function returns a matrix with a single column
         ## make sure that it is named pred
-        if (ncol(modelPred) == 1) names(modelPred) <- "pred"
+        if (ncol(modelPred) == 1) {
+          names(modelPred) <- "pred"
+        }
       }
       modelPred$obs <- testY
       modelPred$Variables <- sizeValues[k]
@@ -567,7 +573,11 @@ rfeIter <- function(
     }
 
     ## save as a vector and rbind at end
-    rfePred <- if (k == 1) modelPred else rbind(rfePred, modelPred)
+    if (k == 1) {
+      rfePred <- modelPred
+    } else {
+      rfePred <- rbind(rfePred, modelPred)
+    }
 
     if (!exists("modImp")) {
       ##todo: get away from this since it finds object in other spaces
@@ -882,7 +892,11 @@ rfeControl <- function(
 #' @rdname caretFuncs
 #' @export
 pickSizeBest <- function(x, metric, maximize) {
-  best <- if (maximize) which.max(x[, metric]) else which.min(x[, metric])
+  if (maximize) {
+    best <- which.max(x[, metric])
+  } else {
+    best <- which.min(x[, metric])
+  }
   min(x[best, "Variables"])
 }
 
@@ -1137,10 +1151,10 @@ gamFuncs <- list(
     }
     loadNamespace("mgcv")
     gam <- get("gam", asNamespace("mgcv"))
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$y <- y
     args <- list(
@@ -1247,10 +1261,10 @@ rfFuncs <- list(
 lmFuncs <- list(
   summary = defaultSummary,
   fit = function(x, y, first, last, ...) {
-    tmp <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      tmp <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      tmp <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     tmp$y <- y
     lm(y ~ ., data = tmp)
@@ -1312,7 +1326,11 @@ nbFuncs <- list(
 #' @export
 lrFuncs <- ldaFuncs
 lrFuncs$fit <- function(x, y, first, last, ...) {
-  tmp <- if (is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
+  if (is.data.frame(x)) {
+    tmp <- x
+  } else {
+    tmp <- as.data.frame(x, stringsAsFactors = TRUE)
+  }
   tmp$Class <- y
   glm(Class ~ ., data = tmp, family = "binomial")
 }
@@ -1458,10 +1476,10 @@ stripplot.rfe <- function(x, data = NULL, metric = x$metric, ...) {
   )
   theDots <- list(...)
   if (any(names(theDots) == "horizontal")) {
-    formText <- if (theDots$horizontal) {
-      paste("Variable ~", metric)
+    if (theDots$horizontal) {
+      formText <- paste("Variable ~", metric)
     } else {
-      paste(metric, "~ Variable")
+      formText <- paste(metric, "~ Variable")
     }
   } else {
     formText <- paste("Variable ~", metric)
@@ -1530,7 +1548,9 @@ predict.rfe <- function(object, newdata, ...) {
     keep <- match(row.names(m), rn)
     newdata <- model.matrix(Terms, m, contrasts = object$contrasts)
     xint <- match("(Intercept)", colnames(newdata), nomatch = 0)
-    if (xint > 0) newdata <- newdata[, -xint, drop = FALSE]
+    if (xint > 0) {
+      newdata <- newdata[, -xint, drop = FALSE]
+    }
   } else {
     if (any(names(object) == "recipe")) {
       newdata <-
@@ -1705,10 +1725,10 @@ rfe_rec <- function(
         data.frame(pred = modelPred, obs = test_y, Variables = sizeValues[k])
     }
     ## save as a vector and rbind at end
-    rfePred <- if (k == 1) {
-      modelPred
+    if (k == 1) {
+      rfePred <- modelPred
     } else {
-      rbind(rfePred, modelPred)
+      rfePred <- rbind(rfePred, modelPred)
     }
 
     if (!exists("modImp")) {
@@ -1920,12 +1940,11 @@ rfe_rec <- function(
     }
 
     ## Set or check the seeds when needed
-    totalSize <-
-      if (any(sizes == p)) {
-        length(sizes)
-      } else {
-        length(sizes) + 1
-      }
+    if (any(sizes == p)) {
+      totalSize <- length(sizes)
+    } else {
+      totalSize <- length(sizes) + 1
+    }
     if (is.null(rfeControl$seeds)) {
       seeds <- vector(mode = "list", length = length(rfeControl$index))
       seeds <-
@@ -2143,15 +2162,14 @@ rfe_rec_workflow <- function(rec, data, sizes, ctrl, lev, ...) {
         holdoutIndex <- modelIndex
       }
 
-      seeds <-
-        if (
-          !(length(ctrl$seeds) == 1 &&
-            is.na(ctrl$seeds))
-        ) {
-          ctrl$seeds[[iter]]
-        } else {
-          NA
-        }
+      if (
+        !(length(ctrl$seeds) == 1 &&
+          is.na(ctrl$seeds))
+      ) {
+        seeds <- ctrl$seeds[[iter]]
+      } else {
+        seeds <- NA
+      }
 
       if (ctrl$verbose) {
         cat("+(rfe)", names(resampleIndex)[iter], "recipe", "\n")
@@ -2355,15 +2373,14 @@ rfe_rec_loo <- function(rec, data, sizes, ctrl, lev, ...) {
       modelIndex <- resampleIndex[[iter]]
       holdoutIndex <- -unique(resampleIndex[[iter]])
 
-      seeds <-
-        if (
-          !(length(ctrl$seeds) == 1 &&
-            is.na(ctrl$seeds))
-        ) {
-          ctrl$seeds[[iter]]
-        } else {
-          NA
-        }
+      if (
+        !(length(ctrl$seeds) == 1 &&
+          is.na(ctrl$seeds))
+      ) {
+        seeds <- ctrl$seeds[[iter]]
+      } else {
+        seeds <- NA
+      }
       if (ctrl$verbose) {
         cat("Preparing recipe\n")
       }

--- a/R/safs.R
+++ b/R/safs.R
@@ -556,24 +556,24 @@ safsControl <- function(
 #' simulated annealing. Science, 220(4598), 671.
 #' @keywords models
 #' @examplesIf !caret:::is_cran_check()
-#' 
-#' 
+#'
+#'
 #' set.seed(1)
 #' train_data <- twoClassSim(100, noiseVars = 10)
 #' test_data <- twoClassSim(10, noiseVars = 10)
-#' 
+#'
 #' ## A short example
 #' ctrl <- safsControl(functions = rfSA, method = "cv", number = 3)
-#' 
+#'
 #' rf_search <- safs(
 #'   x = train_data[, -ncol(train_data)],
 #'   y = train_data$Class,
 #'   iters = 3,
 #'   safsControl = ctrl
 #' )
-#' 
+#'
 #' rf_search
-#' 
+#'
 #' @export safs
 safs <- function(x, ...) UseMethod("safs")
 
@@ -913,36 +913,36 @@ safs <- function(x, ...) UseMethod("safs")
 #' @references
 #'   <http://topepo.github.io/caret/feature-selection-using-simulated-annealing.html>
 #' @examplesIf !caret:::is_cran_check()
-#' 
+#'
 #' selected_vars <- safs_initial(vars = 10, prob = 0.2)
 #' selected_vars
-#' 
+#'
 #' ###
-#' 
+#'
 #' safs_perturb(selected_vars, vars = 10, number = 1)
-#' 
+#'
 #' ###
-#' 
+#'
 #' safs_prob(old = .8, new = .9, iteration = 1)
 #' safs_prob(old = .5, new = .6, iteration = 1)
-#' 
+#'
 #' grid <- expand.grid(old = c(4, 3.5), new = c(4.5, 4, 3.5) + 1, iter = 1:40)
 #' grid <- subset(grid, old < new)
-#' 
+#'
 #' grid$prob <- apply(grid, 1, function(x) {
 #'   safs_prob(new = x["new"], old = x["old"], iteration = x["iter"])
 #' })
-#' 
+#'
 #' grid$Difference <- factor(grid$new - grid$old)
 #' grid$Group <- factor(paste("Current Value", grid$old))
-#' 
+#'
 #' ggplot(grid, aes(x = iter, y = prob, color = Difference)) +
 #'   geom_line() +
 #'   facet_wrap(~Group) +
 #'   theme_bw() +
 #'   ylab("Probability") +
 #'   xlab("Iteration")
-#' 
+#'
 #' ## Hypothetical usage (not run):
 #' ## lda_sa <- safs(x = predictors,
 #' ##                y = classes,
@@ -957,7 +957,7 @@ safs <- function(x, ...) UseMethod("safs")
 #' ##               safsControl = safsControl(functions = rfSA),
 #' ##               ntree = 1000,
 #' ##               importance = TRUE)
-#' 
+#'
 #' @export safs_initial
 safs_initial <- function(vars, prob = 0.20, ...) {
   sort(sample.int(vars, size = floor(vars * prob) + 1))
@@ -1527,21 +1527,21 @@ rfSA <- list(
 #' @seealso [gafs()], [safs()]
 #' @keywords models
 #' @examplesIf !caret:::is_cran_check()
-#' 
+#'
 #' set.seed(1)
 #' train_data <- twoClassSim(100, noiseVars = 10)
 #' test_data <- twoClassSim(10, noiseVars = 10)
-#' 
+#'
 #' ## A short example
 #' ctrl <- safsControl(functions = rfSA, method = "cv", number = 3)
-#' 
+#'
 #' rf_search <- safs(
 #'   x = train_data[, -ncol(train_data)],
 #'   y = train_data$Class,
 #'   iters = 3,
 #'   safsControl = ctrl
 #' )
-#' 
+#'
 #' rf_search2 <- update(
 #'   rf_search,
 #'   iter = 1,
@@ -1750,7 +1750,11 @@ update.safs <- function(object, iter, x, y, ...) {
     if (!is.null(perf_data)) {
       testOutput <- cbind(
         testOutput,
-        perf_data[sample(seq_len(nrow(perf_data)), nrow(testOutput)), , drop = FALSE]
+        perf_data[
+          sample(seq_len(nrow(perf_data)), nrow(testOutput)),
+          ,
+          drop = FALSE
+        ]
       )
     }
 

--- a/R/safs.R
+++ b/R/safs.R
@@ -804,10 +804,10 @@ safs <- function(x, ...) UseMethod("safs")
       best_iter <- averages$Iter[best_index]
       best_vars <- colnames(x)[final_sa$subsets[[best_index]]]
     } else {
-      best_index <- if (safsControl$maximize["external"]) {
-        which.max(averages[, safsControl$metric["external"]])
+      if (safsControl$maximize["external"]) {
+        best_index <- which.max(averages[, safsControl$metric["external"]])
       } else {
-        which.min(averages[, safsControl$metric["external"]])
+        best_index <- which.min(averages[, safsControl$metric["external"]])
       }
       best_iter <- averages$Iter[best_index]
       best_vars <- colnames(x)[final_sa$subsets[[best_index]]]
@@ -1120,7 +1120,11 @@ sa_select <- function(
     Similarity_B = rep(0 * NA, iters),
     stringsAsFactors = FALSE
   )
-  external <- if (!is.null(testX)) data.frame(Iter = 1:(iters)) else NULL
+  if (!is.null(testX)) {
+    external <- data.frame(Iter = 1:(iters))
+  } else {
+    external <- NULL
+  }
 
   for (i in 1:iters) {
     if (i == 1) {
@@ -1191,7 +1195,9 @@ sa_select <- function(
       }
     } else {
       internal[i, (nr - k + 1):nr] <- new_obj$internal
-      if (!is.null(testX)) external[i, -1] <- new_obj$external
+      if (!is.null(testX)) {
+        external[i, -1] <- new_obj$external
+      }
     }
 
     if (sa_verbose) {
@@ -1245,7 +1251,9 @@ sa_select <- function(
       internal$Note[i] <- "Improved"
       last_improve <- i
       since_improve <- 0
-      if (sa_verbose && i > 1) cat(" *\n")
+      if (sa_verbose && i > 1) {
+        cat(" *\n")
+      }
     } else {
       if (i > 1) {
         internal$Prob[i] <- funcs$prob(
@@ -1265,12 +1273,16 @@ sa_select <- function(
         current_subset <- new_subset
         internal$Best[i] <- internal$Best[i - 1]
         internal$Note[i] <- "Accepted"
-        if (sa_verbose && i > 1) cat("A\n")
+        if (sa_verbose && i > 1) {
+          cat("A\n")
+        }
       } else {
         internal$Obj[i] <- internal$Obj[i - 1]
         internal$Best[i] <- internal$Best[i - 1]
         internal$Note[i] <- "Discarded"
-        if (sa_verbose && i > 1) cat("\n")
+        if (sa_verbose && i > 1) {
+          cat("\n")
+        }
       }
     }
 
@@ -1369,27 +1381,30 @@ plot.safs <- function(
   if (output == "data") {
     out <- plot_dat
   }
-  plot_dat <- if (both_estimates) {
-    ddply(plot_dat, c("Iter", "Estimate"), function(x) {
+  if (both_estimates) {
+    plot_dat <- ddply(plot_dat, c("Iter", "Estimate"), function(x) {
       c(Mean = mean(x[, metric]))
     })
   } else {
-    ddply(plot_dat, c("Iter"), function(x) c(Mean = mean(x[, metric])))
+    plot_dat <- ddply(plot_dat, c("Iter"), function(x) {
+      c(Mean = mean(x[, metric]))
+    })
   }
 
   if (output == "ggplot") {
-    out <- if (both_estimates) {
-      ggplot(plot_dat, aes(x = Iter, y = Mean, color = Estimate)) + geom_point()
+    if (both_estimates) {
+      out <- ggplot(plot_dat, aes(x = Iter, y = Mean, color = Estimate)) +
+        geom_point()
     } else {
-      ggplot(plot_dat, aes(x = Iter, y = Mean)) + geom_point()
+      out <- ggplot(plot_dat, aes(x = Iter, y = Mean)) + geom_point()
     }
     out <- out + xlab("Iteration")
   }
   if (output == "lattice") {
-    out <- if (both_estimates) {
-      xyplot(Mean ~ Iter, data = plot_dat, groups = Estimate, ...)
+    if (both_estimates) {
+      out <- xyplot(Mean ~ Iter, data = plot_dat, groups = Estimate, ...)
     } else {
-      xyplot(Mean ~ Iter, data = plot_dat, ...)
+      out <- xyplot(Mean ~ Iter, data = plot_dat, ...)
     }
     out <- update(out, xlab = "Iteration")
   }
@@ -1935,10 +1950,10 @@ update.safs <- function(object, iter, x, y, ...) {
       best_iter <- averages$Iter[best_index]
       best_vars <- colnames(x)[final_sa$subsets[[best_index]]]
     } else {
-      best_index <- if (safsControl$maximize["external"]) {
-        which.max(averages[, safsControl$metric["external"]])
+      if (safsControl$maximize["external"]) {
+        best_index <- which.max(averages[, safsControl$metric["external"]])
       } else {
-        which.min(averages[, safsControl$metric["external"]])
+        best_index <- which.min(averages[, safsControl$metric["external"]])
       }
       best_iter <- averages$Iter[best_index]
       best_vars <- colnames(x)[final_sa$subsets[[best_index]]]

--- a/R/sampling.R
+++ b/R/sampling.R
@@ -21,14 +21,14 @@
 #' @author Max Kuhn
 #' @keywords utilities
 #' @examples
-#' 
+#'
 #' ## A ridiculous example...
 #' data(oil)
 #' table(oilType)
 #' downSample(fattyAcids, oilType)
-#' 
+#'
 #' upSample(fattyAcids, oilType)
-#' 
+#'
 #' @export downSample
 downSample <- function(x, y, list = FALSE, yname = "Class") {
   if (!is.data.frame(x)) {
@@ -44,10 +44,14 @@ downSample <- function(x, y, list = FALSE, yname = "Class") {
   minClass <- min(table(y))
   x$.outcome <- y
 
-  x <- ddply(x, .(y),
-             function(dat, n)
-               dat[sample(seq(along.with = dat$.outcome), n), , drop = FALSE],
-             n = minClass)
+  x <- ddply(
+    x,
+    .(y),
+    function(dat, n) {
+      dat[sample(seq(along.with = dat$.outcome), n), , drop = FALSE]
+    },
+    n = minClass
+  )
   y <- x$.outcome
   x <- x[, !(colnames(x) %in% c("y", ".outcome")), drop = FALSE]
   if (list) {
@@ -78,19 +82,16 @@ upSample <- function(x, y, list = FALSE, yname = "Class") {
   maxClass <- max(table(y))
   x$.outcome <- y
 
-  x <- ddply(x, .(y),
-             function(x, top = maxClass) {
-               if (nrow(x) < top) {
-                 ind <- sample(seq_len(nrow(x)),
-                               size = top - nrow(x),
-                               replace = TRUE)
-                 ind <- c(seq_len(nrow(x)), ind)
-                 x <- x[ind, , drop = FALSE]
-               }
-               x
-             })
+  x <- ddply(x, .(y), function(x, top = maxClass) {
+    if (nrow(x) < top) {
+      ind <- sample(seq_len(nrow(x)), size = top - nrow(x), replace = TRUE)
+      ind <- c(seq_len(nrow(x)), ind)
+      x <- x[ind, , drop = FALSE]
+    }
+    x
+  })
   y <- x$.outcome
-  x <- x[,!(colnames(x) %in% c("y", ".outcome")), drop = FALSE]
+  x <- x[, !(colnames(x) %in% c("y", ".outcome")), drop = FALSE]
   if (list) {
     if (inherits(x, "matrix")) {
       x <- as.matrix(x)
@@ -102,6 +103,3 @@ upSample <- function(x, y, list = FALSE, yname = "Class") {
   }
   out
 }
-
-
-

--- a/R/selectByFilter.R
+++ b/R/selectByFilter.R
@@ -1,17 +1,28 @@
 #' @rdname caret-internal
 #' @export
-sbfIter <- function(x, y, testX, testY, testPerf = NULL,
-                    sbfControl = sbfControl(), ...) {
-  if (is.null(colnames(x)))
+sbfIter <- function(
+  x,
+  y,
+  testX,
+  testY,
+  testPerf = NULL,
+  sbfControl = sbfControl(),
+  ...
+) {
+  if (is.null(colnames(x))) {
     stop("x must have column names")
+  }
 
-  if (is.null(testX) ||
-      is.null(testY))
+  if (
+    is.null(testX) ||
+      is.null(testY)
+  ) {
     stop("a test set must be specified")
+  }
 
   if (sbfControl$multivariate) {
     scores <- sbfControl$functions$score(x, y)
-    if (length(scores) != ncol(x))
+    if (length(scores) != ncol(x)) {
       stop(
         paste(
           "when control$multivariate == TRUE, 'scores'",
@@ -20,41 +31,42 @@ sbfIter <- function(x, y, testX, testY, testPerf = NULL,
           "numeric values"
         )
       )
-  } else  {
+    }
+  } else {
     scores <- vapply(x, sbfControl$functions$score, double(1), y = y)
   }
 
-    retained <- sbfControl$functions$filter(scores, x, y)
-    ## deal with zero length results
+  retained <- sbfControl$functions$filter(scores, x, y)
+  ## deal with zero length results
 
-    testX <- testX[, which(retained), drop = FALSE]
+  testX <- testX[, which(retained), drop = FALSE]
 
-    fitObject <-
-      sbfControl$functions$fit(
-        x = x[, which(retained), drop = FALSE],
-        y = y,
-        ...
-      )
+  fitObject <-
+    sbfControl$functions$fit(
+      x = x[, which(retained), drop = FALSE],
+      y = y,
+      ...
+    )
 
-    modelPred <- sbfControl$functions$pred(fitObject, testX)
-    if (is.data.frame(modelPred) || is.matrix(modelPred)) {
-      if (is.matrix(modelPred))
-        modelPred <- as.data.frame(modelPred, stringsAsFactors = TRUE)
-      modelPred$obs <- testY
-    } else
-      modelPred <- data.frame(pred = modelPred, obs = testY)
-    if (!is.null(testPerf))
-      modelPred <- cbind(modelPred, testPerf)
-
-    list(variables = names(retained)[which(retained)],
-         pred = modelPred)
+  modelPred <- sbfControl$functions$pred(fitObject, testX)
+  if (is.data.frame(modelPred) || is.matrix(modelPred)) {
+    if (is.matrix(modelPred)) {
+      modelPred <- as.data.frame(modelPred, stringsAsFactors = TRUE)
+    }
+    modelPred$obs <- testY
+  } else {
+    modelPred <- data.frame(pred = modelPred, obs = testY)
+  }
+  if (!is.null(testPerf)) {
+    modelPred <- cbind(modelPred, testPerf)
   }
 
+  list(variables = names(retained)[which(retained)], pred = modelPred)
+}
 
-  ######################################################################
-  ######################################################################
 
-
+######################################################################
+######################################################################
 
 #' Selection By Filtering (SBF)
 #'
@@ -130,9 +142,9 @@ sbfIter <- function(x, y, testX, testY, testPerf = NULL,
 #' @family feature-selection
 #' @keywords models
 #' @examplesIf !caret:::is_cran_check()
-#' 
+#'
 #' data(BloodBrain)
-#' 
+#'
 #' ## Use a GAM is the filter, then fit a random forest model
 #' RFwithGAM <- sbf(
 #'   bbbDescr,
@@ -140,22 +152,22 @@ sbfIter <- function(x, y, testX, testY, testPerf = NULL,
 #'   sbfControl = sbfControl(functions = rfSBF, verbose = FALSE, method = "cv")
 #' )
 #' RFwithGAM
-#' 
+#'
 #' predict(RFwithGAM, bbbDescr[1:10, ])
-#' 
+#'
 #' ## classification example with parallel processing
-#' 
+#'
 #' ## library(doMC)
-#' 
+#'
 #' ## Note: if the underlying model also uses foreach, the
 #' ## number of cores specified above will double (along with
 #' ## the memory requirements)
 #' ## registerDoMC(cores = 2)
-#' 
+#'
 #' data(mdrr)
 #' mdrrDescr <- mdrrDescr[, -nearZeroVar(mdrrDescr)]
 #' mdrrDescr <- mdrrDescr[, -findCorrelation(cor(mdrrDescr), .8)]
-#' 
+#'
 #' set.seed(1)
 #' filteredNB <- sbf(
 #'   mdrrDescr,
@@ -169,79 +181,111 @@ sbfIter <- function(x, y, testX, testY, testPerf = NULL,
 #'   )
 #' )
 #' confusionMatrix(filteredNB)
-#' 
+#'
 #' @export sbf
-sbf <- function (x, ...) UseMethod("sbf")
+sbf <- function(x, ...) UseMethod("sbf")
 
 #' @rdname sbf
 #' @export
 "sbf.default" <-
-  function(x, y,
-           sbfControl = sbfControl(), ...) {
+  function(x, y, sbfControl = sbfControl(), ...) {
     startTime <- proc.time()
     funcCall <- match.call(expand.dots = TRUE)
 
     numFeat <- ncol(x)
     classLevels <- levels(y)
 
-    if (sbfControl$method == "oob")
+    if (sbfControl$method == "oob") {
       stop("out-of-bag resampling cannot be used with this function")
+    }
 
-    if(is.null(sbfControl$index)) sbfControl$index <- switch(
-      tolower(sbfControl$method),
-      cv = createFolds(y, sbfControl$number, returnTrain = TRUE),
-      repeatedcv = createMultiFolds(y, sbfControl$number, sbfControl$repeats),
-      loocv = createFolds(y, length(y), returnTrain = TRUE),
-      boot =, boot632 = createResample(y, sbfControl$number),
-      test = createDataPartition(y, 1, sbfControl$p),
-      lgocv = createDataPartition(y, sbfControl$number, sbfControl$p))
+    if (is.null(sbfControl$index)) {
+      sbfControl$index <- switch(
+        tolower(sbfControl$method),
+        cv = createFolds(y, sbfControl$number, returnTrain = TRUE),
+        repeatedcv = createMultiFolds(y, sbfControl$number, sbfControl$repeats),
+        loocv = createFolds(y, length(y), returnTrain = TRUE),
+        boot = ,
+        boot632 = createResample(y, sbfControl$number),
+        test = createDataPartition(y, 1, sbfControl$p),
+        lgocv = createDataPartition(y, sbfControl$number, sbfControl$p)
+      )
+    }
 
-    if(is.null(names(sbfControl$index)))
+    if (is.null(names(sbfControl$index))) {
       names(sbfControl$index) <- prettySeq(sbfControl$index)
-    if(is.null(sbfControl$indexOut)){
-      sbfControl$indexOut <- lapply(sbfControl$index,
-                                    function(training, allSamples) allSamples[-unique(training)],
-                                    allSamples = seq(along.with = y))
+    }
+    if (is.null(sbfControl$indexOut)) {
+      sbfControl$indexOut <- lapply(
+        sbfControl$index,
+        function(training, allSamples) allSamples[-unique(training)],
+        allSamples = seq(along.with = y)
+      )
       names(sbfControl$indexOut) <- prettySeq(sbfControl$indexOut)
     }
     ## check summary function and metric
-    testOutput <- data.frame(pred = sample(y, min(10, length(y))),
-                             obs = sample(y, min(10, length(y))))
+    testOutput <- data.frame(
+      pred = sample(y, min(10, length(y))),
+      obs = sample(y, min(10, length(y)))
+    )
 
-    if(is.factor(y))
-      for(i in seq(along.with = classLevels))
+    if (is.factor(y)) {
+      for (i in seq(along.with = classLevels)) {
         testOutput[, classLevels[i]] <- runif(nrow(testOutput))
-
+      }
+    }
 
     test <- sbfControl$functions$summary(testOutput, lev = classLevels)
     perfNames <- names(test)
 
     ## Set or check the seeds when needed
-    if(is.null(sbfControl$seeds)) {
-      sbfControl$seeds <- sample.int(n = 1000000, size = length(sbfControl$index) + 1)
+    if (is.null(sbfControl$seeds)) {
+      sbfControl$seeds <- sample.int(
+        n = 1000000,
+        size = length(sbfControl$index) + 1
+      )
     } else {
-      if(!(length(sbfControl$seeds) == 1 && is.na(sbfControl$seeds))) {
-        if(length(sbfControl$seeds) != length(sbfControl$index) + 1)
-          stop(paste("Bad seeds: the seed object should be an integer vector of length",
-                     length(sbfControl$index) + 1))
+      if (!(length(sbfControl$seeds) == 1 && is.na(sbfControl$seeds))) {
+        if (length(sbfControl$seeds) != length(sbfControl$index) + 1) {
+          stop(paste(
+            "Bad seeds: the seed object should be an integer vector of length",
+            length(sbfControl$index) + 1
+          ))
+        }
       }
     }
 
-
-
     #########################################################################
 
-    if(sbfControl$method == "LOOCV") {
-      tmp <- looSbfWorkflow(x = x, y = y, ppOpts = preProcess,
-                            ctrl = sbfControl, lev = classLevels, ...)
-      resamples <- do.call("rbind", tmp$everything[names(tmp$everything) == "pred"])
+    if (sbfControl$method == "LOOCV") {
+      tmp <- looSbfWorkflow(
+        x = x,
+        y = y,
+        ppOpts = preProcess,
+        ctrl = sbfControl,
+        lev = classLevels,
+        ...
+      )
+      resamples <- do.call(
+        "rbind",
+        tmp$everything[names(tmp$everything) == "pred"]
+      )
       rownames(resamples) <- seq_len(nrow(resamples))
       selectedVars <- tmp$everything[names(tmp$everything) == "variables"]
       performance <- tmp$performance
     } else {
-      tmp <- nominalSbfWorkflow(x = x, y = y, ppOpts = preProcess,
-                                ctrl = sbfControl, lev = classLevels, ...)
-      resamples <- do.call("rbind", tmp$everything[names(tmp$everything) == "resamples"])
+      tmp <- nominalSbfWorkflow(
+        x = x,
+        y = y,
+        ppOpts = preProcess,
+        ctrl = sbfControl,
+        lev = classLevels,
+        ...
+      )
+      resamples <- do.call(
+        "rbind",
+        tmp$everything[names(tmp$everything) == "resamples"]
+      )
       rownames(resamples) <- seq_len(nrow(resamples))
       selectedVars <- tmp$everything[names(tmp$everything) == "selectedVars"]
       performance <- tmp$performance
@@ -250,12 +294,17 @@ sbf <- function (x, ...) UseMethod("sbf")
     #########################################################################
 
     varList <- unique(unlist(selectedVars))
-    if(sbfControl$multivariate) {
+    if (sbfControl$multivariate) {
       scores <- sbfControl$functions$score(x, y)
-      if(length(scores) != ncol(x))
-        stop(paste("when control$multivariate == TRUE, 'scores'",
-                   "should return a vector with", ncol(x), "numeric values"))
-    } else  {
+      if (length(scores) != ncol(x)) {
+        stop(paste(
+          "when control$multivariate == TRUE, 'scores'",
+          "should return a vector with",
+          ncol(x),
+          "numeric values"
+        ))
+      }
+    } else {
       scores <- apply(x, 2, sbfControl$functions$score, y = y)
     }
     retained <- sbfControl$functions$filter(scores, x, y)
@@ -270,21 +319,27 @@ sbf <- function (x, ...) UseMethod("sbf")
     )
 
     performance <- data.frame(t(performance))
-    performance <- performance[,!grepl("\\.cell|Resample", colnames(performance))]
+    performance <- performance[,
+      !grepl("\\.cell|Resample", colnames(performance))
+    ]
 
-    if(is.factor(y) && any(names(resamples) == ".cell1")) {
+    if (is.factor(y) && any(names(resamples) == ".cell1")) {
       keepers <- c("Resample", grep("\\.cell", names(resamples), value = TRUE))
-      resampledCM <- resamples[,keepers]
+      resampledCM <- resamples[, keepers]
       resamples <- resamples[, -grep("\\.cell", names(resamples))]
-    } else resampledCM <- NULL
+    } else {
+      resampledCM <- NULL
+    }
 
-    resamples <- switch(sbfControl$returnResamp,
-                        none = NULL,
-                        all =, final = resamples)
+    resamples <- switch(
+      sbfControl$returnResamp,
+      none = NULL,
+      all = ,
+      final = resamples
+    )
 
     endTime <- proc.time()
-    times <- list(everything = endTime - startTime,
-                  final = finalTime)
+    times <- list(everything = endTime - startTime, final = finalTime)
 
     #########################################################################
     ## Now, based on probability or static ranking, figure out the best vars
@@ -292,7 +347,7 @@ sbf <- function (x, ...) UseMethod("sbf")
 
     out <- structure(
       list(
-        pred = if(sbfControl$saveDetails) tmp else NULL,
+        pred = if (sbfControl$saveDetails) tmp else NULL,
         variables = selectedVars,
         results = performance,
         fit = fit,
@@ -304,22 +359,31 @@ sbf <- function (x, ...) UseMethod("sbf")
         times = times,
         resampledCM = resampledCM,
         obsLevels = classLevels,
-        dots = list(...)),
-      class = "sbf")
-    if(sbfControl$timingSamps > 0) {
+        dots = list(...)
+      ),
+      class = "sbf"
+    )
+    if (sbfControl$timingSamps > 0) {
       out$times$prediction <-
         system.time(
-          predict(out, x[1:min(nrow(x), sbfControl$timingSamps),,drop = FALSE])
+          predict(
+            out,
+            x[1:min(nrow(x), sbfControl$timingSamps), , drop = FALSE]
+          )
         )
-    } else  out$times$prediction <- rep(NA, 3)
+    } else {
+      out$times$prediction <- rep(NA, 3)
+    }
     out
   }
 
 #' @rdname sbf
 #' @export
-sbf.formula <- function (form, data, ..., subset, na.action, contrasts = NULL) {
+sbf.formula <- function(form, data, ..., subset, na.action, contrasts = NULL) {
   m <- match.call(expand.dots = FALSE)
-  if (is.matrix(eval.parent(m$data))) m$data <- as.data.frame(data, stringsAsFactors = FALSE)
+  if (is.matrix(eval.parent(m$data))) {
+    m$data <- as.data.frame(data, stringsAsFactors = FALSE)
+  }
   m$... <- m$contrasts <- NULL
   m[[1]] <- as.name("model.frame")
   m <- eval.parent(m)
@@ -327,7 +391,9 @@ sbf.formula <- function (form, data, ..., subset, na.action, contrasts = NULL) {
   x <- model.matrix(Terms, m, contrasts)
   cons <- attr(x, "contrast")
   xint <- match("(Intercept)", colnames(x), nomatch = 0)
-  if (xint > 0)  x <- x[, -xint, drop = FALSE]
+  if (xint > 0) {
+    x <- x[, -xint, drop = FALSE]
+  }
   y <- model.response(m)
   res <- sbf(as.data.frame(x, stringsAsFactors = TRUE), y, ...)
   res$terms <- Terms
@@ -346,14 +412,14 @@ sbf.formula <- function (form, data, ..., subset, na.action, contrasts = NULL) {
 #' @rdname sbf
 #' @export
 "sbf.recipe" <-
-  function(x, data,
-           sbfControl = sbfControl(), ...) {
+  function(x, data, sbfControl = sbfControl(), ...) {
     startTime <- proc.time()
     funcCall <- match.call(expand.dots = TRUE)
 
     orig_rec <- x
     trained_rec <- prep(
-      x, training = data,
+      x,
+      training = data,
       fresh = TRUE,
       retain = TRUE,
       verbose = FALSE,
@@ -361,83 +427,124 @@ sbf.formula <- function (form, data, ..., subset, na.action, contrasts = NULL) {
     )
     x <- juice(trained_rec, all_predictors(), composition = "data.frame")
     y <- juice(trained_rec, all_outcomes(), composition = "data.frame")
-    if(ncol(y) > 1)
+    if (ncol(y) > 1) {
       stop("`safs` doesn't support multivariate outcomes", call. = FALSE)
+    }
     y <- y[[1]]
     is_weight <- summary(trained_rec)$role == "case weight"
-    if(any(is_weight))
+    if (any(is_weight)) {
       stop("`safs` does not allow for weights.", call. = FALSE)
+    }
 
     is_perf <- summary(trained_rec)$role == "performance var"
-    if(any(is_perf)) {
+    if (any(is_perf)) {
       perf_data <- juice(trained_rec, has_role("performance var"))
-    } else perf_data <- NULL
+    } else {
+      perf_data <- NULL
+    }
 
     numFeat <- ncol(x)
     classLevels <- levels(y)
 
-    if (sbfControl$method == "oob")
+    if (sbfControl$method == "oob") {
       stop("out-of-bag resampling cannot be used with this function")
+    }
 
-    if(is.null(sbfControl$index)) sbfControl$index <- switch(
-      tolower(sbfControl$method),
-      cv = createFolds(y, sbfControl$number, returnTrain = TRUE),
-      repeatedcv = createMultiFolds(y, sbfControl$number, sbfControl$repeats),
-      loocv = createFolds(y, length(y), returnTrain = TRUE),
-      boot =, boot632 = createResample(y, sbfControl$number),
-      test = createDataPartition(y, 1, sbfControl$p),
-      lgocv = createDataPartition(y, sbfControl$number, sbfControl$p))
+    if (is.null(sbfControl$index)) {
+      sbfControl$index <- switch(
+        tolower(sbfControl$method),
+        cv = createFolds(y, sbfControl$number, returnTrain = TRUE),
+        repeatedcv = createMultiFolds(y, sbfControl$number, sbfControl$repeats),
+        loocv = createFolds(y, length(y), returnTrain = TRUE),
+        boot = ,
+        boot632 = createResample(y, sbfControl$number),
+        test = createDataPartition(y, 1, sbfControl$p),
+        lgocv = createDataPartition(y, sbfControl$number, sbfControl$p)
+      )
+    }
 
-    if(is.null(names(sbfControl$index)))
+    if (is.null(names(sbfControl$index))) {
       names(sbfControl$index) <- prettySeq(sbfControl$index)
-    if(is.null(sbfControl$indexOut)){
-      sbfControl$indexOut <- lapply(sbfControl$index,
-                                    function(training, allSamples) allSamples[-unique(training)],
-                                    allSamples = seq(along.with = y))
+    }
+    if (is.null(sbfControl$indexOut)) {
+      sbfControl$indexOut <- lapply(
+        sbfControl$index,
+        function(training, allSamples) allSamples[-unique(training)],
+        allSamples = seq(along.with = y)
+      )
       names(sbfControl$indexOut) <- prettySeq(sbfControl$indexOut)
     }
     ## check summary function and metric
-    testOutput <- data.frame(pred = sample(y, min(10, length(y))),
-                             obs = sample(y, min(10, length(y))))
+    testOutput <- data.frame(
+      pred = sample(y, min(10, length(y))),
+      obs = sample(y, min(10, length(y)))
+    )
 
-    if(is.factor(y))
-      for(i in seq(along.with = classLevels))
+    if (is.factor(y)) {
+      for (i in seq(along.with = classLevels)) {
         testOutput[, classLevels[i]] <- runif(nrow(testOutput))
-    if(!is.null(perf_data))
+      }
+    }
+    if (!is.null(perf_data)) {
       testOutput <- cbind(
         testOutput,
-        perf_data[sample(seq_len(nrow(perf_data)), nrow(testOutput)),, drop = FALSE]
+        perf_data[
+          sample(seq_len(nrow(perf_data)), nrow(testOutput)),
+          ,
+          drop = FALSE
+        ]
       )
+    }
 
     test <- sbfControl$functions$summary(testOutput, lev = classLevels)
     perfNames <- names(test)
 
     ## Set or check the seeds when needed
-    if(is.null(sbfControl$seeds)) {
-      sbfControl$seeds <- sample.int(n = 1000000, size = length(sbfControl$index) + 1)
+    if (is.null(sbfControl$seeds)) {
+      sbfControl$seeds <- sample.int(
+        n = 1000000,
+        size = length(sbfControl$index) + 1
+      )
     } else {
-      if(!(length(sbfControl$seeds) == 1 && is.na(sbfControl$seeds))) {
-        if(length(sbfControl$seeds) != length(sbfControl$index) + 1)
-          stop(paste("Bad seeds: the seed object should be an integer vector of length",
-                     length(sbfControl$index) + 1))
+      if (!(length(sbfControl$seeds) == 1 && is.na(sbfControl$seeds))) {
+        if (length(sbfControl$seeds) != length(sbfControl$index) + 1) {
+          stop(paste(
+            "Bad seeds: the seed object should be an integer vector of length",
+            length(sbfControl$index) + 1
+          ))
+        }
       }
     }
 
-
-
     #########################################################################
 
-    if(sbfControl$method == "LOOCV") {
-      tmp <- sbf_loo_rec(rec = orig_rec, data = data,
-                         ctrl = sbfControl, lev = classLevels, ...)
-      resamples <- do.call("rbind", tmp$everything[names(tmp$everything) == "pred"])
+    if (sbfControl$method == "LOOCV") {
+      tmp <- sbf_loo_rec(
+        rec = orig_rec,
+        data = data,
+        ctrl = sbfControl,
+        lev = classLevels,
+        ...
+      )
+      resamples <- do.call(
+        "rbind",
+        tmp$everything[names(tmp$everything) == "pred"]
+      )
       rownames(resamples) <- seq_len(nrow(resamples))
       selectedVars <- tmp$everything[names(tmp$everything) == "variables"]
       performance <- tmp$performance
     } else {
-      tmp <- sbf_rec(rec = orig_rec, data = data,
-                     ctrl = sbfControl, lev = classLevels, ...)
-      resamples <- do.call("rbind", tmp$everything[names(tmp$everything) == "resamples"])
+      tmp <- sbf_rec(
+        rec = orig_rec,
+        data = data,
+        ctrl = sbfControl,
+        lev = classLevels,
+        ...
+      )
+      resamples <- do.call(
+        "rbind",
+        tmp$everything[names(tmp$everything) == "resamples"]
+      )
       rownames(resamples) <- seq_len(nrow(resamples))
       selectedVars <- tmp$everything[names(tmp$everything) == "selectedVars"]
       performance <- tmp$performance
@@ -446,12 +553,17 @@ sbf.formula <- function (form, data, ..., subset, na.action, contrasts = NULL) {
     #########################################################################
 
     varList <- unique(unlist(selectedVars))
-    if(sbfControl$multivariate) {
+    if (sbfControl$multivariate) {
       scores <- sbfControl$functions$score(x, y)
-      if(length(scores) != ncol(x))
-        stop(paste("when control$multivariate == TRUE, 'scores'",
-                   "should return a vector with", ncol(x), "numeric values"))
-    } else  {
+      if (length(scores) != ncol(x)) {
+        stop(paste(
+          "when control$multivariate == TRUE, 'scores'",
+          "should return a vector with",
+          ncol(x),
+          "numeric values"
+        ))
+      }
+    } else {
       scores <- apply(x, 2, sbfControl$functions$score, y = y)
     }
     retained <- sbfControl$functions$filter(scores, x, y)
@@ -466,21 +578,27 @@ sbf.formula <- function (form, data, ..., subset, na.action, contrasts = NULL) {
     )
 
     performance <- data.frame(t(performance))
-    performance <- performance[,!grepl("\\.cell|Resample", colnames(performance))]
+    performance <- performance[,
+      !grepl("\\.cell|Resample", colnames(performance))
+    ]
 
-    if(is.factor(y) && any(names(resamples) == ".cell1")) {
+    if (is.factor(y) && any(names(resamples) == ".cell1")) {
       keepers <- c("Resample", grep("\\.cell", names(resamples), value = TRUE))
-      resampledCM <- resamples[,keepers]
+      resampledCM <- resamples[, keepers]
       resamples <- resamples[, -grep("\\.cell", names(resamples))]
-    } else resampledCM <- NULL
+    } else {
+      resampledCM <- NULL
+    }
 
-    resamples <- switch(sbfControl$returnResamp,
-                        none = NULL,
-                        all =, final = resamples)
+    resamples <- switch(
+      sbfControl$returnResamp,
+      none = NULL,
+      all = ,
+      final = resamples
+    )
 
     endTime <- proc.time()
-    times <- list(everything = endTime - startTime,
-                  final = finalTime)
+    times <- list(everything = endTime - startTime, final = finalTime)
 
     #########################################################################
     ## Now, based on probability or static ranking, figure out the best vars
@@ -488,7 +606,7 @@ sbf.formula <- function (form, data, ..., subset, na.action, contrasts = NULL) {
 
     out <- structure(
       list(
-        pred = if(sbfControl$saveDetails) tmp else NULL,
+        pred = if (sbfControl$saveDetails) tmp else NULL,
         variables = selectedVars,
         results = performance,
         fit = fit,
@@ -501,14 +619,21 @@ sbf.formula <- function (form, data, ..., subset, na.action, contrasts = NULL) {
         resampledCM = resampledCM,
         obsLevels = classLevels,
         dots = list(...),
-        recipe = trained_rec),
-      class = "sbf")
-    if(sbfControl$timingSamps > 0) {
+        recipe = trained_rec
+      ),
+      class = "sbf"
+    )
+    if (sbfControl$timingSamps > 0) {
       out$times$prediction <-
         system.time(
-          predict(out, x[1:min(nrow(x), sbfControl$timingSamps),,drop = FALSE])
+          predict(
+            out,
+            x[1:min(nrow(x), sbfControl$timingSamps), , drop = FALSE]
+          )
         )
-    } else  out$times$prediction <- rep(NA, 3)
+    } else {
+      out$times$prediction <- rep(NA, 3)
+    }
     out
   }
 
@@ -516,11 +641,10 @@ sbf.formula <- function (form, data, ..., subset, na.action, contrasts = NULL) {
 sbf_rec <- function(rec, data, ctrl, lev, ...) {
   loadNamespace("caret")
 
-
   resampleIndex <- ctrl$index
-  if(ctrl$method %in% c("boot632")){
+  if (ctrl$method %in% c("boot632")) {
     resampleIndex <- c(list("AllData" = rep(0, nrow(x))), resampleIndex)
-    ctrl$indexOut <- c(list("AllData" = rep(0, nrow(x))),  ctrl$indexOut)
+    ctrl$indexOut <- c(list("AllData" = rep(0, nrow(x))), ctrl$indexOut)
   }
 
   `%op%` <- getOper(ctrl$allowParallel && getDoParWorkers() > 1)
@@ -529,14 +653,17 @@ sbf_rec <- function(rec, data, ctrl, lev, ...) {
     .combine = "c",
     .verbose = FALSE,
     .errorhandling = "stop",
-    .packages = c("caret", "recipes")) %op% {
-      if (!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds)))
+    .packages = c("caret", "recipes")
+  ) %op%
+    {
+      if (!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds))) {
         set.seed(ctrl$seeds[iter])
+      }
 
       loadNamespace("caret")
       requireNamespaceQuietStop("methods")
 
-      if(names(resampleIndex)[iter] != "AllData") {
+      if (names(resampleIndex)[iter] != "AllData") {
         modelIndex <- resampleIndex[[iter]]
         holdoutIndex <- ctrl$indexOut[[iter]]
       } else {
@@ -556,17 +683,25 @@ sbf_rec <- function(rec, data, ctrl, lev, ...) {
       x_tr <- juice(resampled_rec, all_predictors(), composition = "data.frame")
       y_tr <- juice(resampled_rec, all_outcomes(), composition = "data.frame")
       y_tr <- y_tr[[1]]
-      x_te <- bake(resampled_rec, new_data = data[ holdoutIndex, ],
-                   all_predictors(), composition = "data.frame")
-      y_te <- bake(resampled_rec, new_data = data[ holdoutIndex, ],
-                   all_outcomes(), composition = "data.frame")
+      x_te <- bake(
+        resampled_rec,
+        new_data = data[holdoutIndex, ],
+        all_predictors(),
+        composition = "data.frame"
+      )
+      y_te <- bake(
+        resampled_rec,
+        new_data = data[holdoutIndex, ],
+        all_outcomes(),
+        composition = "data.frame"
+      )
       y_te <- y_te[[1]]
       is_perf <- summary(resampled_rec)$role == "performance var"
-      if(any(is_perf)) {
+      if (any(is_perf)) {
         perf_tr <- juice(resampled_rec, has_role("performance var"))
         perf_te <- bake(
           resampled_rec,
-          new_data = data[ holdoutIndex, ],
+          new_data = data[holdoutIndex, ],
           has_role("performance var")
         )
       } else {
@@ -574,59 +709,83 @@ sbf_rec <- function(rec, data, ctrl, lev, ...) {
         perf_te <- NULL
       }
 
-      sbfResults <- sbfIter(x = x_tr,
-                            y = y_tr,
-                            testX = x_te,
-                            testY = y_te,
-                            testPerf = perf_te,
-                            sbfControl = ctrl,
-                            ...)
-      if(ctrl$saveDetails) {
+      sbfResults <- sbfIter(
+        x = x_tr,
+        y = y_tr,
+        testX = x_te,
+        testY = y_te,
+        testPerf = perf_te,
+        sbfControl = ctrl,
+        ...
+      )
+      if (ctrl$saveDetails) {
         tmpPred <- sbfResults$pred
         tmpPred$Resample <- names(resampleIndex)[iter]
         tmpPred$rowIndex <- (1:nrow(data))[unique(holdoutIndex)]
-      } else tmpPred <- NULL
+      } else {
+        tmpPred <- NULL
+      }
       resamples <- ctrl$functions$summary(sbfResults$pred, lev = lev)
-      if(is.factor(y_tr) && length(lev) <= 50)
-        resamples <- c(resamples, flatTable(sbfResults$pred$pred, sbfResults$pred$obs))
+      if (is.factor(y_tr) && length(lev) <= 50) {
+        resamples <- c(
+          resamples,
+          flatTable(sbfResults$pred$pred, sbfResults$pred$obs)
+        )
+      }
       resamples <- data.frame(t(resamples))
       resamples$Resample <- names(resampleIndex)[iter]
 
-      list(resamples = resamples, selectedVars = sbfResults$variables, pred = tmpPred)
+      list(
+        resamples = resamples,
+        selectedVars = sbfResults$variables,
+        pred = tmpPred
+      )
     }
 
   resamples <- rbind.fill(result[names(result) == "resamples"])
-  pred <- if(ctrl$saveDetails) rbind.fill(result[names(result) == "pred"]) else NULL
-  performance <- MeanSD(resamples[,!grepl("Resample", colnames(resamples)),drop = FALSE])
+  pred <- if (ctrl$saveDetails) {
+    rbind.fill(result[names(result) == "pred"])
+  } else {
+    NULL
+  }
+  performance <- MeanSD(resamples[,
+    !grepl("Resample", colnames(resamples)),
+    drop = FALSE
+  ])
 
-  if(ctrl$method %in% c("boot632")) {
+  if (ctrl$method %in% c("boot632")) {
     modelIndex <- seq_len(nrow(x))
     holdoutIndex <- modelIndex
-    appResults <- sbfIter(x = x_tr,
-                          y = y_tr,
-                          testX = x_te,
-                          testY = y_te,
-                          testPerf = perf_te,
-                          ctrl,
-                          ...)
+    appResults <- sbfIter(
+      x = x_tr,
+      y = y_tr,
+      testX = x_te,
+      testY = y_te,
+      testPerf = perf_te,
+      ctrl,
+      ...
+    )
     apparent <- ctrl$functions$summary(appResults$pred, lev = lev)
     perfNames <- names(apparent)
     perfNames <- perfNames[perfNames != "Resample"]
 
-    const <- 1-exp(-1)
+    const <- 1 - exp(-1)
 
-    for(p in seq(along.with = perfNames))
+    for (p in seq(along.with = perfNames)) {
       performance[perfNames[p]] <-
-      (const * performance[perfNames[p]]) +  ((1-const) * apparent[perfNames[p]])
+        (const * performance[perfNames[p]]) +
+        ((1 - const) * apparent[perfNames[p]])
+    }
   }
 
   list(
     performance = performance,
     everything = result,
-    predictions = if (ctrl$saveDetails)
+    predictions = if (ctrl$saveDetails) {
       pred
-    else
+    } else {
       NULL
+    }
   )
 }
 
@@ -644,10 +803,12 @@ sbf_loo_rec <- function(rec, data, ctrl, lev, ...) {
     .combine = "c",
     .verbose = FALSE,
     .errorhandling = "stop",
-    .packages = c("caret", "recipes")) %op% {
-
-      if(!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds)))
+    .packages = c("caret", "recipes")
+  ) %op%
+    {
+      if (!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds))) {
         set.seed(ctrl$seeds[iter])
+      }
 
       loadNamespace("caret")
       requireNamespaceQuietStop("methods")
@@ -666,17 +827,25 @@ sbf_loo_rec <- function(rec, data, ctrl, lev, ...) {
       x_tr <- juice(resampled_rec, all_predictors(), composition = "data.frame")
       y_tr <- juice(resampled_rec, all_outcomes(), composition = "data.frame")
       y_tr <- y_tr[[1]]
-      x_te <- bake(resampled_rec, new_data = data[ holdoutIndex, ],
-                   all_predictors(), composition = "data.frame")
-      y_te <- bake(resampled_rec, new_data = data[ holdoutIndex, ],
-                   all_outcomes(), composition = "data.frame")
+      x_te <- bake(
+        resampled_rec,
+        new_data = data[holdoutIndex, ],
+        all_predictors(),
+        composition = "data.frame"
+      )
+      y_te <- bake(
+        resampled_rec,
+        new_data = data[holdoutIndex, ],
+        all_outcomes(),
+        composition = "data.frame"
+      )
       y_te <- y_te[[1]]
       is_perf <- summary(resampled_rec)$role == "performance var"
-      if(any(is_perf)) {
+      if (any(is_perf)) {
         perf_tr <- juice(resampled_rec, has_role("performance var"))
         perf_te <- bake(
           resampled_rec,
-          new_data = data[ holdoutIndex, ],
+          new_data = data[holdoutIndex, ],
           has_role("performance var")
         )
       } else {
@@ -684,13 +853,15 @@ sbf_loo_rec <- function(rec, data, ctrl, lev, ...) {
         perf_te <- NULL
       }
 
-      sbfResults <- sbfIter(x = x_tr,
-                            y = y_tr,
-                            testX = x_te,
-                            testY = y_te,
-                            testPerf = perf_te,
-                            sbfControl = ctrl,
-                            ...)
+      sbfResults <- sbfIter(
+        x = x_tr,
+        y = y_tr,
+        testX = x_te,
+        testY = y_te,
+        testPerf = perf_te,
+        sbfControl = ctrl,
+        ...
+      )
 
       sbfResults
     }
@@ -700,18 +871,23 @@ sbf_loo_rec <- function(rec, data, ctrl, lev, ...) {
   list(
     performance = performance,
     everything = result,
-    predictions = if (ctrl$saveDetails)
+    predictions = if (ctrl$saveDetails) {
       resamples
-    else
+    } else {
       NULL
+    }
   )
 }
 
 ######################################################################
 
 #' @export
-print.sbf <- function(x, top = 5, digits = max(3, getOption("digits") - 3), ...) {
-
+print.sbf <- function(
+  x,
+  top = 5,
+  digits = max(3, getOption("digits") - 3),
+  ...
+) {
   cat("\nSelection By Filter\n\n")
 
   resampleN <- unlist(lapply(x$control$index, length))
@@ -724,32 +900,38 @@ print.sbf <- function(x, top = 5, digits = max(3, getOption("digits") - 3), ...)
   print(format(x$results, digits = digits), row.names = FALSE)
   cat("\n")
 
-  if(length(x$optVariables) > 0) {
-    cat("Using the training set, ",
-        length(x$optVariables),
-        ifelse(length(x$optVariables) > 1,
-               " variables were selected:\n   ",
-               " variable was selected:\n   "),
-        paste(x$optVariables[1:min(top, length(x$optVariables))],
-              collapse = ", "),
-        ifelse(length(x$optVariables) > top, "..", ""),
-        ".\n\n",
-        sep = "")
-  } else cat("No variables were selected from the training set.\n\n")
-
+  if (length(x$optVariables) > 0) {
+    cat(
+      "Using the training set, ",
+      length(x$optVariables),
+      ifelse(
+        length(x$optVariables) > 1,
+        " variables were selected:\n   ",
+        " variable was selected:\n   "
+      ),
+      paste(
+        x$optVariables[1:min(top, length(x$optVariables))],
+        collapse = ", "
+      ),
+      ifelse(length(x$optVariables) > top, "..", ""),
+      ".\n\n",
+      sep = ""
+    )
+  } else {
+    cat("No variables were selected from the training set.\n\n")
+  }
 
   vars <- sort(table(unlist(x$variables)), decreasing = TRUE)
 
   top <- min(top, length(vars))
 
   smallVars <- vars[1:top]
-  smallVars <- round(smallVars/length(x$control$index)*100, 1)
+  smallVars <- round(smallVars / length(x$control$index) * 100, 1)
 
-  varText <- paste(names(smallVars), " (",
-                   smallVars, "%)", sep = "")
+  varText <- paste(names(smallVars), " (", smallVars, "%)", sep = "")
   varText <- paste(varText, collapse = ", ")
 
-  if(!all(is.na(smallVars))) {
+  if (!all(is.na(smallVars))) {
     cat(
       "During resampling, the top ",
       top,
@@ -787,22 +969,35 @@ predict.sbf <- function(object, newdata = NULL, ...) {
       newdata <- as.data.frame(newdata, stringsAsFactors = FALSE)
       rn <- row.names(newdata)
       Terms <- delete.response(object$terms)
-      m <- model.frame(Terms, newdata, na.action = na.omit, xlev = object$xlevels)
-      if (!is.null(cl <- attr(Terms, "dataClasses")))
+      m <- model.frame(
+        Terms,
+        newdata,
+        na.action = na.omit,
+        xlev = object$xlevels
+      )
+      if (!is.null(cl <- attr(Terms, "dataClasses"))) {
         .checkMFClasses(cl, m)
+      }
       keep <- match(row.names(m), rn)
       newdata <- model.matrix(Terms, m, contrasts = object$contrasts)
       xint <- match("(Intercept)", colnames(newdata), nomatch = 0)
-      if (xint > 0)
-        newdata <- newdata[,-xint, drop = FALSE]
+      if (xint > 0) {
+        newdata <- newdata[, -xint, drop = FALSE]
+      }
     } else {
       if (any(names(object) == "recipe") && !is.null(object$recipe)) {
         newdata <-
-          bake(object$recipe, newdata, all_predictors(), composition = "data.frame")
+          bake(
+            object$recipe,
+            newdata,
+            all_predictors(),
+            composition = "data.frame"
+          )
       }
     }
-    if (!all(object$optVariables %in% colnames(newdata)))
+    if (!all(object$optVariables %in% colnames(newdata))) {
       stop("required columns in newdata are missing", call. = FALSE)
+    }
     newdata <- newdata[, object$optVariables, drop = FALSE]
     out <- object$control$functions$pred(object$fit, newdata)
   } else {
@@ -907,9 +1102,9 @@ predict.sbf <- function(object, newdata = NULL, ...) {
 #'   [ldaSBF()] and [nbSBF()]
 #' @keywords utilities
 #' @examplesIf !caret:::is_cran_check()
-#' 
+#'
 #' data(BloodBrain)
-#' 
+#'
 #' ## Use a GAM is the filter, then fit a random forest model
 #' set.seed(1)
 #' RFwithGAM <- sbf(
@@ -923,11 +1118,11 @@ predict.sbf <- function(object, newdata = NULL, ...) {
 #'   )
 #' )
 #' RFwithGAM
-#' 
+#'
 #' ## A simple example for multivariate scoring
 #' rfSBF2 <- rfSBF
 #' rfSBF2$score <- function(x, y) apply(x, 2, rfSBF$score, y = y)
-#' 
+#'
 #' set.seed(1)
 #' RFwithGAM2 <- sbf(
 #'   bbbDescr,
@@ -941,25 +1136,26 @@ predict.sbf <- function(object, newdata = NULL, ...) {
 #'   )
 #' )
 #' RFwithGAM2
-#' 
+#'
 #' @export sbfControl
-sbfControl <- function(functions = NULL,
-                       method = "boot",
-                       saveDetails = FALSE,
-                       number = ifelse(method %in% c("cv", "repeatedcv"), 10, 25),
-                       repeats = ifelse(method %in% c("cv", "repeatedcv"), 1, number),
-                       verbose = FALSE,
-                       returnResamp = "final",
-                       p = 0.75,
-                       index = NULL,
-                       indexOut = NULL,
-                       timingSamps = 0,
-                       seeds = NA,
-                       allowParallel = TRUE,
-                       multivariate = FALSE)
-{
+sbfControl <- function(
+  functions = NULL,
+  method = "boot",
+  saveDetails = FALSE,
+  number = ifelse(method %in% c("cv", "repeatedcv"), 10, 25),
+  repeats = ifelse(method %in% c("cv", "repeatedcv"), 1, number),
+  verbose = FALSE,
+  returnResamp = "final",
+  p = 0.75,
+  index = NULL,
+  indexOut = NULL,
+  timingSamps = 0,
+  seeds = NA,
+  allowParallel = TRUE,
+  multivariate = FALSE
+) {
   list(
-    functions = if(is.null(functions)) caretSBF else functions,
+    functions = if (is.null(functions)) caretSBF else functions,
     method = method,
     saveDetails = saveDetails,
     number = number,
@@ -972,7 +1168,8 @@ sbfControl <- function(functions = NULL,
     timingSamps = timingSamps,
     seeds = seeds,
     allowParallel = allowParallel,
-    multivariate = multivariate)
+    multivariate = multivariate
+  )
 }
 
 ######################################################################
@@ -1008,240 +1205,280 @@ sbfControl <- function(functions = NULL,
 #' @seealso [sbfControl()], [sbf()], [gam::summary.Gam()]
 #' @keywords models
 #' @export caretSBF
-caretSBF <- list(summary = defaultSummary,
-                 fit = function(x, y, ...)
-                 {
-                   if(ncol(x) > 0)
-                   {
-                     train(x, y, ...)
-                   } else nullModel(y = y)
-                 },
-                 pred = function(object, x)
-                 {
-                   if(!inherits(object, "nullModel"))
-                   {
-                     tmp <- predict(object, x)
-                     if(object$modelType == "Classification" &&
-                          !is.null(object$modelInfo$prob))
-                     {
-                       out <- cbind(data.frame(pred = tmp),
-                                    as.data.frame(predict(object, x, type = "prob"), stringsAsFactors = TRUE))
-                     } else out <- tmp
-                   } else {
-                     tmp <- predict(object, x)
-                     if(!is.null(object$levels))
-                     {
-                       out <- cbind(data.frame(pred = tmp),
-                                    as.data.frame(predict(object, x, type = "prob"), stringsAsFactors = TRUE))
-                     } else out <- tmp
-                   }
-                   out
-                 },
-                 score = function(x, y)
-                 {
-                   ## should return a named logical vector
-                   if(is.factor(y)) anovaScores(x, y) else gamScores(x, y)
-                 },
-                 filter = function(score, x, y) score <= 0.05
+caretSBF <- list(
+  summary = defaultSummary,
+  fit = function(x, y, ...) {
+    if (ncol(x) > 0) {
+      train(x, y, ...)
+    } else {
+      nullModel(y = y)
+    }
+  },
+  pred = function(object, x) {
+    if (!inherits(object, "nullModel")) {
+      tmp <- predict(object, x)
+      if (
+        object$modelType == "Classification" &&
+          !is.null(object$modelInfo$prob)
+      ) {
+        out <- cbind(
+          data.frame(pred = tmp),
+          as.data.frame(
+            predict(object, x, type = "prob"),
+            stringsAsFactors = TRUE
+          )
+        )
+      } else {
+        out <- tmp
+      }
+    } else {
+      tmp <- predict(object, x)
+      if (!is.null(object$levels)) {
+        out <- cbind(
+          data.frame(pred = tmp),
+          as.data.frame(
+            predict(object, x, type = "prob"),
+            stringsAsFactors = TRUE
+          )
+        )
+      } else {
+        out <- tmp
+      }
+    }
+    out
+  },
+  score = function(x, y) {
+    ## should return a named logical vector
+    if (is.factor(y)) anovaScores(x, y) else gamScores(x, y)
+  },
+  filter = function(score, x, y) score <= 0.05
 )
 
 #' @export
-rfSBF <- list(summary = defaultSummary,
-              fit = function(x, y, ...)
-              {
-                if(ncol(x) > 0)
-                {
-                  loadNamespace("randomForest")
-                  randomForest::randomForest(x, y, ...)
-                } else nullModel(y = y)
-              },
-              pred = function(object, x)
-              {
-                if (inherits(object, "nullModel"))
-                {
-                  tmp <- predict(object, x)
-                  if(!is.null(object$levels))
-                  {
-                    out <- cbind(data.frame(pred = tmp),
-                                 as.data.frame(predict(object, x, type = "prob"), stringsAsFactors = TRUE))
-                  } else out <- tmp
-                } else {
-                  tmp <- predict(object, x)
-                  if(is.factor(object$y))
-                  {
-                    out <- cbind(data.frame(pred = tmp),
-                                 as.data.frame(predict(object, x, type = "prob"), stringsAsFactors = TRUE))
-                  } else out <- tmp
-                }
+rfSBF <- list(
+  summary = defaultSummary,
+  fit = function(x, y, ...) {
+    if (ncol(x) > 0) {
+      loadNamespace("randomForest")
+      randomForest::randomForest(x, y, ...)
+    } else {
+      nullModel(y = y)
+    }
+  },
+  pred = function(object, x) {
+    if (inherits(object, "nullModel")) {
+      tmp <- predict(object, x)
+      if (!is.null(object$levels)) {
+        out <- cbind(
+          data.frame(pred = tmp),
+          as.data.frame(
+            predict(object, x, type = "prob"),
+            stringsAsFactors = TRUE
+          )
+        )
+      } else {
+        out <- tmp
+      }
+    } else {
+      tmp <- predict(object, x)
+      if (is.factor(object$y)) {
+        out <- cbind(
+          data.frame(pred = tmp),
+          as.data.frame(
+            predict(object, x, type = "prob"),
+            stringsAsFactors = TRUE
+          )
+        )
+      } else {
+        out <- tmp
+      }
+    }
 
-                out
-              },
-              score = function(x, y)
-              {
-                ## should return a named logical vector
-                if(is.factor(y)) anovaScores(x, y) else gamScores(x, y)
-              },
-              filter = function(score, x, y) score <= 0.05
+    out
+  },
+  score = function(x, y) {
+    ## should return a named logical vector
+    if (is.factor(y)) anovaScores(x, y) else gamScores(x, y)
+  },
+  filter = function(score, x, y) score <= 0.05
 )
 
 #' @export
-lmSBF <- list(summary = defaultSummary,
-              fit = function(x, y, ...)
-              {
-                if(ncol(x) > 0)
-                {
-                  tmp <- as.data.frame(x, stringsAsFactors = TRUE)
-                  tmp$y <- y
-                  lm(y~., data = tmp)
-                } else nullModel(y = y)
-              },
-              pred = function(object, x)
-              {
-                predict(object, x)
-              },
-              score = function(x, y)
-              {
-                anovaScores(y, x)
-              },
-              filter = function(score, x, y) score <= 0.05
+lmSBF <- list(
+  summary = defaultSummary,
+  fit = function(x, y, ...) {
+    if (ncol(x) > 0) {
+      tmp <- as.data.frame(x, stringsAsFactors = TRUE)
+      tmp$y <- y
+      lm(y ~ ., data = tmp)
+    } else {
+      nullModel(y = y)
+    }
+  },
+  pred = function(object, x) {
+    predict(object, x)
+  },
+  score = function(x, y) {
+    anovaScores(y, x)
+  },
+  filter = function(score, x, y) score <= 0.05
 )
 
 #' @export
-ldaSBF <- list(summary = defaultSummary,
-               fit = function(x, y, ...)
-               {
-                 if(ncol(x) > 0)
-                 {
-                   loadNamespace("MASS")
-                   MASS::lda(x, y, ...)
-                 } else nullModel(y = y)
-               },
-               pred = function(object, x)
-               {
-                 if (inherits(object, "nullModel"))
-                 {
-                   tmp <- predict(object, x)
-                   out <- cbind(data.frame(pred = tmp),
-                                as.data.frame(
-                                  predict(object,
-                                          x,
-                                          type = "prob")))
-                 } else {
-                   tmp <- predict(object, x)
-                   out <- cbind(data.frame(pred = tmp$class),
-                                as.data.frame(tmp$posterior, stringsAsFactors = FALSE))
-                 }
-                 out
-               },
-               score = function(x, y)
-               {
-                 ## should return a named logical vector
-                 anovaScores(x, y)
-               },
-               filter = function(score, x, y) score <= 0.05
+ldaSBF <- list(
+  summary = defaultSummary,
+  fit = function(x, y, ...) {
+    if (ncol(x) > 0) {
+      loadNamespace("MASS")
+      MASS::lda(x, y, ...)
+    } else {
+      nullModel(y = y)
+    }
+  },
+  pred = function(object, x) {
+    if (inherits(object, "nullModel")) {
+      tmp <- predict(object, x)
+      out <- cbind(
+        data.frame(pred = tmp),
+        as.data.frame(
+          predict(object, x, type = "prob")
+        )
+      )
+    } else {
+      tmp <- predict(object, x)
+      out <- cbind(
+        data.frame(pred = tmp$class),
+        as.data.frame(tmp$posterior, stringsAsFactors = FALSE)
+      )
+    }
+    out
+  },
+  score = function(x, y) {
+    ## should return a named logical vector
+    anovaScores(x, y)
+  },
+  filter = function(score, x, y) score <= 0.05
 )
 
 #' @export
-nbSBF <- list(summary = defaultSummary,
-              fit = function(x, y, ...)
-              {
-                if(ncol(x) > 0)
-                {
-                  loadNamespace("klaR")
-                  klaR::NaiveBayes(x, y, usekernel = TRUE, fL = 2, ...)
+nbSBF <- list(
+  summary = defaultSummary,
+  fit = function(x, y, ...) {
+    if (ncol(x) > 0) {
+      loadNamespace("klaR")
+      klaR::NaiveBayes(x, y, usekernel = TRUE, fL = 2, ...)
+    } else {
+      nullModel(y = y)
+    }
+  },
+  pred = function(object, x) {
+    if (inherits(object, "nullModel")) {
+      tmp <- predict(object, x)
+      out <- cbind(
+        data.frame(pred = tmp),
+        as.data.frame(
+          predict(object, x, type = "prob")
+        )
+      )
+    } else {
+      tmp <- predict(object, x)
+      out <- cbind(
+        data.frame(pred = tmp$class),
+        as.data.frame(tmp$posterior, stringsAsFactors = FALSE)
+      )
+    }
+    out
+  },
 
-                } else nullModel(y = y)
-              },
-              pred = function(object, x)
-              {
-                if (inherits(object, "nullModel"))
-                {
-                  tmp <- predict(object, x)
-                  out <- cbind(data.frame(pred = tmp),
-                               as.data.frame(
-                                 predict(object,
-                                         x,
-                                         type = "prob")))
-                } else {
-                  tmp <- predict(object, x)
-                  out <- cbind(data.frame(pred = tmp$class),
-                               as.data.frame(tmp$posterior, stringsAsFactors = FALSE))
-                }
-                out
-              },
-
-              pred = function(object, x)
-              {
-                predict(object, x)$class
-              },
-              score = function(x, y)
-              {
-                ## should return a named logical vector
-                anovaScores(x, y)
-              },
-              filter = function(score, x, y) score <= 0.05
+  pred = function(object, x) {
+    predict(object, x)$class
+  },
+  score = function(x, y) {
+    ## should return a named logical vector
+    anovaScores(x, y)
+  },
+  filter = function(score, x, y) score <= 0.05
 )
 
 #' @export
-treebagSBF <- list(summary = defaultSummary,
-                   fit = function(x, y, ...)
-                   {
-                     if(ncol(x) > 0)
-                     {
-                       loadNamespace("ipred")
-                       ipred::ipredbagg(y, x, ...)
-                     } else nullModel(y = y)
-                   },
+treebagSBF <- list(
+  summary = defaultSummary,
+  fit = function(x, y, ...) {
+    if (ncol(x) > 0) {
+      loadNamespace("ipred")
+      ipred::ipredbagg(y, x, ...)
+    } else {
+      nullModel(y = y)
+    }
+  },
 
-                   pred = function(object, x)
-                   {
-                     if (inherits(object, "nullModel"))
-                     {
-                       tmp <- predict(object, x)
-                       if(!is.null(object$levels))
-                       {
-                         out <- cbind(data.frame(pred = tmp),
-                                      as.data.frame(predict(object, x, type = "prob"), stringsAsFactors = TRUE))
-                       } else out <- tmp
-                     } else {
-                       tmp <- predict(object, x)
-                       if(is.factor(object$y))
-                       {
-                         out <- cbind(data.frame(pred = tmp),
-                                      as.data.frame(predict(object, x, type = "prob"), stringsAsFactors = TRUE))
-                       } else out <- tmp
-                     }
-                     out
-                   },
-                   score = function(x, y)
-                   {
-                     ## should return a named logical vector
-                     anovaScores(x, y)
-                   },
-                   filter = function(score, x, y) score <= 0.05
+  pred = function(object, x) {
+    if (inherits(object, "nullModel")) {
+      tmp <- predict(object, x)
+      if (!is.null(object$levels)) {
+        out <- cbind(
+          data.frame(pred = tmp),
+          as.data.frame(
+            predict(object, x, type = "prob"),
+            stringsAsFactors = TRUE
+          )
+        )
+      } else {
+        out <- tmp
+      }
+    } else {
+      tmp <- predict(object, x)
+      if (is.factor(object$y)) {
+        out <- cbind(
+          data.frame(pred = tmp),
+          as.data.frame(
+            predict(object, x, type = "prob"),
+            stringsAsFactors = TRUE
+          )
+        )
+      } else {
+        out <- tmp
+      }
+    }
+    out
+  },
+  score = function(x, y) {
+    ## should return a named logical vector
+    anovaScores(x, y)
+  },
+  filter = function(score, x, y) score <= 0.05
 )
 
 
 #' @rdname caretSBF
 #' @export
 anovaScores <- function(x, y) {
-  if(is.factor(x)) stop("The predictors should be numeric")
+  if (is.factor(x)) {
+    stop("The predictors should be numeric")
+  }
   pv <- try(anova(lm(x ~ y), test = "F")[1, "Pr(>F)"], silent = TRUE)
-  if(any(class(pv) == "try-error") || is.na(pv) || is.nan(pv)) pv <- 1
+  if (any(class(pv) == "try-error") || is.na(pv) || is.nan(pv)) {
+    pv <- 1
+  }
   pv
 }
 
 #' @rdname caretSBF
 #' @export
 gamScores <- function(x, y) {
-  if(is.factor(x)) stop("The predictors should be numeric")
+  if (is.factor(x)) {
+    stop("The predictors should be numeric")
+  }
   requireNamespaceQuietStop("gam")
   pv <- try(anova(gam::gam(y ~ s(x)), test = "F")[2, "Pr(F)"], silent = TRUE)
-  if(any(class(pv) == "try-error")) pv <- try(anova(lm(x ~ y), test = "F")[1, "Pr(>F)"], silent = TRUE)
-  if(any(class(pv) == "try-error") || is.na(pv) || is.nan(pv)) pv <- 1
+  if (any(class(pv) == "try-error")) {
+    pv <- try(anova(lm(x ~ y), test = "F")[1, "Pr(>F)"], silent = TRUE)
+  }
+  if (any(class(pv) == "try-error") || is.na(pv) || is.nan(pv)) {
+    pv <- 1
+  }
   pv
 }
-
 
 
 ######################################################################
@@ -1249,16 +1486,16 @@ gamScores <- function(x, y) {
 ## lattice functions
 
 #' @export
-densityplot.sbf <- function(x,
-                            data = NULL,
-                            metric = x$metric[1],
-                            ...)
-{
-  if (!is.null(match.call()$data))
+densityplot.sbf <- function(x, data = NULL, metric = x$metric[1], ...) {
+  if (!is.null(match.call()$data)) {
     warning("explicit 'data' specification ignored")
+  }
 
-  if(x$control$method %in%  c("oob", "LOOCV"))
-    stop("Resampling plots cannot be done with leave-out-out CV or out-of-bag resampling")
+  if (x$control$method %in% c("oob", "LOOCV")) {
+    stop(
+      "Resampling plots cannot be done with leave-out-out CV or out-of-bag resampling"
+    )
+  }
 
   data <- as.data.frame(x$resample, stringsAsFactors = TRUE)
   form <- as.formula(paste("~", metric))
@@ -1266,24 +1503,22 @@ densityplot.sbf <- function(x,
 }
 
 #' @export
-histogram.sbf <- function(x,
-                          data = NULL,
-                          metric = x$metric[1],
-                          ...)
-{
-  if (!is.null(match.call()$data))
+histogram.sbf <- function(x, data = NULL, metric = x$metric[1], ...) {
+  if (!is.null(match.call()$data)) {
     warning("explicit 'data' specification ignored")
+  }
 
-  if(x$control$method %in%  c("oob", "LOOCV"))
-    stop("Resampling plots cannot be done with leave-out-out CV or out-of-bag resampling")
+  if (x$control$method %in% c("oob", "LOOCV")) {
+    stop(
+      "Resampling plots cannot be done with leave-out-out CV or out-of-bag resampling"
+    )
+  }
 
   data <- as.data.frame(x$resample, stringsAsFactors = TRUE)
 
   form <- as.formula(paste("~", metric))
   histogram(form, data = data, ...)
 }
-
-
 
 
 ######################################################################
@@ -1293,22 +1528,20 @@ histogram.sbf <- function(x,
 predictors.sbf <- function(x, ...) x$optVariables
 
 #' @export
-varImp.sbf <- function(object, onlyFinal = TRUE, ...)
-{
-
-  vars <- sort(table(unlist(object$variables)), decreasing = TRUE)/length(object$control$index)
-
+varImp.sbf <- function(object, onlyFinal = TRUE, ...) {
+  vars <- sort(table(unlist(object$variables)), decreasing = TRUE) /
+    length(object$control$index)
 
   out <- as.data.frame(vars, stringsAsFactors = FALSE)
   names(out) <- "Overall"
-  if(onlyFinal) out <- subset(out, rownames(out) %in% object$optVariables)
-  out[order(-out$Overall),,drop = FALSE]
-
+  if (onlyFinal) {
+    out <- subset(out, rownames(out) %in% object$optVariables)
+  }
+  out[order(-out$Overall), , drop = FALSE]
 }
 
 ######################################################################
 ## what to do when no predictors are selected?
-
 
 #' Fit a simple, non-informative model
 #'
@@ -1346,7 +1579,7 @@ varImp.sbf <- function(object, onlyFinal = TRUE, ...)
 #' the class of `y`. All predictions are always the same.
 #' @keywords models
 #' @examples
-#' 
+#'
 #' outcome <- factor(sample(
 #'   letters[1:2],
 #'   size = 100,
@@ -1356,62 +1589,61 @@ varImp.sbf <- function(object, onlyFinal = TRUE, ...)
 #' useless <- nullModel(y = outcome)
 #' useless
 #' predict(useless, matrix(NA, nrow = 10))
-#' 
+#'
 #' @export nullModel
-nullModel <- function (x, ...) UseMethod("nullModel")
+nullModel <- function(x, ...) UseMethod("nullModel")
 
 #' @rdname nullModel
 #' @export
-nullModel.default <- function(x = NULL, y, ...)
-{
-
-  if(is.factor(y))
-  {
+nullModel.default <- function(x = NULL, y, ...) {
+  if (is.factor(y)) {
     lvls <- levels(y)
     tab <- table(y)
     value <- names(tab)[which.max(tab)]
-    pct <- tab/sum(tab)
+    pct <- tab / sum(tab)
   } else {
     lvls <- NULL
     pct <- NULL
     value <- mean(y, na.rm = TRUE)
   }
   structure(
-    list(call = match.call(),
-         value = value,
-         levels = lvls,
-         pct = pct,
-         n = length(y)),
-    class = "nullModel")
+    list(
+      call = match.call(),
+      value = value,
+      levels = lvls,
+      pct = pct,
+      n = length(y)
+    ),
+    class = "nullModel"
+  )
 }
 
 #' @export
-print.nullModel <- function(x, digits = max(3, getOption("digits") - 3), ...)
-{
-  cat("Null",
-      ifelse(is.null(x$levels), "Classification", "Regression"),
-      "Model\n")
+print.nullModel <- function(x, digits = max(3, getOption("digits") - 3), ...) {
+  cat(
+    "Null",
+    ifelse(is.null(x$levels), "Classification", "Regression"),
+    "Model\n"
+  )
   printCall(x$call)
 
-  cat("Predicted Value:",
-      ifelse(is.null(x$levels), format(x$value, digitis = digits), x$value),
-      "\n")
+  cat(
+    "Predicted Value:",
+    ifelse(is.null(x$levels), format(x$value, digitis = digits), x$value),
+    "\n"
+  )
 }
 
 #' @rdname nullModel
 #' @export
-predict.nullModel <- function (object, newdata = NULL, type  = NULL, ...)
-{
-  if(is.null(type))
-  {
-    type <- if(is.null(object$levels)) "raw" else "class"
+predict.nullModel <- function(object, newdata = NULL, type = NULL, ...) {
+  if (is.null(type)) {
+    type <- if (is.null(object$levels)) "raw" else "class"
   }
 
-  n <- if(is.null(newdata)) object$n else nrow(newdata)
-  if(!is.null(object$levels))
-  {
-    if(type == "prob")
-    {
+  n <- if (is.null(newdata)) object$n else nrow(newdata)
+  if (!is.null(object$levels)) {
+    if (type == "prob") {
       out <- matrix(rep(object$pct, n), nrow = n, byrow = TRUE)
       colnames(out) <- object$levels
       out <- as.data.frame(out, stringsAsFactors = TRUE)
@@ -1419,7 +1651,9 @@ predict.nullModel <- function (object, newdata = NULL, type  = NULL, ...)
       out <- factor(rep(object$value, n), levels = object$levels)
     }
   } else {
-    if(type %in% c("prob", "class")) stop("ony raw predicitons are applicable to regression models")
+    if (type %in% c("prob", "class")) {
+      stop("ony raw predicitons are applicable to regression models")
+    }
     out <- rep(object$value, n)
   }
   out

--- a/R/selectByFilter.R
+++ b/R/selectByFilter.R
@@ -743,10 +743,10 @@ sbf_rec <- function(rec, data, ctrl, lev, ...) {
     }
 
   resamples <- rbind.fill(result[names(result) == "resamples"])
-  pred <- if (ctrl$saveDetails) {
-    rbind.fill(result[names(result) == "pred"])
+  if (ctrl$saveDetails) {
+    pred <- rbind.fill(result[names(result) == "pred"])
   } else {
-    NULL
+    pred <- NULL
   }
   performance <- MeanSD(resamples[,
     !grepl("Resample", colnames(resamples)),
@@ -1249,7 +1249,11 @@ caretSBF <- list(
   },
   score = function(x, y) {
     ## should return a named logical vector
-    if (is.factor(y)) anovaScores(x, y) else gamScores(x, y)
+    if (is.factor(y)) {
+      anovaScores(x, y)
+    } else {
+      gamScores(x, y)
+    }
   },
   filter = function(score, x, y) score <= 0.05
 )
@@ -1298,7 +1302,11 @@ rfSBF <- list(
   },
   score = function(x, y) {
     ## should return a named logical vector
-    if (is.factor(y)) anovaScores(x, y) else gamScores(x, y)
+    if (is.factor(y)) {
+      anovaScores(x, y)
+    } else {
+      gamScores(x, y)
+    }
   },
   filter = function(score, x, y) score <= 0.05
 )
@@ -1638,10 +1646,18 @@ print.nullModel <- function(x, digits = max(3, getOption("digits") - 3), ...) {
 #' @export
 predict.nullModel <- function(object, newdata = NULL, type = NULL, ...) {
   if (is.null(type)) {
-    type <- if (is.null(object$levels)) "raw" else "class"
+    if (is.null(object$levels)) {
+      type <- "raw"
+    } else {
+      type <- "class"
+    }
   }
 
-  n <- if (is.null(newdata)) object$n else nrow(newdata)
+  if (is.null(newdata)) {
+    n <- object$n
+  } else {
+    n <- nrow(newdata)
+  }
   if (!is.null(object$levels)) {
     if (type == "prob") {
       out <- matrix(rep(object$pct, n), nrow = n, byrow = TRUE)

--- a/R/selection.R
+++ b/R/selection.R
@@ -1,4 +1,3 @@
-
 ## In these functions, x is the data fram of performance values and tuning parameters.
 #' Selecting tuning Parameters
 #'
@@ -81,20 +80,20 @@
 #'   Regression Trees*. Wadsworth.
 #' @keywords manip
 #' @examplesIf !caret:::is_cran_check()
-#' 
+#'
 #' # simulate a PLS regression model
 #' test <- data.frame(ncomp = 1:5, RMSE = c(3, 1.1, 1.02, 1, 2), RMSESD = .4)
-#' 
+#'
 #' best(test, "RMSE", maximize = FALSE)
 #' oneSE(test, "RMSE", maximize = FALSE, num = 10)
 #' tolerance(test, "RMSE", tol = 3, maximize = FALSE)
-#' 
+#'
 #' ### usage example
-#' 
+#'
 #' data(BloodBrain)
-#' 
+#'
 #' marsGrid <- data.frame(degree = 1, nprune = (1:10) * 3)
-#' 
+#'
 #' set.seed(1)
 #' marsFit <- train(
 #'   bbbDescr,
@@ -107,49 +106,45 @@
 #'     selectionFunction = "tolerance"
 #'   )
 #' )
-#' 
+#'
 #' # around 18 terms should yield the smallest CV RMSE
-#' 
+#'
 #' @export oneSE
-oneSE <- function(x, metric, num, maximize)
-  {
-    index <- seq_len(nrow(x))
-    
-    if(!maximize)
-      {
-        bestIndex <- which.min(x[,metric])  
-        perf <- x[bestIndex,metric] + (x[bestIndex,paste(metric, "SD", sep = "")])/sqrt(num)
-        candidates <- index[x[, metric] <= perf]
-        bestIter <- min(candidates)
-      } else {
-        bestIndex <- which.max(x[,metric])  
-        perf <- x[bestIndex,metric] - (x[bestIndex,paste(metric, "SD", sep = "")])/sqrt(num)
+oneSE <- function(x, metric, num, maximize) {
+  index <- seq_len(nrow(x))
 
-        candidates <- index[x[, metric] >= perf]
-        bestIter <- min(candidates)
-      }
-    bestIter
+  if (!maximize) {
+    bestIndex <- which.min(x[, metric])
+    perf <- x[bestIndex, metric] +
+      (x[bestIndex, paste(metric, "SD", sep = "")]) / sqrt(num)
+    candidates <- index[x[, metric] <= perf]
+    bestIter <- min(candidates)
+  } else {
+    bestIndex <- which.max(x[, metric])
+    perf <- x[bestIndex, metric] -
+      (x[bestIndex, paste(metric, "SD", sep = "")]) / sqrt(num)
+
+    candidates <- index[x[, metric] >= perf]
+    bestIter <- min(candidates)
   }
+  bestIter
+}
 
 #' @rdname oneSE
 #' @export
-tolerance <- function(x, metric, tol = 1.5, maximize)
-  {
-       
-    index <- seq_len(nrow(x))
-    
-    if(!maximize)
-      {
-        best <- min(x[,metric])  
-        perf <- (x[,metric] - best)/best * 100
-        candidates <- index[perf < tol]
-        bestIter <- min(candidates)
-      } else {
-        best <- max(x[,metric])  
-        perf <- (x[,metric] - best)/best * -100
-        candidates <- index[perf < tol]
-        bestIter <- min(candidates)
-      }
-    bestIter
-  }
+tolerance <- function(x, metric, tol = 1.5, maximize) {
+  index <- seq_len(nrow(x))
 
+  if (!maximize) {
+    best <- min(x[, metric])
+    perf <- (x[, metric] - best) / best * 100
+    candidates <- index[perf < tol]
+    bestIter <- min(candidates)
+  } else {
+    best <- max(x[, metric])
+    perf <- (x[, metric] - best) / best * -100
+    candidates <- index[perf < tol]
+    bestIter <- min(candidates)
+  }
+  bestIter
+}

--- a/R/sensitivity.R
+++ b/R/sensitivity.R
@@ -58,10 +58,10 @@
 #' @family performance
 #' @keywords manip
 #' @examplesIf !caret:::is_cran_check()
-#' 
+#'
 #' ###################
 #' ## 2 class example
-#' 
+#'
 #' lvs <- c("normal", "abnormal")
 #' truth <- factor(rep(lvs, times = c(86, 258)), levels = rev(lvs))
 #' pred <- factor(
@@ -71,26 +71,26 @@
 #'   ),
 #'   levels = rev(lvs)
 #' )
-#' 
+#'
 #' xtab <- table(pred, truth)
-#' 
+#'
 #' sensitivity(pred, truth)
 #' sensitivity(xtab)
 #' posPredValue(pred, truth)
 #' posPredValue(pred, truth, prevalence = 0.25)
-#' 
+#'
 #' specificity(pred, truth)
 #' negPredValue(pred, truth)
 #' negPredValue(xtab)
 #' negPredValue(pred, truth, prevalence = 0.25)
-#' 
+#'
 #' prev <- seq(0.001, .99, length = 20)
 #' npvVals <- ppvVals <- prev * NA
 #' for (i in seq(along.with = prev)) {
 #'   ppvVals[i] <- posPredValue(pred, truth, prevalence = prev[i])
 #'   npvVals[i] <- negPredValue(pred, truth, prevalence = prev[i])
 #' }
-#' 
+#'
 #' plot(
 #'   prev,
 #'   ppvVals,
@@ -109,69 +109,76 @@
 #'   col = c("black", "red", "black", "red"),
 #'   lty = c(1, 1, 2, 2)
 #' )
-#' 
+#'
 #' ###################
 #' ## 3 class example
-#' 
+#'
 #' library(MASS)
-#' 
+#'
 #' fit <- lda(Species ~ ., data = iris)
 #' model <- predict(fit)$class
-#' 
+#'
 #' irisTabs <- table(model, iris$Species)
-#' 
+#'
 #' ## When passing factors, an error occurs with more
 #' ## than two levels
 #' try(sensitivity(model, iris$Species))
-#' 
+#'
 #' ## When passing a table, more than two levels can
 #' ## be used
 #' sensitivity(irisTabs, "versicolor")
 #' specificity(irisTabs, c("setosa", "virginica"))
-#' 
+#'
 #' @export sensitivity
 sensitivity <-
-  function(data, ...){
+  function(data, ...) {
     UseMethod("sensitivity")
   }
 
 #' @rdname sensitivity
 #' @export
 "sensitivity.default" <-
-  function(data, reference, positive = levels(reference)[1], na.rm = TRUE, ...)
-{
-  if(!is.factor(reference) || !is.factor(data))
-    stop("inputs must be factors")
-
-  ## todo: relax the =2 constraint and let ngative length be > 2
-  if(length(unique(c(levels(reference), levels(data)))) != 2)
-    stop("input data must have the same two levels")
-  if(na.rm)
-    {
-      cc <- complete.cases(data) & complete.cases(reference)
-      if(any(!cc))
-        {
-          data <- data[cc]
-          reference <- reference[cc]
-        }
+  function(
+    data,
+    reference,
+    positive = levels(reference)[1],
+    na.rm = TRUE,
+    ...
+  ) {
+    if (!is.factor(reference) || !is.factor(data)) {
+      stop("inputs must be factors")
     }
-  numer <- sum(data %in% positive & reference %in% positive)
-  denom <- sum(reference %in% positive)
-  sens <- ifelse(denom > 0, numer / denom, NA)
-  sens
-}
+
+    ## todo: relax the =2 constraint and let ngative length be > 2
+    if (length(unique(c(levels(reference), levels(data)))) != 2) {
+      stop("input data must have the same two levels")
+    }
+    if (na.rm) {
+      cc <- complete.cases(data) & complete.cases(reference)
+      if (any(!cc)) {
+        data <- data[cc]
+        reference <- reference[cc]
+      }
+    }
+    numer <- sum(data %in% positive & reference %in% positive)
+    denom <- sum(reference %in% positive)
+    sens <- ifelse(denom > 0, numer / denom, NA)
+    sens
+  }
 
 #' @rdname sensitivity
 #' @export
 "sensitivity.table" <-
-  function(data, positive = rownames(data)[1], ...)
-{
-  ## "truth" in columns, predictions in rows
-  if(!all.equal(nrow(data), ncol(data))) stop("the table must have nrow = ncol")
-  if(!all.equal(rownames(data), colnames(data))) stop("the table must the same groups in the same order")
+  function(data, positive = rownames(data)[1], ...) {
+    ## "truth" in columns, predictions in rows
+    if (!all.equal(nrow(data), ncol(data))) {
+      stop("the table must have nrow = ncol")
+    }
+    if (!all.equal(rownames(data), colnames(data))) {
+      stop("the table must the same groups in the same order")
+    }
 
-  if(nrow(data) > 2)
-    {
+    if (nrow(data) > 2) {
       tmp <- data
       data <- matrix(NA, 2, 2)
 
@@ -188,17 +195,16 @@ sensitivity <-
       rm(tmp)
     }
 
-  numer <- sum(data[positive, positive])
-  denom <- sum(data[, positive])
-  sens <- ifelse(denom > 0, numer / denom, NA)
-  sens
-}
+    numer <- sum(data[positive, positive])
+    denom <- sum(data[, positive])
+    sens <- ifelse(denom > 0, numer / denom, NA)
+    sens
+  }
 
 #' @rdname sensitivity
 #' @export
 "sensitivity.matrix" <-
-  function(data, positive = rownames(data)[1], ...)
-{
-  data <- as.table(data)
-  sensitivity.table(data)
-}
+  function(data, positive = rownames(data)[1], ...) {
+    data <- as.table(data)
+    sensitivity.table(data)
+  }

--- a/R/sortImp.R
+++ b/R/sortImp.R
@@ -1,37 +1,36 @@
 #' @rdname caret-internal
 #' @export
-sortImp <- function(object, top)
-{
+sortImp <- function(object, top) {
+  if (object$calledFrom == "varImp") {
+    best <- switch(
+      object$model,
+      pam = "maxabs",
+      "max"
+    )
+  } else {
+    best <- "max"
+  }
 
-   if(object$calledFrom == "varImp")
-   {
-      best <- switch(
-         object$model,
-         pam = "maxabs",
-         "max")   
-   } else {
-      best <- "max"
-   }
-     
-   featureRank <- switch(best,
-      max = rank(-apply(object$importance, 1, max, na.rm = TRUE)),
-      min = rank(apply(object$importance, 1, min, na.rm = TRUE)),         
-      maxabs = rank(-apply(abs(object$importance), 1, max, na.rm = TRUE)))     
+  featureRank <- switch(
+    best,
+    max = rank(-apply(object$importance, 1, max, na.rm = TRUE)),
+    min = rank(apply(object$importance, 1, min, na.rm = TRUE)),
+    maxabs = rank(-apply(abs(object$importance), 1, max, na.rm = TRUE))
+  )
 
-   tiedRanks <- as.numeric(names(table(featureRank)[table(featureRank) > 1]))
+  tiedRanks <- as.numeric(names(table(featureRank)[table(featureRank) > 1]))
 
-   if(length(tiedRanks) > 0)
-   {
-      for(i in seq(along.with = tiedRanks))
-      {
-         tmp <- featureRank[featureRank == tiedRanks[i]] 
-         featureRank[featureRank == tiedRanks[i]] <- tmp + runif(length(tmp), min = 0.001, max = 0.999)
-      }
-   }
+  if (length(tiedRanks) > 0) {
+    for (i in seq(along.with = tiedRanks)) {
+      tmp <- featureRank[featureRank == tiedRanks[i]]
+      featureRank[featureRank == tiedRanks[i]] <- tmp +
+        runif(length(tmp), min = 0.001, max = 0.999)
+    }
+  }
 
-   featureOrder <- order(featureRank)   
+  featureOrder <- order(featureRank)
 
-   out <- object$importance[featureOrder,, drop = FALSE]
-   out <- out[1:top,, drop = FALSE]
-   out
+  out <- object$importance[featureOrder, , drop = FALSE]
+  out <- out[1:top, , drop = FALSE]
+  out
 }

--- a/R/spatialSign.R
+++ b/R/spatialSign.R
@@ -47,12 +47,11 @@
     )
   }
   denom <- sum(x^2, na.rm = na.rm)
-  out <-
-    if (sqrt(denom) > .Machine$double.eps) {
-      x / sqrt(denom)
-    } else {
-      x * 0
-    }
+  if (sqrt(denom) > .Machine$double.eps) {
+    out <- x / sqrt(denom)
+  } else {
+    out <- x * 0
+  }
   out
 }
 

--- a/R/spatialSign.R
+++ b/R/spatialSign.R
@@ -18,36 +18,41 @@
 #' @family preprocessing
 #' @keywords manip
 #' @examples
-#' 
+#'
 #' spatialSign(rnorm(5))
-#' 
+#'
 #' spatialSign(matrix(rnorm(12), ncol = 3))
-#' 
+#'
 #' # should fail since the fifth column is a factor
 #' try(spatialSign(iris), silent = TRUE)
-#' 
+#'
 #' spatialSign(iris[, -5])
-#' 
+#'
 #' trellis.par.set(caretTheme())
 #' featurePlot(iris[, -5], iris[, 5], "pairs")
 #' featurePlot(spatialSign(scale(iris[, -5])), iris[, 5], "pairs")
-#' 
+#'
 #' @export spatialSign
-"spatialSign" <- function(x, ...) 
+"spatialSign" <- function(x, ...) {
   UseMethod("spatialSign")
+}
 
 #' @export
 #' @rdname spatialSign
 "spatialSign.default" <- function(x, na.rm = TRUE, ...) {
-  if (is.character(x) || is.factor(x))
-    stop("spatial sign is not defined for character or factor data",
-         call. = FALSE)
-  denom <- sum(x ^ 2, na.rm = na.rm)
+  if (is.character(x) || is.factor(x)) {
+    stop(
+      "spatial sign is not defined for character or factor data",
+      call. = FALSE
+    )
+  }
+  denom <- sum(x^2, na.rm = na.rm)
   out <-
-    if (sqrt(denom) > .Machine$double.eps)
+    if (sqrt(denom) > .Machine$double.eps) {
       x / sqrt(denom)
-  else
-    x * 0
+    } else {
+      x * 0
+    }
   out
 }
 
@@ -55,14 +60,15 @@
 #' @rdname spatialSign
 "spatialSign.matrix" <- function(x, na.rm = TRUE, ...) {
   # check for character data
-  if (is.character(x))
-    stop("spatial sign is not defined for character data",
-         call. = FALSE)
+  if (is.character(x)) {
+    stop("spatial sign is not defined for character data", call. = FALSE)
+  }
   xNames <- dimnames(x)
   p <- ncol(x)
   tmp <- t(apply(x, 1, spatialSign.default, na.rm = na.rm))
-  if (p == 1 && nrow(tmp) == 1)
+  if (p == 1 && nrow(tmp) == 1) {
     tmp <- t(tmp)
+  }
   dimnames(tmp) <- xNames
   tmp
 }
@@ -70,15 +76,21 @@
 #' @export
 #' @rdname spatialSign
 "spatialSign.data.frame" <- function(x, na.rm = TRUE, ...) {
-  if (any(apply(x, 2, function(data)
-    is.character(data) | is.factor(data))))
-    stop("spatial sign is not defined for character or factor data",
-         call. = FALSE)
+  if (
+    any(apply(x, 2, function(data) {
+      is.character(data) | is.factor(data)
+    }))
+  ) {
+    stop(
+      "spatial sign is not defined for character or factor data",
+      call. = FALSE
+    )
+  }
   xNames <- dimnames(x)
   x <- as.matrix(x)
-  if (!is.numeric(x))
-    stop("a character matrix was the result of as.matrix",
-         call. = FALSE)
+  if (!is.numeric(x)) {
+    stop("a character matrix was the result of as.matrix", call. = FALSE)
+  }
   tmp <- spatialSign(x, na.rm = na.rm)
   dimnames(tmp) <- xNames
   tmp

--- a/R/specificity.R
+++ b/R/specificity.R
@@ -1,47 +1,54 @@
 #' @export
 #' @rdname sensitivity
 specificity <-
-  function(data, ...){
+  function(data, ...) {
     UseMethod("specificity")
   }
 
 #' @export
 #' @rdname sensitivity
 "specificity.default" <-
-function(data, reference, negative = levels(reference)[-1], na.rm = TRUE, ...)
-{
-   if(!is.factor(reference) || !is.factor(data))
+  function(
+    data,
+    reference,
+    negative = levels(reference)[-1],
+    na.rm = TRUE,
+    ...
+  ) {
+    if (!is.factor(reference) || !is.factor(data)) {
       stop("input data must be a factor")
+    }
 
-   ## todo: relax the =2 constraint and let ngative length be > 2
-   if(length(unique(c(levels(reference), levels(data)))) != 2)
+    ## todo: relax the =2 constraint and let ngative length be > 2
+    if (length(unique(c(levels(reference), levels(data)))) != 2) {
       stop("input data must have the same two levels")
-   if(na.rm)
-     {
-       cc <- complete.cases(data) & complete.cases(reference)
-       if(any(!cc))
-         {
-           data <- data[cc]
-           reference <- reference[cc]
-         }
-     }
-   numer <- sum(data %in% negative & reference %in% negative)
-   denom <- sum(reference %in% negative)
-   spec <- ifelse(denom > 0, numer / denom, NA)
-   spec
-}
+    }
+    if (na.rm) {
+      cc <- complete.cases(data) & complete.cases(reference)
+      if (any(!cc)) {
+        data <- data[cc]
+        reference <- reference[cc]
+      }
+    }
+    numer <- sum(data %in% negative & reference %in% negative)
+    denom <- sum(reference %in% negative)
+    spec <- ifelse(denom > 0, numer / denom, NA)
+    spec
+  }
 
 #' @export
 #' @rdname sensitivity
 "specificity.table" <-
-  function(data, negative = rownames(data)[-1], ...)
-{
-  ## "truth" in columns, predictions in rows
-  if(!all.equal(nrow(data), ncol(data))) stop("the table must have nrow = ncol")
-  if(!all.equal(rownames(data), colnames(data))) stop("the table must the same groups in the same order")
+  function(data, negative = rownames(data)[-1], ...) {
+    ## "truth" in columns, predictions in rows
+    if (!all.equal(nrow(data), ncol(data))) {
+      stop("the table must have nrow = ncol")
+    }
+    if (!all.equal(rownames(data), colnames(data))) {
+      stop("the table must the same groups in the same order")
+    }
 
-  if(nrow(data) > 2)
-    {
+    if (nrow(data) > 2) {
       tmp <- data
       data <- matrix(NA, 2, 2)
 
@@ -58,16 +65,15 @@ function(data, reference, negative = levels(reference)[-1], na.rm = TRUE, ...)
       rm(tmp)
     }
 
-  numer <- sum(data[negative, negative])
-  denom <- sum(data[, negative])
-  spec <- ifelse(denom > 0, numer / denom, NA)
-  spec
-}
+    numer <- sum(data[negative, negative])
+    denom <- sum(data[, negative])
+    spec <- ifelse(denom > 0, numer / denom, NA)
+    spec
+  }
 
 #' @export
 "specificity.matrix" <-
-  function(data, negative = rownames(data)[-1], ...)
-{
-  data <- as.table(data)
-  specificity.table(data)
-}
+  function(data, negative = rownames(data)[-1], ...) {
+    data <- as.table(data)
+    specificity.table(data)
+  }

--- a/R/splsda.R
+++ b/R/splsda.R
@@ -1,65 +1,75 @@
 #' @export
-splsda <- function (x, ...)
+splsda <- function(x, ...) {
   UseMethod("splsda")
+}
 
 #' @export
-predict.splsda <- function(object, newdata = NULL, type = "class", ...)
-{
+predict.splsda <- function(object, newdata = NULL, type = "class", ...) {
   requireNamespaceQuietStop("spls")
   tmpPred <- spls::predict.spls(object, newx = newdata)
 
-  if(type == "raw") return(tmpPred)
+  if (type == "raw") {
+    return(tmpPred)
+  }
 
-  if(is.null(object$probModel))
-    {
-      ## use softmax
-      out <- switch(type,
+  if (is.null(object$probModel)) {
+    ## use softmax
+    out <- switch(
+      type,
 
-             class =
-             {
-               classIndex <- object$obsLevels[apply(tmpPred, 1, which.max)]
-               factor(classIndex, levels = object$obsLevels)
-             },
-             prob = t(apply(tmpPred, 1, function(data) exp(data)/sum(exp(data)))))
-    } else {
-      requireNamespaceQuietStop("klaR")
-      ## Bayes rule
-      tmpPred <-  as.data.frame(tmpPred[,-length(object$obsLevels)], stringsAsFactors = TRUE)
-      pred <- predict(object$probModel, tmpPred)
-      out <- switch(type, class = pred$class, prob = pred$posterior)
-
-    }
+      class = {
+        classIndex <- object$obsLevels[apply(tmpPred, 1, which.max)]
+        factor(classIndex, levels = object$obsLevels)
+      },
+      prob = t(apply(tmpPred, 1, function(data) exp(data) / sum(exp(data))))
+    )
+  } else {
+    requireNamespaceQuietStop("klaR")
+    ## Bayes rule
+    tmpPred <- as.data.frame(
+      tmpPred[, -length(object$obsLevels)],
+      stringsAsFactors = TRUE
+    )
+    pred <- predict(object$probModel, tmpPred)
+    out <- switch(type, class = pred$class, prob = pred$posterior)
+  }
   out
 }
 
 #' @export
-splsda.default <- function(x, y, probMethod = "softmax", prior = NULL, ...)
-{
+splsda.default <- function(x, y, probMethod = "softmax", prior = NULL, ...) {
   requireNamespaceQuietStop("spls")
   funcCall <- match.call(expand.dots = TRUE)
 
-  if(probMethod == "softmax")
-    {
-      if(!is.null(prior)) warning("Priors are ignored unless probMethod = \"Bayes\"")
+  if (probMethod == "softmax") {
+    if (!is.null(prior)) {
+      warning("Priors are ignored unless probMethod = \"Bayes\"")
     }
+  }
 
-  if(is.factor(y))
-    {
-      obsLevels <- levels(y)
-      oldY <- y
-      y <- class2ind(y)
+  if (is.factor(y)) {
+    obsLevels <- levels(y)
+    oldY <- y
+    y <- class2ind(y)
+  } else {
+    if (is.matrix(y)) {
+      test <- apply(y, 1, sum)
+      if (any(test != 1)) {
+        stop("the rows of y must be 0/1 and sum to 1")
+      }
+      obsLevels <- colnames(y)
+      if (is.null(obsLevels)) {
+        stop("the y matrix must have column names")
+      }
+      oldY <- obsLevels[apply(y, 1, which.max)]
     } else {
-      if(is.matrix(y))
-        {
-          test <- apply(y, 1, sum)
-          if(any(test != 1)) stop("the rows of y must be 0/1 and sum to 1")
-          obsLevels <- colnames(y)
-          if(is.null(obsLevels)) stop("the y matrix must have column names")
-          oldY <- obsLevels[apply(y, 1, which.max)]
-        } else stop("y must be a matrix or a factor")
+      stop("y must be a matrix or a factor")
     }
+  }
 
-  if(!is.matrix(x)) x <- as.matrix(x)
+  if (!is.matrix(x)) {
+    x <- as.matrix(x)
+  }
 
   tmpData <- data.frame(n = paste("row", seq_len(nrow(y)), sep = ""))
   tmpData$y <- y
@@ -69,24 +79,23 @@ splsda.default <- function(x, y, probMethod = "softmax", prior = NULL, ...)
 
   out$obsLevels <- obsLevels
   out$probMethod <- probMethod
-  if(probMethod == "Bayes")
-    {
+  if (probMethod == "Bayes") {
+    requireNamespaceQuietStop("klaR")
+    makeModels <- function(x, y, pri) {
+      probModel <- klaR::NaiveBayes(x, y, prior = pri, usekernel = TRUE)
+      probModel$train <- predict(probModel)$posterior
+      probModel$x <- NULL
+      probModel
+    }
+    train <- predict(out, as.matrix(tmpData$x))
+    ## Get the raw model predictions, but leave one behind since the
+    ## final class probs sum to one
+    train <- train[, -length(obsLevels), drop = FALSE]
 
-      requireNamespaceQuietStop("klaR")
-      makeModels <- function(x, y, pri)
-        {
-          probModel <- klaR::NaiveBayes(x, y, prior = pri, usekernel = TRUE)
-          probModel$train <- predict(probModel)$posterior
-          probModel$x <- NULL
-          probModel
-        }
-      train <- predict(out, as.matrix(tmpData$x))
-      ## Get the raw model predictions, but leave one behind since the
-      ## final class probs sum to one
-      train <- train[, -length(obsLevels), drop = FALSE]
-
-      out$probModel <- makeModels(train, oldY, pri = prior)
-    } else out$probModel <- NULL
+    out$probModel <- makeModels(train, oldY, pri = prior)
+  } else {
+    out$probModel <- NULL
+  }
 
   ##out$call <- funcCall
   class(out) <- "splsda"
@@ -94,55 +103,76 @@ splsda.default <- function(x, y, probMethod = "softmax", prior = NULL, ...)
 }
 
 #' @export
-print.splsda <- function (x, ...)
-{
-    xmat <- x$x
-    p <- ncol(xmat)
-    A <- x$A
-    xAnames <- colnames(xmat)[A]
-    q <- ncol(x$y)
-    eta <- x$eta
-    K <- x$K
-    kappa <- x$kappa
-    select <- x$select
-    fit <- x$fit
-    if (q == 1) {
-        cat("\nSparse Partial Least Squares for discriminant analysis\n")
-        cat("----\n")
-        cat(paste("Parameters: eta = ", eta, ", K = ", K, "\n",
-            sep = ""))
-    }
-    if (q > 1) {
-        cat("\nSparse Partial Least Squares for discriminant analysis\n")
-        cat("----\n")
-        cat(paste("Parameters: eta = ", eta, ", K = ", K, ", kappa = ",
-            kappa, "\n", sep = ""))
-    }
-    cat(paste("PLS algorithm:\n", select, " for variable selection, ",
-        fit, " for model fitting\n", sep = ""))
+print.splsda <- function(x, ...) {
+  xmat <- x$x
+  p <- ncol(xmat)
+  A <- x$A
+  xAnames <- colnames(xmat)[A]
+  q <- ncol(x$y)
+  eta <- x$eta
+  K <- x$K
+  kappa <- x$kappa
+  select <- x$select
+  fit <- x$fit
+  if (q == 1) {
+    cat("\nSparse Partial Least Squares for discriminant analysis\n")
+    cat("----\n")
+    cat(paste("Parameters: eta = ", eta, ", K = ", K, "\n", sep = ""))
+  }
+  if (q > 1) {
+    cat("\nSparse Partial Least Squares for discriminant analysis\n")
+    cat("----\n")
+    cat(paste(
+      "Parameters: eta = ",
+      eta,
+      ", K = ",
+      K,
+      ", kappa = ",
+      kappa,
+      "\n",
+      sep = ""
+    ))
+  }
+  cat(paste(
+    "PLS algorithm:\n",
+    select,
+    " for variable selection, ",
+    fit,
+    " for model fitting\n",
+    sep = ""
+  ))
 
-    switch(x$probMethod,
-           softmax = cat("The softmax function was used to compute class probabilities.\n"),
-           Bayes = cat("Bayes rule was used to compute class probabilities.\n"))
+  switch(
+    x$probMethod,
+    softmax = cat(
+      "The softmax function was used to compute class probabilities.\n"
+    ),
+    Bayes = cat("Bayes rule was used to compute class probabilities.\n")
+  )
 
-    cat(paste("\nSPLS chose ", length(A), " variables among ",
-        p, " variables\n\n", sep = ""))
-    cat("Selected variables: \n")
-    if (!is.null(xAnames)) {
-        for (i in seq_along(A)) {
-            cat(paste(xAnames[i], "\t", sep = ""))
-            if (i%%5 == 0) {
-                cat("\n")
-            }
-        }
+  cat(paste(
+    "\nSPLS chose ",
+    length(A),
+    " variables among ",
+    p,
+    " variables\n\n",
+    sep = ""
+  ))
+  cat("Selected variables: \n")
+  if (!is.null(xAnames)) {
+    for (i in seq_along(A)) {
+      cat(paste(xAnames[i], "\t", sep = ""))
+      if (i %% 5 == 0) {
+        cat("\n")
+      }
     }
-    else {
-        for (i in seq_along(A)) {
-            cat(paste(A[i], "\t", sep = ""))
-            if (i%%5 == 0) {
-                cat("\n")
-            }
-        }
+  } else {
+    for (i in seq_along(A)) {
+      cat(paste(A[i], "\t", sep = ""))
+      if (i %% 5 == 0) {
+        cat("\n")
+      }
     }
-    cat("\n")
+  }
+  cat("\n")
 }

--- a/R/suggestions.R
+++ b/R/suggestions.R
@@ -1,43 +1,169 @@
-suggestions <- function(model)
-{
+suggestions <- function(model) {
+  out <- c("center" = FALSE, "scale" = FALSE, "nzv" = FALSE, "corr" = FALSE)
 
-  out <- c("center" = FALSE, "scale" = FALSE,
-           "nzv" = FALSE, "corr" = FALSE)
+  if (
+    model %in%
+      c(
+        "enet",
+        "gaussprLinear",
+        "gaussprPoly",
+        "gaussprRadial",
+        "glmnet",
+        "gpls",
+        "knn",
+        "lars",
+        "lars2",
+        "lasso",
+        "lssvmLinear",
+        "lssvmPoly",
+        "lssvmRadial",
+        "multinom",
+        "neuralnet",
+        "nnet",
+        "penalized",
+        "pls",
+        "relaxo",
+        "rocc",
+        "rvmLinear",
+        "rvmPoly",
+        "rvmRadial",
+        "smda",
+        "sparseLDA",
+        "spls",
+        "superpc",
+        "svmLinear",
+        "svmPoly",
+        "svmRadial"
+      )
+  ) {
+    out["center"] <- TRUE
+  }
+  if (
+    model %in%
+      c(
+        "gaussprLinear",
+        "gaussprPoly",
+        "gaussprRadial",
+        "glmnet",
+        "gpls",
+        "knn",
+        "lars",
+        "lars2",
+        "lasso",
+        "lssvmLinear",
+        "lssvmPoly",
+        "lssvmRadial",
+        "multinom",
+        "neuralnet",
+        "nnet",
+        "penalized",
+        "pls",
+        "relaxo",
+        "rocc",
+        "rvmLinear",
+        "rvmPoly",
+        "rvmRadial",
+        "smda",
+        "sparseLDA",
+        "spls",
+        "superpc",
+        "svmLinear",
+        "svmPoly",
+        "svmRadial"
+      )
+  ) {
+    out["scale"] <- TRUE
+  }
+  if (
+    model %in%
+      c(
+        "enet",
+        "gaussprLinear",
+        "gaussprPoly",
+        "gaussprRadial",
+        "gpls",
+        "hda",
+        "hdda",
+        "icr",
+        "knn",
+        "lars",
+        "lars2",
+        "lasso",
+        "lda",
+        "knn",
+        "lm",
+        "lmStepAIC",
+        "glm",
+        "glmStepAIC",
+        "lssvmLinear",
+        "lssvmPoly",
+        "lssvmRadial",
+        "lvq",
+        "mda",
+        "multinom",
+        "nb",
+        "neuralnet",
+        "nnet",
+        "pam",
+        "pcaNNet",
+        "pcr",
+        "pda",
+        "pda2",
+        "penalized",
+        "pls",
+        "qda",
+        "QdaCov",
+        "rda",
+        "relaxo",
+        "rlm",
+        "rocc",
+        "rvmLinear",
+        "rvmPoly",
+        "rvmRadial",
+        "scrda",
+        "sda",
+        "sddaLDA",
+        "sddaQDA",
+        "slda",
+        "smda",
+        "sparseLDA",
+        "spls",
+        "stepLDA",
+        "stepQDA",
+        "superpc",
+        "svmLinear",
+        "svmPoly",
+        "svmRadial",
+        "vbmpRadial"
+      )
+  ) {
+    out["nzv"] <- TRUE
+  }
 
-  if(model %in% c("enet", "gaussprLinear", "gaussprPoly",
-                  "gaussprRadial", "glmnet", "gpls", "knn",
-                  "lars", "lars2", "lasso", "lssvmLinear",
-                  "lssvmPoly", "lssvmRadial", "multinom",
-                  "neuralnet", "nnet", "penalized", "pls",
-                  "relaxo", "rocc", "rvmLinear", "rvmPoly",
-                  "rvmRadial", "smda", "sparseLDA", "spls",
-                  "superpc", "svmLinear", "svmPoly", "svmRadial")) out["center"] <- TRUE
-  if(model %in% c("gaussprLinear", "gaussprPoly",
-                  "gaussprRadial", "glmnet", "gpls", "knn",
-                  "lars", "lars2", "lasso", "lssvmLinear",
-                  "lssvmPoly", "lssvmRadial", "multinom",
-                  "neuralnet", "nnet", "penalized", "pls",
-                  "relaxo", "rocc", "rvmLinear", "rvmPoly",
-                  "rvmRadial", "smda", "sparseLDA", "spls",
-                  "superpc", "svmLinear", "svmPoly", "svmRadial")) out["scale"] <- TRUE
-  if(model %in% c("enet", "gaussprLinear", "gaussprPoly",
-                  "gaussprRadial", "gpls", "hda", "hdda", "icr",
-                  "knn", "lars", "lars2", "lasso", "lda", "knn",
-                  "lm", "lmStepAIC", "glm", "glmStepAIC",
-                  "lssvmLinear", "lssvmPoly", "lssvmRadial",
-                  "lvq", "mda", "multinom", "nb",
-                  "neuralnet", "nnet", "pam", "pcaNNet",  "pcr",
-                  "pda", "pda2", "penalized", "pls", "qda",
-                  "QdaCov", "rda", "relaxo", "rlm", "rocc",
-                  "rvmLinear", "rvmPoly", "rvmRadial",
-                  "scrda", "sda", "sddaLDA", "sddaQDA",      
-                  "slda", "smda", "sparseLDA", "spls",         
-                  "stepLDA", "stepQDA", "superpc", "svmLinear",  
-                  "svmPoly", "svmRadial", "vbmpRadial")) out["nzv"] <- TRUE
-
-  if(model %in% c("enet", "lars", "lars2", "lasso", "lda",
-                  "lm", "lmStepAIC", "glm", "glmStepAIC",
-                  "multinom", "nb", "neuralnet", "nnet",
-                  "pda", "pda2", "penalized", "relaxo", "rlm" )) out["nzv"] <- TRUE
+  if (
+    model %in%
+      c(
+        "enet",
+        "lars",
+        "lars2",
+        "lasso",
+        "lda",
+        "lm",
+        "lmStepAIC",
+        "glm",
+        "glmStepAIC",
+        "multinom",
+        "nb",
+        "neuralnet",
+        "nnet",
+        "pda",
+        "pda2",
+        "penalized",
+        "relaxo",
+        "rlm"
+      )
+  ) {
+    out["nzv"] <- TRUE
+  }
   out
 }

--- a/R/thresholder.R
+++ b/R/thresholder.R
@@ -50,14 +50,14 @@
 #' set.seed(2444)
 #' dat <- twoClassSim(500, intercept = -10)
 #' table(dat$Class)
-#' 
+#'
 #' ctrl <- trainControl(
 #'   method = "cv",
 #'   classProbs = TRUE,
 #'   savePredictions = "all",
 #'   summaryFunction = twoClassSummary
 #' )
-#' 
+#'
 #' set.seed(2863)
 #' mod <- train(
 #'   Class ~ .,
@@ -67,13 +67,13 @@
 #'   metric = "ROC",
 #'   trControl = ctrl
 #' )
-#' 
+#'
 #' resample_stats <- thresholder(
 #'   mod,
 #'   threshold = seq(.5, 1, by = 0.05),
 #'   final = TRUE
 #' )
-#' 
+#'
 #' ggplot(resample_stats, aes(x = prob_threshold, y = J)) +
 #'   geom_point()
 #' ggplot(resample_stats, aes(x = prob_threshold, y = Dist)) +
@@ -82,62 +82,93 @@
 #'   geom_point() +
 #'   geom_point(aes(y = Specificity), col = "red")
 thresholder <- function(x, threshold, final = TRUE, statistics = "all") {
-  if(!inherits(x, "train"))
-    stop("`x` should be an object of class 'train'", 
-         call. = FALSE)
-  if (!x$control$classProbs)
-    stop("`classProbs` must be TRUE in `trainControl`",
-         call. = FALSE)
-  if (is.null(threshold))
-    stop("Please supply probability threshold values.",
-         call. = FALSE)
-  if (any(threshold > 1 | threshold < 0))
-    stop("`threshold` should be on [0,1]", call. = FALSE)
-  
-  if (is.logical(x$control$savePredictions)) {
-    if (!x$control$savePredictions)
-      stop("`savePredictions` should be TRUE, 'all', or 'final'")
-  } else {
-    if (x$control$savePredictions == "none")
-      stop("`savePredictions` should be TRUE, 'all', or 'final'")
+  if (!inherits(x, "train")) {
+    stop("`x` should be an object of class 'train'", call. = FALSE)
   }
-  if (length(levels(x$pred$obs)) > 2)
-    stop("For two class problems only", call. = TRUE)
-  
-  stat_names <- c("Sensitivity", "Specificity", "Pos Pred Value",
-                  "Neg Pred Value", "Precision", "Recall", "F1", "Prevalence",
-                  "Detection Rate", "Detection Prevalence", "Balanced Accuracy",
-                  "Accuracy", "Kappa", "J", "Dist")
-  if (!any(statistics %in% c("all", stat_names)) ||
-      ("all" %in% statistics && length(statistics) > 1))
-    stop("`statistics` should be either 'all', or one or more of '",
-         paste0(stat_names, collapse="', '"), "'.")
+  if (!x$control$classProbs) {
+    stop("`classProbs` must be TRUE in `trainControl`", call. = FALSE)
+  }
+  if (is.null(threshold)) {
+    stop("Please supply probability threshold values.", call. = FALSE)
+  }
+  if (any(threshold > 1 | threshold < 0)) {
+    stop("`threshold` should be on [0,1]", call. = FALSE)
+  }
 
-  if (length(statistics) == 1 && statistics == "all")
+  if (is.logical(x$control$savePredictions)) {
+    if (!x$control$savePredictions) {
+      stop("`savePredictions` should be TRUE, 'all', or 'final'")
+    }
+  } else {
+    if (x$control$savePredictions == "none") {
+      stop("`savePredictions` should be TRUE, 'all', or 'final'")
+    }
+  }
+  if (length(levels(x$pred$obs)) > 2) {
+    stop("For two class problems only", call. = TRUE)
+  }
+
+  stat_names <- c(
+    "Sensitivity",
+    "Specificity",
+    "Pos Pred Value",
+    "Neg Pred Value",
+    "Precision",
+    "Recall",
+    "F1",
+    "Prevalence",
+    "Detection Rate",
+    "Detection Prevalence",
+    "Balanced Accuracy",
+    "Accuracy",
+    "Kappa",
+    "J",
+    "Dist"
+  )
+  if (
+    !any(statistics %in% c("all", stat_names)) ||
+      ("all" %in% statistics && length(statistics) > 1)
+  ) {
+    stop(
+      "`statistics` should be either 'all', or one or more of '",
+      paste0(stat_names, collapse = "', '"),
+      "'."
+    )
+  }
+
+  if (length(statistics) == 1 && statistics == "all") {
     statistics <- stat_names
-  
+  }
+
   disc <- c("pred", "rowIndex", x$levels[-1])
-  
+
   ## Expand the predicted values with the candidate values of
   ## the threshold
-  pred_dat <- expand_preds(if (final)
-    merge(x$pred, x$bestTune)
-    else
-      x$pred,
+  pred_dat <- expand_preds(
+    if (final) {
+      merge(x$pred, x$bestTune)
+    } else {
+      x$pred
+    },
     threshold,
-    disc)
-  
+    disc
+  )
+
   param <- c("Resample", names(x$bestTune), "prob_threshold")
-  
+
   ## Based on the threshold, recode the predicted classes
   pred_dat <- ddply(pred_dat, .variables = param, recode)
-  
+
   ## Compute statistics per threshold and tuning parameters
   pred_stats <- ddply(pred_dat, .variables = param, stats)
-  
+
   ## Summarize over resamples
-  pred_resamp <- ddply(pred_stats, .variables = param[-1],
-                       summ_stats, statistics)
+  pred_resamp <- ddply(
+    pred_stats,
+    .variables = param[-1],
+    summ_stats,
+    statistics
+  )
   pred_resamp
 }
 
@@ -145,9 +176,10 @@ expand_preds <- function(df, th, excl = NULL) {
   th <- unique(th)
   nth <- length(th)
   ndf <- nrow(df)
-  if (!is.null(excl))
+  if (!is.null(excl)) {
     df <- df[, !(names(df) %in% excl), drop = FALSE]
-  df <- df[rep(seq_len(nrow(df)), times = nth),]
+  }
+  df <- df[rep(seq_len(nrow(df)), times = nth), ]
   df$prob_threshold <- rep(th, each = ndf)
   df
 }
@@ -155,19 +187,23 @@ expand_preds <- function(df, th, excl = NULL) {
 
 recode <- function(dat) {
   lvl <- levels(dat$obs)
-  dat$pred <- ifelse(dat[, lvl[1]] > dat$prob_threshold,
-                     lvl[1], lvl[2])
+  dat$pred <- ifelse(dat[, lvl[1]] > dat$prob_threshold, lvl[1], lvl[2])
   dat$pred <- factor(dat$pred, levels = lvl)
   dat
 }
 
 stats <- function(dat) {
-  tab <- caret::confusionMatrix(dat$pred, dat$obs,
-                                positive = levels(dat$obs)[1])
+  tab <- caret::confusionMatrix(
+    dat$pred,
+    dat$obs,
+    positive = levels(dat$obs)[1]
+  )
   res <- c(tab$byClass, tab$overall[c("Accuracy", "Kappa")])
-  res <- c(res,
-           res["Sensitivity"] + res["Specificity"] - 1,
-           sqrt((res["Sensitivity"] - 1) ^ 2 + (res["Specificity"] - 1) ^ 2))
+  res <- c(
+    res,
+    res["Sensitivity"] + res["Specificity"] - 1,
+    sqrt((res["Sensitivity"] - 1)^2 + (res["Specificity"] - 1)^2)
+  )
   names(res)[-seq_len(length(res) - 2)] <- c("J", "Dist")
   res
 }
@@ -176,9 +212,13 @@ summ_stats <- function(x, cols) {
   na_cols <- apply(x, 2, function(x) anyNA(x))
   na_col_names <- colnames(x)[na_cols]
   relevant_col_names <- intersect(na_col_names, cols)
-  if (length(relevant_col_names) > 0)
-    warning("The following columns have missing values (NA), which have been ",
-            "removed: '", paste0(relevant_col_names, collapse = "', '"),
-            "'.\n")
+  if (length(relevant_col_names) > 0) {
+    warning(
+      "The following columns have missing values (NA), which have been ",
+      "removed: '",
+      paste0(relevant_col_names, collapse = "', '"),
+      "'.\n"
+    )
+  }
   colMeans(x[, cols, drop = FALSE], na.rm = TRUE)
 }

--- a/R/train.default.R
+++ b/R/train.default.R
@@ -411,7 +411,11 @@ train.default <- function(
     x <- as.data.frame(x, stringsAsFactors = TRUE)
   }
   check_dims(x = x, y = y)
-  n <- if (inherits(y, "Surv")) nrow(y) else length(y)
+  if (inherits(y, "Surv")) {
+    n <- nrow(y)
+  } else {
+    n <- length(y)
+  }
 
   ## TODO add check method and execute here
 
@@ -520,10 +524,10 @@ train.default <- function(
   )
 
   if (is.logical(trControl$savePredictions)) {
-    trControl$savePredictions <- if (trControl$savePredictions) {
-      "all"
+    if (trControl$savePredictions) {
+      trControl$savePredictions <- "all"
     } else {
-      "none"
+      trControl$savePredictions <- "none"
     }
   } else {
     if (!(trControl$savePredictions %in% c("all", "final", "none"))) {
@@ -637,7 +641,11 @@ train.default <- function(
 
   ## In case prediction bounds are used, compute the limits. For now,
   ## store these in the control object since that gets passed everywhere
-  trControl$yLimits <- if (is.numeric(y)) get_range(y) else NULL
+  if (is.numeric(y)) {
+    trControl$yLimits <- get_range(y)
+  } else {
+    trControl$yLimits <- NULL
+  }
 
   if (trControl$method != "none") {
     ##------------------------------------------------------------------------------------------------------------------------------------------------------#
@@ -726,12 +734,18 @@ train.default <- function(
         )
       }
       lengths <- unlist(lapply(trainInfo$submodels, nrow))
-      if (all(lengths == 0)) trainInfo$submodels <- NULL
+      if (all(lengths == 0)) {
+        trainInfo$submodels <- NULL
+      }
     } else {
       trainInfo <- list(loop = tuneGrid)
     }
 
-    num_rs <- if (trControl$method != "oob") length(trControl$index) else 1L
+    if (trControl$method != "oob") {
+      num_rs <- length(trControl$index)
+    } else {
+      num_rs <- 1L
+    }
     if (trControl$method %in% c("boot632", "optimism_boot", "boot_all")) {
       num_rs <- num_rs + 1L
     }
@@ -1050,10 +1064,10 @@ train.default <- function(
 
   ## Make the final model based on the tuning results
 
-  indexFinal <- if (is.null(trControl$indexFinal)) {
-    seq(along.with = y)
+  if (is.null(trControl$indexFinal)) {
+    indexFinal <- seq(along.with = y)
   } else {
-    trControl$indexFinal
+    indexFinal <- trControl$indexFinal
   }
 
   if (!(length(trControl$seeds) == 1 && is.na(trControl$seeds))) {
@@ -1089,10 +1103,10 @@ train.default <- function(
       p_reduction <- (unclass(old_size) - unclass(new_size)) /
         unclass(old_size) *
         100
-      p_reduction <- if (p_reduction < 1) {
-        "< 1%"
+      if (p_reduction < 1) {
+        p_reduction <- "< 1%"
       } else {
-        paste0(round(p_reduction, 0), "%")
+        p_reduction <- paste0(round(p_reduction, 0), "%")
       }
       cat(
         "Final model footprint reduced by",
@@ -1121,7 +1135,11 @@ train.default <- function(
   }
 
   if (trControl$returnData) {
-    outData <- if (inherits(x, "sparseMatrix")) as.matrix(x) else x
+    if (inherits(x, "sparseMatrix")) {
+      outData <- as.matrix(x)
+    } else {
+      outData <- x
+    }
     if (!is.data.frame(outData)) {
       outData <- try(
         as.data.frame(outData, stringsAsFactors = TRUE),
@@ -1135,7 +1153,9 @@ train.default <- function(
       outData <- NULL
     } else {
       outData$.outcome <- y
-      if (!is.null(weights)) outData$.weights <- weights
+      if (!is.null(weights)) {
+        outData$.weights <- weights
+      }
     }
   } else {
     outData <- NULL
@@ -1250,7 +1270,9 @@ train.formula <- function(
     ## since it has not been converted to dummy variables.
     res$trainingData <- data[, all.vars(Terms), drop = FALSE]
     isY <- names(res$trainingData) %in% as.character(form[[2]])
-    if (any(isY)) colnames(res$trainingData)[isY] <- ".outcome"
+    if (any(isY)) {
+      colnames(res$trainingData)[isY] <- ".outcome"
+    }
   }
   class(res) <- c("train", "train.formula")
   res
@@ -1409,7 +1431,11 @@ train.recipe <- function(
   }
 
   check_dims(x = x_dat, y = y_dat)
-  n <- if (inherits(y_dat, "Surv")) nrow(y_dat) else length(y_dat)
+  if (inherits(y_dat, "Surv")) {
+    n <- nrow(y_dat)
+  } else {
+    n <- length(y_dat)
+  }
 
   ## Some models that use RWeka start multiple threads and this conflicts with multicore:
   parallel_check("RWeka", models)
@@ -1513,10 +1539,10 @@ train.recipe <- function(
   )
 
   if (is.logical(trControl$savePredictions)) {
-    trControl$savePredictions <- if (trControl$savePredictions) {
-      "all"
+    if (trControl$savePredictions) {
+      trControl$savePredictions <- "all"
     } else {
-      "none"
+      trControl$savePredictions <- "none"
     }
   } else {
     if (!(trControl$savePredictions %in% c("all", "final", "none"))) {
@@ -1577,7 +1603,11 @@ train.recipe <- function(
 
   ## In case prediction bounds are used, compute the limits. For now,
   ## store these in the control object since that gets passed everywhere
-  trControl$yLimits <- if (is.numeric(y_dat)) get_range(y_dat) else NULL
+  if (is.numeric(y_dat)) {
+    trControl$yLimits <- get_range(y_dat)
+  } else {
+    trControl$yLimits <- NULL
+  }
 
   if (trControl$method != "none") {
     if (is.function(models$loop) && nrow(tuneGrid) > 1) {
@@ -1589,12 +1619,18 @@ train.recipe <- function(
         )
       }
       lengths <- unlist(lapply(trainInfo$submodels, nrow))
-      if (all(lengths == 0)) trainInfo$submodels <- NULL
+      if (all(lengths == 0)) {
+        trainInfo$submodels <- NULL
+      }
     } else {
       trainInfo <- list(loop = tuneGrid)
     }
 
-    num_rs <- if (trControl$method != "oob") length(trControl$index) else 1L
+    if (trControl$method != "oob") {
+      num_rs <- length(trControl$index)
+    } else {
+      num_rs <- 1L
+    }
     if (trControl$method %in% c("boot632", "optimism_boot", "boot_all")) {
       num_rs <- num_rs + 1L
     }
@@ -1903,10 +1939,10 @@ train.recipe <- function(
   }
 
   ## Make the final model based on the tuning results
-  indexFinal <- if (is.null(trControl$indexFinal)) {
-    seq(along.with = data[[y_orig_val]])
+  if (is.null(trControl$indexFinal)) {
+    indexFinal <- seq(along.with = data[[y_orig_val]])
   } else {
-    trControl$indexFinal
+    indexFinal <- trControl$indexFinal
   }
 
   if (!(length(trControl$seeds) == 1 && is.na(trControl$seeds))) {
@@ -1940,10 +1976,10 @@ train.recipe <- function(
       p_reduction <- (unclass(old_size) - unclass(new_size)) /
         unclass(old_size) *
         100
-      p_reduction <- if (p_reduction < 1) {
-        "< 1%"
+      if (p_reduction < 1) {
+        p_reduction <- "< 1%"
       } else {
-        paste0(round(p_reduction, 0), "%")
+        p_reduction <- paste0(round(p_reduction, 0), "%")
       }
       cat(
         "Final model footprint reduced by",

--- a/R/trainControl.R
+++ b/R/trainControl.R
@@ -261,11 +261,17 @@ trainControl <- function(
     stop("incorrect value of adaptive$alpha")
   }
   if (grepl("adapt", method)) {
-    num <- if (method == "adaptive_cv") number * repeats else number
+    if (method == "adaptive_cv") {
+      num <- number * repeats
+    } else {
+      num <- number
+    }
     if (adaptive$min >= num) {
       stop(paste("adaptive$min should be less than", num))
     }
-    if (adaptive$min <= 1) stop("adaptive$min should be greater than 1")
+    if (adaptive$min <= 1) {
+      stop("adaptive$min should be greater than 1")
+    }
   }
   if (!(search %in% c("grid", "random"))) {
     stop("`search` should be either 'grid' or 'random'")

--- a/R/trainControl.R
+++ b/R/trainControl.R
@@ -152,23 +152,23 @@
 #' @family train
 #' @keywords utilities
 #' @examplesIf !caret:::is_cran_check()
-#' 
-#' 
+#'
+#'
 #' ## Do 5 repeats of 10-Fold CV for the iris data. We will fit
 #' ## a KNN model that evaluates 12 values of k and set the seed
 #' ## at each iteration.
-#' 
+#'
 #' set.seed(123)
 #' seeds <- vector(mode = "list", length = 51)
 #' for (i in 1:50) {
 #'   seeds[[i]] <- sample.int(1000, 22)
 #' }
-#' 
+#'
 #' ## For the last model:
 #' seeds[[51]] <- sample.int(1000, 1)
-#' 
+#'
 #' ctrl <- trainControl(method = "repeatedcv", repeats = 5, seeds = seeds)
-#' 
+#'
 #' set.seed(1)
 #' mod <- train(
 #'   Species ~ .,
@@ -177,14 +177,14 @@
 #'   tuneLength = 12,
 #'   trControl = ctrl
 #' )
-#' 
+#'
 #' ctrl2 <- trainControl(
 #'   method = "adaptive_cv",
 #'   repeats = 5,
 #'   verboseIter = TRUE,
 #'   seeds = seeds
 #' )
-#' 
+#'
 #' set.seed(1)
 #' mod2 <- train(
 #'   Species ~ .,
@@ -193,87 +193,118 @@
 #'   tuneLength = 12,
 #'   trControl = ctrl2
 #' )
-#' 
-#' 
+#'
+#'
 #' @export trainControl
-trainControl <- function(method = "boot",
-                         number = ifelse(grepl("cv", method), 10, 25),
-                         repeats = ifelse(grepl("[d_]cv$", method), 1, NA),
-                         p = 0.75,
-                         search = "grid",
-                         initialWindow = NULL,
-                         horizon = 1,
-                         fixedWindow = TRUE,
-                         skip = 0,
-                         verboseIter = FALSE,
-                         returnData = TRUE,
-                         returnResamp = "final",
-                         savePredictions = FALSE,
-                         classProbs = FALSE,
-                         summaryFunction = defaultSummary,
-                         selectionFunction = "best",
-                         preProcOptions = list(thresh = 0.95, ICAcomp = 3, k = 5,
-                                               freqCut = 95/5, uniqueCut = 10,
-                                               cutoff = 0.9),
-                         sampling = NULL,
-                         index = NULL,
-                         indexOut = NULL,
-                         indexFinal = NULL,
-                         timingSamps = 0,
-                         predictionBounds = rep(FALSE, 2),
-                         seeds = NA,
-                         adaptive = list(min = 5, alpha = 0.05, method = "gls", complete = TRUE),
-                         trim = FALSE,
-                         allowParallel = TRUE)
-{
-  if(is.null(selectionFunction)) stop("null selectionFunction values not allowed")
-  if(!(returnResamp %in% c("all", "final", "none"))) stop("incorrect value of returnResamp")
-  if(length(predictionBounds) > 0 && length(predictionBounds) != 2) stop("'predictionBounds' should be a logical or numeric vector of length 2")
-  if(any(names(preProcOptions) == "method")) stop("'method' cannot be specified here")
-  if(any(names(preProcOptions) == "x")) stop("'x' cannot be specified here")
-  if(!is.na(repeats) && !(method %in% c("repeatedcv", "adaptive_cv")))
-    warning("`repeats` has no meaning for this resampling method.", call. = FALSE)
-
-  if(!(adaptive$method %in% c("gls", "BT"))) stop("incorrect value of adaptive$method")
-  if(adaptive$alpha < 0.0000001 || adaptive$alpha > 1) stop("incorrect value of adaptive$alpha")
-  if(grepl("adapt", method)) {
-    num <- if(method == "adaptive_cv") number*repeats else number
-    if(adaptive$min >= num) stop(paste("adaptive$min should be less than", num))
-    if(adaptive$min <= 1) stop("adaptive$min should be greater than 1")
+trainControl <- function(
+  method = "boot",
+  number = ifelse(grepl("cv", method), 10, 25),
+  repeats = ifelse(grepl("[d_]cv$", method), 1, NA),
+  p = 0.75,
+  search = "grid",
+  initialWindow = NULL,
+  horizon = 1,
+  fixedWindow = TRUE,
+  skip = 0,
+  verboseIter = FALSE,
+  returnData = TRUE,
+  returnResamp = "final",
+  savePredictions = FALSE,
+  classProbs = FALSE,
+  summaryFunction = defaultSummary,
+  selectionFunction = "best",
+  preProcOptions = list(
+    thresh = 0.95,
+    ICAcomp = 3,
+    k = 5,
+    freqCut = 95 / 5,
+    uniqueCut = 10,
+    cutoff = 0.9
+  ),
+  sampling = NULL,
+  index = NULL,
+  indexOut = NULL,
+  indexFinal = NULL,
+  timingSamps = 0,
+  predictionBounds = rep(FALSE, 2),
+  seeds = NA,
+  adaptive = list(min = 5, alpha = 0.05, method = "gls", complete = TRUE),
+  trim = FALSE,
+  allowParallel = TRUE
+) {
+  if (is.null(selectionFunction)) {
+    stop("null selectionFunction values not allowed")
   }
-  if(!(search %in% c("grid", "random")))
+  if (!(returnResamp %in% c("all", "final", "none"))) {
+    stop("incorrect value of returnResamp")
+  }
+  if (length(predictionBounds) > 0 && length(predictionBounds) != 2) {
+    stop("'predictionBounds' should be a logical or numeric vector of length 2")
+  }
+  if (any(names(preProcOptions) == "method")) {
+    stop("'method' cannot be specified here")
+  }
+  if (any(names(preProcOptions) == "x")) {
+    stop("'x' cannot be specified here")
+  }
+  if (!is.na(repeats) && !(method %in% c("repeatedcv", "adaptive_cv"))) {
+    warning(
+      "`repeats` has no meaning for this resampling method.",
+      call. = FALSE
+    )
+  }
+
+  if (!(adaptive$method %in% c("gls", "BT"))) {
+    stop("incorrect value of adaptive$method")
+  }
+  if (adaptive$alpha < 0.0000001 || adaptive$alpha > 1) {
+    stop("incorrect value of adaptive$alpha")
+  }
+  if (grepl("adapt", method)) {
+    num <- if (method == "adaptive_cv") number * repeats else number
+    if (adaptive$min >= num) {
+      stop(paste("adaptive$min should be less than", num))
+    }
+    if (adaptive$min <= 1) stop("adaptive$min should be greater than 1")
+  }
+  if (!(search %in% c("grid", "random"))) {
     stop("`search` should be either 'grid' or 'random'")
-  if(method == "oob" && any(names(match.call()) == "summaryFunction")) {
-    warning("Custom summary measures cannot be computed for out-of-bag resampling. ",
-            "This value of `summaryFunction` will be ignored.",
-            call. = FALSE)
+  }
+  if (method == "oob" && any(names(match.call()) == "summaryFunction")) {
+    warning(
+      "Custom summary measures cannot be computed for out-of-bag resampling. ",
+      "This value of `summaryFunction` will be ignored.",
+      call. = FALSE
+    )
   }
 
-  list(method = method,
-       number = number,
-       repeats = repeats,
-       search = search,
-       p = p,
-       initialWindow = initialWindow,
-       horizon = horizon,
-       fixedWindow = fixedWindow,
-       skip = skip,
-       verboseIter = verboseIter,
-       returnData = returnData,
-       returnResamp = returnResamp,
-       savePredictions = savePredictions,
-       classProbs = classProbs,
-       summaryFunction = summaryFunction,
-       selectionFunction = selectionFunction,
-       preProcOptions = preProcOptions,
-       sampling = sampling,
-       index = index,
-       indexOut = indexOut,
-       indexFinal = indexFinal,
-       timingSamps = timingSamps,
-       predictionBounds = predictionBounds,
-       seeds = seeds,
-       adaptive = adaptive,
-       trim = trim,
-       allowParallel = allowParallel)
+  list(
+    method = method,
+    number = number,
+    repeats = repeats,
+    search = search,
+    p = p,
+    initialWindow = initialWindow,
+    horizon = horizon,
+    fixedWindow = fixedWindow,
+    skip = skip,
+    verboseIter = verboseIter,
+    returnData = returnData,
+    returnResamp = returnResamp,
+    savePredictions = savePredictions,
+    classProbs = classProbs,
+    summaryFunction = summaryFunction,
+    selectionFunction = selectionFunction,
+    preProcOptions = preProcOptions,
+    sampling = sampling,
+    index = index,
+    indexOut = indexOut,
+    indexFinal = indexFinal,
+    timingSamps = timingSamps,
+    predictionBounds = predictionBounds,
+    seeds = seeds,
+    adaptive = adaptive,
+    trim = trim,
+    allowParallel = allowParallel
+  )
 }

--- a/R/train_recipes.R
+++ b/R/train_recipes.R
@@ -13,10 +13,10 @@ predict.train.recipe <- function(
     )
     names(predicted) <- NULL
     if (!is.null(object$levels) && all(!is.na(object$levels))) {
-      predicted <- if (attr(object$levels, "ordered")) {
-        ordered(as.character(predicted), levels = object$levels)
+      if (attr(object$levels, "ordered")) {
+        predicted <- ordered(as.character(predicted), levels = object$levels)
       } else {
-        factor(as.character(predicted), levels = object$levels)
+        predicted <- factor(as.character(predicted), levels = object$levels)
       }
     }
   } else {
@@ -148,13 +148,13 @@ rec_model <- function(
     ]
 
     other_cols <- other_cols$variable
-    other_dat <- if (
+    if (
       is.matrix(dat) ||
         (is.data.frame(dat) && !inherits(dat, "tbl_df"))
     ) {
-      dat[, other_cols, drop = FALSE]
+      other_dat <- dat[, other_cols, drop = FALSE]
     } else {
-      dat[, other_cols]
+      other_dat <- dat[, other_cols]
     }
 
     tmp <- sampling$func(other_dat, y)
@@ -214,7 +214,11 @@ rec_model <- function(
   }
   if (!isS4(modelFit) && !model_failed(modelFit)) {
     modelFit$xNames <- colnames(x)
-    modelFit$problemType <- if (is.factor(y)) "Classification" else "Regression"
+    if (is.factor(y)) {
+      modelFit$problemType <- "Classification"
+    } else {
+      modelFit$problemType <- "Regression"
+    }
     modelFit$tuneValue <- tuneValue
     modelFit$obsLevels <- obsLevels
     modelFit$param <- list(...)
@@ -369,7 +373,9 @@ loo_train_rec <- function(
         } else {
           probValues <- fill_failed_prob(holdoutIndex, lev, submod)
         }
-        if (testing) print(head(probValues))
+        if (testing) {
+          print(head(probValues))
+        }
       }
 
       predicted <- trim_values(predicted, ctrl, is.null(lev))
@@ -633,7 +639,9 @@ train_rec <- function(rec, dat, info, method, ctrl, lev, testing = FALSE, ...) {
         } else {
           probValues <- fill_failed_prob(holdoutIndex, lev, submod)
         }
-        if (testing) print(head(probValues))
+        if (testing) {
+          print(head(probValues))
+        }
       }
 
       ##################################
@@ -830,10 +838,10 @@ train_rec <- function(rec, dat, info, method, ctrl, lev, testing = FALSE, ...) {
     out <- merge(out, apparent)
     const <- 1 - exp(-1)
     sapply(perfNames, function(perfName) {
-      perfOut <- if (ctrl$method == "boot_all") {
-        paste0(perfName, "_632")
+      if (ctrl$method == "boot_all") {
+        perfOut <- paste0(perfName, "_632")
       } else {
-        perfName
+        perfOut <- perfName
       }
       out[, perfOut] <<- (const * out[, perfName]) +
         ((1 - const) * out[, paste(perfName, "Apparent", sep = "")])
@@ -864,10 +872,10 @@ train_rec <- function(rec, dat, info, method, ctrl, lev, testing = FALSE, ...) {
       ## Remove unnecessary values
       out[, paste0(perfName, "Orig")] <<- NULL
       out[, paste0(perfName, "Boot")] <<- NULL
-      perfOut <- if (ctrl$method == "boot_all") {
-        paste0(perfName, "_OptBoot")
+      if (ctrl$method == "boot_all") {
+        perfOut <- paste0(perfName, "_OptBoot")
       } else {
-        perfName
+        perfOut <- perfName
       }
       ## Update estimates
       out[, paste0(perfName, "Optimism")] <<- optimism
@@ -1017,7 +1025,9 @@ train_adapt_rec <- function(
         } else {
           probValues <- fill_failed_prob(holdoutIndex, lev, submod)
         }
-        if (testing) print(head(probValues))
+        if (testing) {
+          print(head(probValues))
+        }
       }
 
       ##################################
@@ -1134,10 +1144,10 @@ train_adapt_rec <- function(
     } ## end initial loop over resamples and models
 
   init_resamp <- rbind.fill(init_result[names(init_result) == "resamples"])
-  init_pred <- if (keep_pred) {
-    rbind.fill(init_result[names(init_result) == "pred"])
+  if (keep_pred) {
+    init_pred <- rbind.fill(init_result[names(init_result) == "pred"])
   } else {
-    NULL
+    init_pred <- NULL
   }
   names(init_resamp) <- gsub("^\\.", "", names(init_resamp))
   if (
@@ -1267,7 +1277,9 @@ train_adapt_rec <- function(
             } else {
               probValues <- fill_failed_prob(holdoutIndex, lev, submod)
             }
-            if (testing) print(head(probValues))
+            if (testing) {
+              print(head(probValues))
+            }
           }
 
           ##################################
@@ -1489,7 +1501,9 @@ train_adapt_rec <- function(
 
     last_iter <- iter
 
-    if (num_left == 1) break
+    if (num_left == 1) {
+      break
+    }
   }
 
   ## finish up last resamples
@@ -1605,7 +1619,9 @@ train_adapt_rec <- function(
           } else {
             probValues <- fill_failed_prob(holdoutIndex, lev, submod)
           }
-          if (testing) print(head(probValues))
+          if (testing) {
+            print(head(probValues))
+          }
         }
         ##################################
 
@@ -1734,10 +1750,10 @@ train_adapt_rec <- function(
   }
 
   resamples <- rbind.fill(init_result[names(init_result) == "resamples"])
-  pred <- if (keep_pred) {
-    rbind.fill(init_result[names(init_result) == "pred"])
+  if (keep_pred) {
+    pred <- rbind.fill(init_result[names(init_result) == "pred"])
   } else {
-    NULL
+    pred <- NULL
   }
   names(resamples) <- gsub("^\\.", "", names(resamples))
 

--- a/R/train_recipes.R
+++ b/R/train_recipes.R
@@ -1,26 +1,30 @@
-
 #' @export
-predict.train.recipe <- function(object,
-                                 newdata = stop("Please provide `newdata`"),
-                                 type = "raw",
-                                 ...) {
+predict.train.recipe <- function(
+  object,
+  newdata = stop("Please provide `newdata`"),
+  type = "raw",
+  ...
+) {
   if (type == "raw") {
-    predicted <- rec_pred(method = object$modelInfo,
-                          object = list(fit = object$finalModel,
-                                        recipe = object$recipe),
-                          newdata = newdata)
+    predicted <- rec_pred(
+      method = object$modelInfo,
+      object = list(fit = object$finalModel, recipe = object$recipe),
+      newdata = newdata
+    )
     names(predicted) <- NULL
     if (!is.null(object$levels) && all(!is.na(object$levels))) {
-      predicted <- if (attr(object$levels, "ordered"))
+      predicted <- if (attr(object$levels, "ordered")) {
         ordered(as.character(predicted), levels = object$levels)
-      else
+      } else {
         factor(as.character(predicted), levels = object$levels)
+      }
     }
   } else {
-    predicted <- rec_prob(method = object$modelInfo,
-                          object = list(fit = object$finalModel,
-                                        recipe = object$recipe),
-                          newdata = newdata)
+    predicted <- rec_prob(
+      method = object$modelInfo,
+      object = list(fit = object$finalModel, recipe = object$recipe),
+      newdata = newdata
+    )
     predicted <- predicted[, object$levels]
   }
   predicted
@@ -29,10 +33,12 @@ predict.train.recipe <- function(object,
 
 ## drop dimensions from a `tibble`
 get_vector <- function(object) {
-  if(!inherits(object, "tbl_df") && !is.data.frame(object))
+  if (!inherits(object, "tbl_df") && !is.data.frame(object)) {
     return(object)
-  if(ncol(object) > 1)
+  }
+  if (ncol(object) > 1) {
     stop("Only one column should be available")
+  }
   getElement(object, names(object)[1])
 }
 
@@ -46,51 +52,66 @@ role_cols <- function(object, role) {
 preproc_dots <- function(...) {
   dots <- list(...)
   is_pp <- grepl("^preProc", names(dots))
-  if(any(is_pp))
-    warning("When using a recipe with `train`, ",
-            paste0("`", names(dots)[is_pp], "`", collapse = ", "),
-            " will be ignored.",
-            call. = FALSE)
+  if (any(is_pp)) {
+    warning(
+      "When using a recipe with `train`, ",
+      paste0("`", names(dots)[is_pp], "`", collapse = ", "),
+      " will be ignored.",
+      call. = FALSE
+    )
+  }
   invisible(NULL)
 }
 
 
 model_failed <- function(x) {
-  if(inherits(x, "try-error"))
+  if (inherits(x, "try-error")) {
     return(TRUE)
-  if(any(names(x) == "fit"))
-    if(inherits(x$fit, "try-error"))
+  }
+  if (any(names(x) == "fit")) {
+    if (inherits(x$fit, "try-error")) {
       return(TRUE)
-  if(any(names(x) == "recipe"))
-    if(inherits(x$recipe, "try-error"))
+    }
+  }
+  if (any(names(x) == "recipe")) {
+    if (inherits(x$recipe, "try-error")) {
       return(TRUE)
+    }
+  }
   FALSE
 }
 
-pred_failed <- function(x)
+pred_failed <- function(x) {
   inherits(x, "try-error")
+}
 
 ## Convert the recipe to holdout data.
 holdout_rec <- function(object, dat, index) {
   ##
-  ho_data <- bake(object$recipe,
-                  new_data = subset_x(dat, index),
-                  all_outcomes())
+  ho_data <- bake(
+    object$recipe,
+    new_data = subset_x(dat, index),
+    all_outcomes()
+  )
   names(ho_data) <- "obs"
   ## ~~~~~~ move these two to other functions:
   wt_cols <- role_cols(object$recipe, "case weight")
-  if(length(wt_cols) > 0) {
-    wts <- bake(object$recipe,
-                new_data = subset_x(dat, index),
-                has_role("case weight"))
+  if (length(wt_cols) > 0) {
+    wts <- bake(
+      object$recipe,
+      new_data = subset_x(dat, index),
+      has_role("case weight")
+    )
     ho_data$weights <- get_vector(wts)
     rm(wts)
   }
   perf_cols <- role_cols(object$recipe, "performance var")
-  if(length(perf_cols) > 0) {
-    perf_data <- bake(object$recipe,
-                      new_data = subset_x(dat, index),
-                      has_role("performance var"))
+  if (length(perf_cols) > 0) {
+    perf_data <- bake(
+      object$recipe,
+      new_data = subset_x(dat, index),
+      has_role("performance var")
+    )
     ho_data <- cbind(ho_data, perf_data)
   }
   ## ~~~~~~
@@ -99,26 +120,42 @@ holdout_rec <- function(object, dat, index) {
   ho_data <- as.data.frame(ho_data, stringsAsFactors = FALSE)
 }
 
-rec_model <- function(rec, dat, method, tuneValue, obsLevels,
-                      last = FALSE, sampling = NULL, classProbs, ...) {
-
-  if(!is.null(sampling) && sampling$first) {
+rec_model <- function(
+  rec,
+  dat,
+  method,
+  tuneValue,
+  obsLevels,
+  last = FALSE,
+  sampling = NULL,
+  classProbs,
+  ...
+) {
+  if (!is.null(sampling) && sampling$first) {
     ## get original column names for downsamping then reassemble
     ## the training set prior to making the recipe
     var_info <- summary(rec)
     y_cols <- role_cols(rec, "outcome")
     y <- dat[, y_cols]
-    if(length(y_cols) > 1)
+    if (length(y_cols) > 1) {
       stop("`train` doesn't support multivariate outcomes")
-    if(is.data.frame(y)) y <- getElement(y, names(y))
-    other_cols <- var_info[var_info$role %in% c("predictor", "case weight", "performance var"),]
+    }
+    if (is.data.frame(y)) {
+      y <- getElement(y, names(y))
+    }
+    other_cols <- var_info[
+      var_info$role %in% c("predictor", "case weight", "performance var"),
+    ]
 
     other_cols <- other_cols$variable
-    other_dat <- if (is.matrix(dat) ||
-                     (is.data.frame(dat) && !inherits(dat, "tbl_df")))
+    other_dat <- if (
+      is.matrix(dat) ||
+        (is.data.frame(dat) && !inherits(dat, "tbl_df"))
+    ) {
       dat[, other_cols, drop = FALSE]
-    else
+    } else {
       dat[, other_cols]
+    }
 
     tmp <- sampling$func(other_dat, y)
     orig_dat <- dat
@@ -127,41 +164,57 @@ rec_model <- function(rec, dat, method, tuneValue, obsLevels,
     rm(tmp, y, other_cols, other_dat, orig_dat)
   }
 
-  trained_rec <- prep(rec, training = dat, fresh = TRUE,
-                      verbose = FALSE,
-                      retain = TRUE)
+  trained_rec <- prep(
+    rec,
+    training = dat,
+    fresh = TRUE,
+    verbose = FALSE,
+    retain = TRUE
+  )
   x <- juice(trained_rec, all_predictors())
   y <- juice(trained_rec, all_outcomes())
   y <- get_vector(y)
 
   is_weight <- summary(trained_rec)$role == "case weight"
-  if(any(is_weight)) {
-    if(sum(is_weight) > 1)
+  if (any(is_weight)) {
+    if (sum(is_weight) > 1) {
       stop("Ony one column can be used as a case weight.")
+    }
     weights <- juice(trained_rec, has_role("case weight"))
     weights <- get_vector(weights)
-  } else weights <- NULL
+  } else {
+    weights <- NULL
+  }
 
-  if(!is.null(sampling) && !sampling$first) {
+  if (!is.null(sampling) && !sampling$first) {
     tmp <- sampling$func(x, y)
     x <- tmp$x
     y <- tmp$y
     rm(tmp)
   }
 
-  modelFit <- try(method$fit(x = x,
-                         y = y, wts = weights,
-                         param  = tuneValue, lev = obsLevels,
-                         last = last,
-                         classProbs = classProbs, ...),
-                  silent = TRUE)
+  modelFit <- try(
+    method$fit(
+      x = x,
+      y = y,
+      wts = weights,
+      param = tuneValue,
+      lev = obsLevels,
+      last = last,
+      classProbs = classProbs,
+      ...
+    ),
+    silent = TRUE
+  )
 
   ## for models using S4 classes, you can't easily append data, so
   ## exclude these and we'll use other methods to get this information
-  if(is.null(method$label)) method$label <- ""
-  if(!isS4(modelFit) && !model_failed(modelFit)) {
+  if (is.null(method$label)) {
+    method$label <- ""
+  }
+  if (!isS4(modelFit) && !model_failed(modelFit)) {
     modelFit$xNames <- colnames(x)
-    modelFit$problemType <- if(is.factor(y)) "Classification" else "Regression"
+    modelFit$problemType <- if (is.factor(y)) "Classification" else "Regression"
     modelFit$tuneValue <- tuneValue
     modelFit$obsLevels <- obsLevels
     modelFit$param <- list(...)
@@ -170,31 +223,43 @@ rec_model <- function(rec, dat, method, tuneValue, obsLevels,
   list(fit = modelFit, recipe = trained_rec)
 }
 
-rec_pred <- function (method, object, newdata, param = NULL)  {
+rec_pred <- function(method, object, newdata, param = NULL) {
   x <- bake(object$recipe, new_data = newdata, all_predictors())
-  out <- method$predict(modelFit = object$fit, newdata = x,
-                        submodels = param)
-  if(is.matrix(out) || is.data.frame(out))
-    out <- out[,1]
+  out <- method$predict(modelFit = object$fit, newdata = x, submodels = param)
+  if (is.matrix(out) || is.data.frame(out)) {
+    out <- out[, 1]
+  }
   out
 }
 
-rec_prob <- function (method, object, newdata = NULL, param = NULL)  {
+rec_prob <- function(method, object, newdata = NULL, param = NULL) {
   x <- bake(object$recipe, new_data = newdata, all_predictors())
   obsLevels <- levels(object$fit)
-  classProb <- method$prob(modelFit = object$fit, newdata = x,
-                           submodels = param)
+  classProb <- method$prob(
+    modelFit = object$fit,
+    newdata = x,
+    submodels = param
+  )
   if (!is.data.frame(classProb) && is.null(param)) {
     classProb <- as.data.frame(classProb, stringsAsFactors = FALSE)
-    if (!is.null(obsLevels))
+    if (!is.null(obsLevels)) {
       classprob <- classProb[, obsLevels]
+    }
   }
   classProb
 }
 
 ## analogous workflows to the originals
-loo_train_rec <- function(rec, dat, info, method,
-                          ctrl, lev, testing = FALSE, ...) {
+loo_train_rec <- function(
+  rec,
+  dat,
+  info,
+  method,
+  ctrl,
+  lev,
+  testing = FALSE,
+  ...
+) {
   loadNamespace("caret")
   loadNamespace("recipes")
 
@@ -204,141 +269,183 @@ loo_train_rec <- function(rec, dat, info, method,
   `%op%` <- getOper(ctrl$allowParallel && getDoParWorkers() > 1)
 
   pkgs <- c("methods", "caret", "recipes")
-  if(!is.null(method$library))
+  if (!is.null(method$library)) {
     pkgs <- c(pkgs, method$library)
+  }
 
-  result <- foreach(iter = seq(along.with = ctrl$index),
-                    .combine = "rbind",
-                    .verbose = FALSE,
-                    .packages = pkgs,
-                    .errorhandling = "stop") %:%
-    foreach(parm = seq_len(nrow(info$loop)),
-            .combine = "rbind",
-            .verbose = FALSE,
-            .packages = pkgs,
-            .errorhandling = "stop") %op% {
+  result <- foreach(
+    iter = seq(along.with = ctrl$index),
+    .combine = "rbind",
+    .verbose = FALSE,
+    .packages = pkgs,
+    .errorhandling = "stop"
+  ) %:%
+    foreach(
+      parm = seq_len(nrow(info$loop)),
+      .combine = "rbind",
+      .verbose = FALSE,
+      .packages = pkgs,
+      .errorhandling = "stop"
+    ) %op%
+    {
+      if (!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds))) {
+        set.seed(ctrl$seeds[[iter]][parm])
+      }
 
-              if(!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds)))
-                set.seed(ctrl$seeds[[iter]][parm])
+      if (testing) {
+        cat("after loops\n")
+      }
+      loadNamespace("caret")
+      if (ctrl$verboseIter) {
+        progress(printed[parm, , drop = FALSE], names(ctrl$index), iter, TRUE)
+      }
 
-              if(testing) cat("after loops\n")
-              loadNamespace("caret")
-              if(ctrl$verboseIter)
-                progress(printed[parm,,drop = FALSE],
-                         names(ctrl$index), iter, TRUE)
+      if (is.null(info$submodels[[parm]]) || nrow(info$submodels[[parm]]) > 0) {
+        submod <- info$submodels[[parm]]
+      } else {
+        submod <- NULL
+      }
 
-              if(is.null(info$submodels[[parm]])
-                 || nrow(info$submodels[[parm]]) > 0) {
-                submod <- info$submodels[[parm]]
-              } else submod <- NULL
+      mod_rec <-
+        try(
+          rec_model(
+            rec,
+            dat[ctrl$index[[iter]], ],
+            method = method,
+            tuneValue = info$loop[parm, , drop = FALSE],
+            obsLevels = lev,
+            classProbs = ctrl$classProbs,
+            sampling = ctrl$sampling,
+            ...
+          ),
+          silent = TRUE
+        )
 
-              mod_rec <-
-                try(
-                  rec_model(rec, dat[ ctrl$index[[iter]], ],
-                            method = method,
-                            tuneValue = info$loop[parm,,drop = FALSE],
-                            obsLevels = lev,
-                            classProbs = ctrl$classProbs,
-                            sampling = ctrl$sampling,
-                            ...),
-                  silent = TRUE)
+      holdoutIndex <- ctrl$indexOut[[iter]]
 
-              holdoutIndex <- ctrl$indexOut[[iter]]
+      if (!model_failed(mod_rec)) {
+        predicted <- try(
+          rec_pred(
+            method = method,
+            object = mod_rec,
+            newdata = subset_x(dat, holdoutIndex),
+            param = submod
+          ),
+          silent = TRUE
+        )
 
-              if(!model_failed(mod_rec)) {
-                predicted <- try(
-                  rec_pred(method = method,
-                           object = mod_rec,
-                           newdata = subset_x(dat, holdoutIndex),
-                           param = submod),
-                  silent = TRUE)
+        if (pred_failed(predicted)) {
+          fail_warning(
+            settings = printed[parm, , drop = FALSE],
+            msg = predicted,
+            where = "predictions",
+            iter = names(ctrl$index)[iter],
+            verb = ctrl$verboseIter
+          )
 
-                if(pred_failed(predicted)) {
-                  fail_warning(settings = printed[parm,,drop = FALSE],
-                               msg  = predicted,
-                               where = "predictions",
-                               iter = names(ctrl$index)[iter],
-                               verb = ctrl$verboseIter)
+          predicted <- fill_failed_pred(index = holdoutIndex, lev = lev, submod)
+        }
+      } else {
+        fail_warning(
+          settings = printed[parm, , drop = FALSE],
+          msg = mod_rec,
+          iter = names(ctrl$index)[iter],
+          verb = ctrl$verboseIter
+        )
+        predicted <- fill_failed_pred(index = holdoutIndex, lev = lev, submod)
+      }
 
-                  predicted <- fill_failed_pred(index = holdoutIndex, lev = lev, submod)
-                }
-              } else {
-                fail_warning(settings = printed[parm,,drop = FALSE],
-                             msg  = mod_rec,
-                             iter = names(ctrl$index)[iter],
-                             verb = ctrl$verboseIter)
-                predicted <- fill_failed_pred(index = holdoutIndex, lev = lev, submod)
-              }
+      if (testing) {
+        print(head(predicted))
+      }
+      if (ctrl$classProbs) {
+        if (!model_failed(mod_rec)) {
+          probValues <- rec_prob(
+            method = method,
+            object = mod_rec,
+            newdata = subset_x(dat, holdoutIndex),
+            param = submod
+          )
+        } else {
+          probValues <- fill_failed_prob(holdoutIndex, lev, submod)
+        }
+        if (testing) print(head(probValues))
+      }
 
-              if(testing) print(head(predicted))
-              if(ctrl$classProbs) {
-                if(!model_failed(mod_rec)) {
-                  probValues <- rec_prob(method = method,
-                                         object = mod_rec,
-                                         newdata = subset_x(dat, holdoutIndex),
-                                         param = submod)
-                } else {
-                  probValues <- fill_failed_prob(holdoutIndex, lev, submod)
-                }
-                if(testing) print(head(probValues))
-              }
+      predicted <- trim_values(predicted, ctrl, is.null(lev))
 
-              predicted <- trim_values(predicted, ctrl, is.null(lev))
+      ##################################
 
-              ##################################
+      ## We'll attach data points/columns to the object used
+      ## to assess holdout performance
 
-              ## We'll attach data points/columns to the object used
-              ## to assess holdout performance
+      ho_data <- holdout_rec(mod_rec, dat, holdoutIndex)
 
-              ho_data <- holdout_rec(mod_rec, dat, holdoutIndex)
+      if (!is.null(info$submodels)) {
+        ## collate the predictions across all the sub-models
+        predicted <- lapply(
+          predicted,
+          function(x, lv, dat) {
+            x <- outcome_conversion(x, lv = lev)
+            dat$pred <- x
+            dat
+          },
+          lv = lev,
+          dat = ho_data
+        )
+        if (testing) {
+          print(head(predicted))
+        }
+        ## same for the class probabilities
+        if (ctrl$classProbs) {
+          for (k in seq(along.with = predicted)) {
+            predicted[[k]] <-
+              cbind(predicted[[k]], probValues[[k]])
+          }
+        }
+        predicted <- do.call("rbind", predicted)
+        allParam <- expandParameters(info$loop[parm, , drop = FALSE], submod)
+        rownames(predicted) <- NULL
+        predicted <- cbind(predicted, allParam)
+        ## if saveDetails then save and export 'predicted'
+      } else {
+        pred_val <- outcome_conversion(predicted, lv = lev)
+        predicted <- ho_data
+        predicted$pred <- pred_val
+        if (ctrl$classProbs) {
+          predicted <- cbind(predicted, probValues)
+        }
+        predicted <- cbind(predicted, info$loop[parm, , drop = FALSE])
+      }
+      if (ctrl$verboseIter) {
+        progress(printed[parm, , drop = FALSE], names(ctrl$index), iter, FALSE)
+      }
 
-              if(!is.null(info$submodels)) {
-                ## collate the predictions across all the sub-models
-                predicted <- lapply(predicted,
-                                    function(x, lv, dat) {
-                                      x <- outcome_conversion(x, lv = lev)
-                                      dat$pred <- x
-                                      dat
-                                    },
-                                    lv = lev,
-                                    dat  = ho_data)
-                if(testing) print(head(predicted))
-                ## same for the class probabilities
-                if(ctrl$classProbs) {
-                  for(k in seq(along.with = predicted)) predicted[[k]] <-
-                      cbind(predicted[[k]], probValues[[k]])
-                }
-                predicted <- do.call("rbind", predicted)
-                allParam <- expandParameters(info$loop[parm,,drop = FALSE], submod)
-                rownames(predicted) <- NULL
-                predicted <- cbind(predicted, allParam)
-                ## if saveDetails then save and export 'predicted'
-              } else {
-                pred_val <- outcome_conversion(predicted, lv = lev)
-                predicted <-  ho_data
-                predicted$pred <- pred_val
-                if(ctrl$classProbs) predicted <- cbind(predicted, probValues)
-                predicted <- cbind(predicted, info$loop[parm,,drop = FALSE])
-              }
-              if(ctrl$verboseIter)
-                progress(printed[parm,,drop = FALSE],
-                         names(ctrl$index), iter, FALSE)
-
-              predicted
-            }
+      predicted
+    }
 
   names(result) <- gsub("^\\.", "", names(result))
-  out <- ddply(result,
-               as.character(method$parameter$parameter),
-               ctrl$summaryFunction,
-               lev = lev,
-               model = method)
+  out <- ddply(
+    result,
+    as.character(method$parameter$parameter),
+    ctrl$summaryFunction,
+    lev = lev,
+    model = method
+  )
   list(performance = out, predictions = result)
 }
 
 
-oob_train_rec <- function(rec, dat, info, method,
-                          ctrl, lev, testing = FALSE, ...) {
+oob_train_rec <- function(
+  rec,
+  dat,
+  info,
+  method,
+  ctrl,
+  lev,
+  testing = FALSE,
+  ...
+) {
   loadNamespace("caret")
   loadNamespace("recipes")
 
@@ -346,35 +453,46 @@ oob_train_rec <- function(rec, dat, info, method,
   colnames(printed) <- gsub("^\\.", "", colnames(printed))
   `%op%` <- getOper(ctrl$allowParallel && getDoParWorkers() > 1)
 
-
   pkgs <- c("methods", "caret", "recipes")
-  if(!is.null(method$library)) pkgs <- c(pkgs, method$library)
+  if (!is.null(method$library)) {
+    pkgs <- c(pkgs, method$library)
+  }
   result <- foreach(
     parm = seq_len(nrow(info$loop)),
     .packages = pkgs,
-    .combine = "rbind") %op%  {
-
+    .combine = "rbind"
+  ) %op%
+    {
       loadNamespace("caret")
-      if(ctrl$verboseIter)
-        progress(printed[parm,,drop = FALSE], "", 1, TRUE)
+      if (ctrl$verboseIter) {
+        progress(printed[parm, , drop = FALSE], "", 1, TRUE)
+      }
 
-      if(!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds)))
+      if (!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds))) {
         set.seed(ctrl$seeds[[1L]][parm])
+      }
 
-      mod <- rec_model(rec, dat,
-                       method = method,
-                       tuneValue = info$loop[parm,,drop = FALSE],
-                       obsLevels = lev,
-                       classProbs = ctrl$classProbs,
-                       sampling = ctrl$sampling,
-                       ...)
+      mod <- rec_model(
+        rec,
+        dat,
+        method = method,
+        tuneValue = info$loop[parm, , drop = FALSE],
+        obsLevels = lev,
+        classProbs = ctrl$classProbs,
+        sampling = ctrl$sampling,
+        ...
+      )
 
       out <- method$oob(mod$fit)
 
-      if(ctrl$verboseIter)
-        progress(printed[parm,,drop = FALSE], "", 1, FALSE)
+      if (ctrl$verboseIter) {
+        progress(printed[parm, , drop = FALSE], "", 1, FALSE)
+      }
 
-      cbind(as.data.frame(t(out), stringsAsFactors = TRUE), info$loop[parm,,drop = FALSE])
+      cbind(
+        as.data.frame(t(out), stringsAsFactors = TRUE),
+        info$loop[parm, , drop = FALSE]
+      )
     }
   names(result) <- gsub("^\\.", "", names(result))
   result
@@ -391,33 +509,47 @@ train_rec <- function(rec, dat, info, method, ctrl, lev, testing = FALSE, ...) {
   ## fitting and predicting the full data set.
 
   resampleIndex <- ctrl$index
-  if(ctrl$method %in% c("boot632", "optimism_boot", "boot_all")) {
+  if (ctrl$method %in% c("boot632", "optimism_boot", "boot_all")) {
     resampleIndex <- c(list("AllData" = rep(0, nrow(dat))), resampleIndex)
-    ctrl$indexOut <- c(list("AllData" = rep(0, nrow(dat))),  ctrl$indexOut)
-    if(!is.null(ctrl$indexExtra))
+    ctrl$indexOut <- c(list("AllData" = rep(0, nrow(dat))), ctrl$indexOut)
+    if (!is.null(ctrl$indexExtra)) {
       ctrl$indexExtra <- c(list("AllData" = NULL), ctrl$indexExtra)
+    }
   }
   `%op%` <- getOper(ctrl$allowParallel && getDoParWorkers() > 1)
-  keep_pred <- isTRUE(ctrl$savePredictions) || ctrl$savePredictions %in% c("all", "final")
+  keep_pred <- isTRUE(ctrl$savePredictions) ||
+    ctrl$savePredictions %in% c("all", "final")
   pkgs <- c("methods", "caret", "recipes")
-  if(!is.null(method$library)) pkgs <- c(pkgs, method$library)
-
+  if (!is.null(method$library)) {
+    pkgs <- c(pkgs, method$library)
+  }
 
   export <- c()
 
-  result <- foreach(iter = seq(along.with = resampleIndex), .combine = "c", .packages = pkgs, .export = export) %:%
-    foreach(parm = seq_len(nrow(info$loop)), .combine = "c", .packages = pkgs, .export = export)  %op% {
-
-      if(!(length(ctrl$seeds) == 1L && is.na(ctrl$seeds)))
+  result <- foreach(
+    iter = seq(along.with = resampleIndex),
+    .combine = "c",
+    .packages = pkgs,
+    .export = export
+  ) %:%
+    foreach(
+      parm = seq_len(nrow(info$loop)),
+      .combine = "c",
+      .packages = pkgs,
+      .export = export
+    ) %op%
+    {
+      if (!(length(ctrl$seeds) == 1L && is.na(ctrl$seeds))) {
         set.seed(ctrl$seeds[[iter]][parm])
+      }
 
       loadNamespace("caret")
       loadNamespace("recipes")
-      if(ctrl$verboseIter)
-        progress(printed[parm,,drop = FALSE],
-                 names(resampleIndex), iter)
+      if (ctrl$verboseIter) {
+        progress(printed[parm, , drop = FALSE], names(resampleIndex), iter)
+      }
 
-      if(names(resampleIndex)[iter] != "AllData") {
+      if (names(resampleIndex)[iter] != "AllData") {
         modelIndex <- resampleIndex[[iter]]
         holdoutIndex <- ctrl$indexOut[[iter]]
       } else {
@@ -425,61 +557,83 @@ train_rec <- function(rec, dat, info, method, ctrl, lev, testing = FALSE, ...) {
         holdoutIndex <- modelIndex
       }
 
-      if(testing) cat("pre-model\n")
+      if (testing) {
+        cat("pre-model\n")
+      }
 
-      if(!is.null(info$submodels[[parm]]) && nrow(info$submodels[[parm]]) > 0) {
+      if (
+        !is.null(info$submodels[[parm]]) && nrow(info$submodels[[parm]]) > 0
+      ) {
         submod <- info$submodels[[parm]]
-      } else submod <- NULL
+      } else {
+        submod <- NULL
+      }
 
       mod_rec <- try(
-        rec_model(rec,
-                  subset_x(dat, modelIndex),
-                  method = method,
-                  tuneValue = info$loop[parm,,drop = FALSE],
-                  obsLevels = lev,
-                  classProbs = ctrl$classProbs,
-                  sampling = ctrl$sampling,
-                  ...),
-        silent = TRUE)
-      if(testing) print(mod_rec)
+        rec_model(
+          rec,
+          subset_x(dat, modelIndex),
+          method = method,
+          tuneValue = info$loop[parm, , drop = FALSE],
+          obsLevels = lev,
+          classProbs = ctrl$classProbs,
+          sampling = ctrl$sampling,
+          ...
+        ),
+        silent = TRUE
+      )
+      if (testing) {
+        print(mod_rec)
+      }
 
-      if(!model_failed(mod_rec)) {
+      if (!model_failed(mod_rec)) {
         predicted <- try(
-          rec_pred(method = method,
-                   object = mod_rec,
-                   newdata = subset_x(dat, holdoutIndex),
-                   param = submod),
-          silent = TRUE)
+          rec_pred(
+            method = method,
+            object = mod_rec,
+            newdata = subset_x(dat, holdoutIndex),
+            param = submod
+          ),
+          silent = TRUE
+        )
 
-        if(pred_failed(predicted)) {
-          fail_warning(settings = printed[parm,,drop = FALSE],
-                       msg  = predicted,
-                       where = "predictions",
-                       iter = names(resampleIndex)[iter],
-                       verb = ctrl$verboseIter)
+        if (pred_failed(predicted)) {
+          fail_warning(
+            settings = printed[parm, , drop = FALSE],
+            msg = predicted,
+            where = "predictions",
+            iter = names(resampleIndex)[iter],
+            verb = ctrl$verboseIter
+          )
 
           predicted <- fill_failed_pred(index = holdoutIndex, lev = lev, submod)
         }
       } else {
-        fail_warning(settings = printed[parm,,drop = FALSE],
-                     msg  = mod_rec,
-                     iter = names(resampleIndex)[iter],
-                     verb = ctrl$verboseIter)
+        fail_warning(
+          settings = printed[parm, , drop = FALSE],
+          msg = mod_rec,
+          iter = names(resampleIndex)[iter],
+          verb = ctrl$verboseIter
+        )
         ## setup a dummy results with NA values for all predictions
         predicted <- fill_failed_pred(index = holdoutIndex, lev = lev, submod)
       }
 
-      if(testing) print(head(predicted))
-      if(ctrl$classProbs) {
-        if(!model_failed(mod_rec)) {
-          probValues <- rec_prob(method = method,
-                                 object = mod_rec,
-                                 newdata = subset_x(dat, holdoutIndex),
-                                 param = submod)
+      if (testing) {
+        print(head(predicted))
+      }
+      if (ctrl$classProbs) {
+        if (!model_failed(mod_rec)) {
+          probValues <- rec_prob(
+            method = method,
+            object = mod_rec,
+            newdata = subset_x(dat, holdoutIndex),
+            param = submod
+          )
         } else {
           probValues <- fill_failed_prob(holdoutIndex, lev, submod)
         }
-        if(testing) print(head(probValues))
+        if (testing) print(head(probValues))
       }
 
       ##################################
@@ -492,160 +646,255 @@ train_rec <- function(rec, dat, info, method, ctrl, lev, testing = FALSE, ...) {
       ## TODO what to do when the recipe fails?
       ho_data <- holdout_rec(mod_rec, dat, holdoutIndex)
 
-      if(!is.null(submod)) {
+      if (!is.null(submod)) {
         ## merge the fixed and seq parameter values together
-        allParam <- expandParameters(info$loop[parm,,drop = FALSE], submod)
-        allParam <- allParam[complete.cases(allParam),, drop = FALSE]
+        allParam <- expandParameters(info$loop[parm, , drop = FALSE], submod)
+        allParam <- allParam[complete.cases(allParam), , drop = FALSE]
 
         ## collate the predictions across all the sub-models
-        predicted <- lapply(predicted,
-                            function(x, lv, dat) {
-                              x <- outcome_conversion(x, lv = lev)
-                              dat$pred <- x
-                              dat
-                            },
-                            lv = lev,
-                            dat  = ho_data)
-        if(testing) print(head(predicted))
+        predicted <- lapply(
+          predicted,
+          function(x, lv, dat) {
+            x <- outcome_conversion(x, lv = lev)
+            dat$pred <- x
+            dat
+          },
+          lv = lev,
+          dat = ho_data
+        )
+        if (testing) {
+          print(head(predicted))
+        }
 
         ## same for the class probabilities
-        if(ctrl$classProbs) predicted <- mapply(cbind, predicted, probValues, SIMPLIFY = FALSE)
+        if (ctrl$classProbs) {
+          predicted <- mapply(cbind, predicted, probValues, SIMPLIFY = FALSE)
+        }
 
-        if(keep_pred) {
+        if (keep_pred) {
           tmpPred <- predicted
-          for(modIndex in seq(along.with = tmpPred)) {
-            tmpPred[[modIndex]] <- merge(tmpPred[[modIndex]],
-                                         allParam[modIndex,,drop = FALSE],
-                                         all = TRUE)
+          for (modIndex in seq(along.with = tmpPred)) {
+            tmpPred[[modIndex]] <- merge(
+              tmpPred[[modIndex]],
+              allParam[modIndex, , drop = FALSE],
+              all = TRUE
+            )
           }
           tmpPred <- rbind.fill(tmpPred)
           tmpPred$Resample <- names(resampleIndex)[iter]
-        } else tmpPred <- NULL
+        } else {
+          tmpPred <- NULL
+        }
 
         ## get the performance for this resample for each sub-model
-        thisResample <- lapply(predicted,
-                               ctrl$summaryFunction,
-                               lev = lev,
-                               model = method)
-        if(testing) print(head(thisResample))
+        thisResample <- lapply(
+          predicted,
+          ctrl$summaryFunction,
+          lev = lev,
+          model = method
+        )
+        if (testing) {
+          print(head(thisResample))
+        }
 
         ## for classification, add the cell counts
-        if(length(lev) > 1 && length(lev) <= 50) {
-          cells <- lapply(predicted,
-                          function(x) flatTable(x$pred, x$obs))
-          for(ind in seq(along.with = cells))
+        if (length(lev) > 1 && length(lev) <= 50) {
+          cells <- lapply(predicted, function(x) flatTable(x$pred, x$obs))
+          for (ind in seq(along.with = cells)) {
             thisResample[[ind]] <- c(thisResample[[ind]], cells[[ind]])
+          }
         }
         thisResample <- do.call("rbind", thisResample)
         thisResample <- cbind(allParam, thisResample)
-
       } else {
         pred_val <- outcome_conversion(predicted, lv = lev)
-        tmp <-  ho_data
+        tmp <- ho_data
         tmp$pred <- pred_val
-        if(ctrl$classProbs) tmp <- cbind(tmp, probValues)
+        if (ctrl$classProbs) {
+          tmp <- cbind(tmp, probValues)
+        }
 
-        if(keep_pred) {
+        if (keep_pred) {
           tmpPred <- tmp
           tmpPred$rowIndex <- holdoutIndex
-          tmpPred <- merge(tmpPred, info$loop[parm,,drop = FALSE],
-                           all = TRUE)
+          tmpPred <- merge(tmpPred, info$loop[parm, , drop = FALSE], all = TRUE)
           tmpPred$Resample <- names(resampleIndex)[iter]
-        } else tmpPred <- NULL
+        } else {
+          tmpPred <- NULL
+        }
 
         ##################################
 
-        thisResample <- ctrl$summaryFunction(tmp,
-                                             lev = lev,
-                                             model = method)
+        thisResample <- ctrl$summaryFunction(tmp, lev = lev, model = method)
 
         ## if classification, get the confusion matrix
-        if(length(lev) > 1 && length(lev) <= 50)
+        if (length(lev) > 1 && length(lev) <= 50) {
           thisResample <- c(thisResample, flatTable(tmp$pred, tmp$obs))
+        }
         thisResample <- as.data.frame(t(thisResample), stringsAsFactors = FALSE)
-        thisResample <- cbind(thisResample, info$loop[parm,,drop = FALSE])
+        thisResample <- cbind(thisResample, info$loop[parm, , drop = FALSE])
       }
       thisResample$Resample <- names(resampleIndex)[iter]
 
-      thisResampleExtra <- optimism_rec(ctrl, dat, iter, lev, method, mod_rec, predicted,
-                                        submod, info$loop[parm,, drop = FALSE])
+      thisResampleExtra <- optimism_rec(
+        ctrl,
+        dat,
+        iter,
+        lev,
+        method,
+        mod_rec,
+        predicted,
+        submod,
+        info$loop[parm, , drop = FALSE]
+      )
 
-      if(ctrl$verboseIter)
-        progress(printed[parm,,drop = FALSE],
-                 names(resampleIndex), iter, FALSE)
+      if (ctrl$verboseIter) {
+        progress(
+          printed[parm, , drop = FALSE],
+          names(resampleIndex),
+          iter,
+          FALSE
+        )
+      }
 
-      if(testing) print(thisResample)
-      list(resamples = thisResample, pred = tmpPred, resamplesExtra = thisResampleExtra)
+      if (testing) {
+        print(thisResample)
+      }
+      list(
+        resamples = thisResample,
+        pred = tmpPred,
+        resamplesExtra = thisResampleExtra
+      )
     }
 
   resamples <- rbind.fill(result[names(result) == "resamples"])
   pred <- rbind.fill(result[names(result) == "pred"])
   resamplesExtra <- rbind.fill(result[names(result) == "resamplesExtra"])
-  if(ctrl$method %in% c("boot632", "optimism_boot", "boot_all")) {
+  if (ctrl$method %in% c("boot632", "optimism_boot", "boot_all")) {
     perfNames <- names(resamples)
-    perfNames <- perfNames[!(perfNames %in% c("Resample", as.character(method$parameters$parameter)))]
+    perfNames <- perfNames[
+      !(perfNames %in% c("Resample", as.character(method$parameters$parameter)))
+    ]
     perfNames <- perfNames[!grepl("^\\.cell[0-9]", perfNames)]
     apparent <- subset(resamples, Resample == "AllData")
-    apparent <- apparent[,!grepl("^\\.cell|Resample", colnames(apparent)), drop = FALSE]
+    apparent <- apparent[,
+      !grepl("^\\.cell|Resample", colnames(apparent)),
+      drop = FALSE
+    ]
     names(apparent)[which(names(apparent) %in% perfNames)] <-
-      paste(names(apparent)[which(names(apparent) %in% perfNames)], "Apparent", sep = "")
+      paste(
+        names(apparent)[which(names(apparent) %in% perfNames)],
+        "Apparent",
+        sep = ""
+      )
     names(apparent) <- gsub("^\\.", "", names(apparent))
-    if(any(!complete.cases(apparent[,!grepl("^cell|Resample", colnames(apparent)), drop = FALSE])))
+    if (
+      any(
+        !complete.cases(apparent[,
+          !grepl("^cell|Resample", colnames(apparent)),
+          drop = FALSE
+        ])
+      )
+    ) {
       warning("There were missing values in the apparent performance measures.")
+    }
 
     resamples <- subset(resamples, Resample != "AllData")
-    if(!is.null(pred)) {
+    if (!is.null(pred)) {
       predHat <- subset(pred, Resample == "AllData")
       pred <- subset(pred, Resample != "AllData")
     }
   }
   names(resamples) <- gsub("^\\.", "", names(resamples))
 
-  if(any(!complete.cases(resamples[,!grepl("^cell|Resample", colnames(resamples)), drop = FALSE])))
+  if (
+    any(
+      !complete.cases(resamples[,
+        !grepl("^cell|Resample", colnames(resamples)),
+        drop = FALSE
+      ])
+    )
+  ) {
     warning("There were missing values in resampled performance measures.")
+  }
 
-  out <- ddply(resamples[,!grepl("^cell|Resample", colnames(resamples)), drop = FALSE],
-               ## TODO check this for seq models
-               gsub("^\\.", "", colnames(info$loop)),
-               MeanSD,
-               exclude = gsub("^\\.", "", colnames(info$loop)))
+  out <- ddply(
+    resamples[, !grepl("^cell|Resample", colnames(resamples)), drop = FALSE],
+    ## TODO check this for seq models
+    gsub("^\\.", "", colnames(info$loop)),
+    MeanSD,
+    exclude = gsub("^\\.", "", colnames(info$loop))
+  )
 
-  if(ctrl$method %in% c("boot632", "boot_all")) {
+  if (ctrl$method %in% c("boot632", "boot_all")) {
     out <- merge(out, apparent)
     const <- 1 - exp(-1)
     sapply(perfNames, function(perfName) {
-      perfOut <- if(ctrl$method == "boot_all") paste0(perfName, "_632") else perfName
-      out[, perfOut] <<- (const * out[, perfName]) +  ((1-const) * out[, paste(perfName, "Apparent", sep = "")])
+      perfOut <- if (ctrl$method == "boot_all") {
+        paste0(perfName, "_632")
+      } else {
+        perfName
+      }
+      out[, perfOut] <<- (const * out[, perfName]) +
+        ((1 - const) * out[, paste(perfName, "Apparent", sep = "")])
       NULL
     })
   }
 
-  if(ctrl$method %in% c("optimism_boot", "boot_all")) {
+  if (ctrl$method %in% c("optimism_boot", "boot_all")) {
     out <- merge(out, apparent)
-    out <- merge(out, ddply(resamplesExtra[, !grepl("Resample", colnames(resamplesExtra)), drop = FALSE],
-                            colnames(info$loop),
-                            function(df, exclude) {
-                              colMeans(df[, setdiff(colnames(df), exclude), drop = FALSE])
-                            },
-                            exclude = colnames(info$loop)))
+    out <- merge(
+      out,
+      ddply(
+        resamplesExtra[,
+          !grepl("Resample", colnames(resamplesExtra)),
+          drop = FALSE
+        ],
+        colnames(info$loop),
+        function(df, exclude) {
+          colMeans(df[, setdiff(colnames(df), exclude), drop = FALSE])
+        },
+        exclude = colnames(info$loop)
+      )
+    )
     sapply(perfNames, function(perfName) {
-      optimism <- out[ , paste0(perfName, "Orig")] - out[ , paste0(perfName, "Boot")]
-      final_estimate <- out[ , paste0(perfName, "Apparent")] + optimism
+      optimism <- out[, paste0(perfName, "Orig")] -
+        out[, paste0(perfName, "Boot")]
+      final_estimate <- out[, paste0(perfName, "Apparent")] + optimism
       ## Remove unnecessary values
-      out[ , paste0(perfName, "Orig")] <<- NULL
-      out[ , paste0(perfName, "Boot")] <<- NULL
-      perfOut <- if(ctrl$method == "boot_all") paste0(perfName, "_OptBoot") else perfName
+      out[, paste0(perfName, "Orig")] <<- NULL
+      out[, paste0(perfName, "Boot")] <<- NULL
+      perfOut <- if (ctrl$method == "boot_all") {
+        paste0(perfName, "_OptBoot")
+      } else {
+        perfName
+      }
       ## Update estimates
-      out[ , paste0(perfName, "Optimism")] <<- optimism
-      out[ , perfOut] <<- final_estimate
+      out[, paste0(perfName, "Optimism")] <<- optimism
+      out[, perfOut] <<- final_estimate
       NULL
     })
   }
 
-  list(performance = out, resamples = resamples, predictions = if(keep_pred) pred else NULL)
+  list(
+    performance = out,
+    resamples = resamples,
+    predictions = if (keep_pred) pred else NULL
+  )
 }
 
-train_adapt_rec <- function(rec, dat, info, method, ctrl, lev, metric, maximize, testing = FALSE, ...) {
+train_adapt_rec <- function(
+  rec,
+  dat,
+  info,
+  method,
+  ctrl,
+  lev,
+  metric,
+  maximize,
+  testing = FALSE,
+  ...
+) {
   loadNamespace("caret")
 
   printed <- format(info$loop, digits = 4)
@@ -657,198 +906,265 @@ train_adapt_rec <- function(rec, dat, info, method, ctrl, lev, metric, maximize,
   `%op%` <- getOper(ctrl$allowParallel && getDoParWorkers() > 1)
 
   pkgs <- c("methods", "caret")
-  if(!is.null(method$library)) pkgs <- c(pkgs, method$library)
+  if (!is.null(method$library)) {
+    pkgs <- c(pkgs, method$library)
+  }
 
-  init_index <- seq(along.with = resampleIndex)[1:(ctrl$adaptive$min-1)]
-  extra_index <- seq(along.with = resampleIndex)[-(1:(ctrl$adaptive$min-1))]
+  init_index <- seq(along.with = resampleIndex)[1:(ctrl$adaptive$min - 1)]
+  extra_index <- seq(along.with = resampleIndex)[-(1:(ctrl$adaptive$min - 1))]
 
-  keep_pred <- isTRUE(ctrl$savePredictions) || ctrl$savePredictions %in% c("all", "final")
+  keep_pred <- isTRUE(ctrl$savePredictions) ||
+    ctrl$savePredictions %in% c("all", "final")
 
-  init_result <- foreach(iter = seq(along.with = init_index),
-                         .combine = "c",
-                         .verbose = FALSE,
-                         .packages = pkgs,
-                         .errorhandling = "stop") %:%
-    foreach(parm = seq_len(nrow(info$loop)),
-            .combine = "c",
-            .verbose = FALSE,
-            .packages = pkgs,
-            .errorhandling = "stop")  %op% {
-              testing <- FALSE
-              if(!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds)))
-                set.seed(ctrl$seeds[[iter]][parm])
+  init_result <- foreach(
+    iter = seq(along.with = init_index),
+    .combine = "c",
+    .verbose = FALSE,
+    .packages = pkgs,
+    .errorhandling = "stop"
+  ) %:%
+    foreach(
+      parm = seq_len(nrow(info$loop)),
+      .combine = "c",
+      .verbose = FALSE,
+      .packages = pkgs,
+      .errorhandling = "stop"
+    ) %op%
+    {
+      testing <- FALSE
+      if (!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds))) {
+        set.seed(ctrl$seeds[[iter]][parm])
+      }
 
-              loadNamespace("caret")
-              loadNamespace("recipes")
+      loadNamespace("caret")
+      loadNamespace("recipes")
 
-              if(ctrl$verboseIter)
-                progress(printed[parm,,drop = FALSE],
-                         names(resampleIndex), iter)
+      if (ctrl$verboseIter) {
+        progress(printed[parm, , drop = FALSE], names(resampleIndex), iter)
+      }
 
-              modelIndex <- resampleIndex[[iter]]
-              holdoutIndex <- ctrl$indexOut[[iter]]
+      modelIndex <- resampleIndex[[iter]]
+      holdoutIndex <- ctrl$indexOut[[iter]]
 
-              if(testing) cat("pre-model\n")
+      if (testing) {
+        cat("pre-model\n")
+      }
 
-              if(is.null(info$submodels[[parm]]) || nrow(info$submodels[[parm]]) > 0) {
-                submod <- info$submodels[[parm]]
-              } else submod <- NULL
+      if (is.null(info$submodels[[parm]]) || nrow(info$submodels[[parm]]) > 0) {
+        submod <- info$submodels[[parm]]
+      } else {
+        submod <- NULL
+      }
 
-              mod_rec <- try(
-                rec_model(rec,
-                          subset_x(dat, modelIndex),
-                          method = method,
-                          tuneValue = info$loop[parm,,drop = FALSE],
-                          obsLevels = lev,
-                          classProbs = ctrl$classProbs,
-                          sampling = ctrl$sampling,
-                          ...),
-                silent = TRUE)
+      mod_rec <- try(
+        rec_model(
+          rec,
+          subset_x(dat, modelIndex),
+          method = method,
+          tuneValue = info$loop[parm, , drop = FALSE],
+          obsLevels = lev,
+          classProbs = ctrl$classProbs,
+          sampling = ctrl$sampling,
+          ...
+        ),
+        silent = TRUE
+      )
 
-              if(!model_failed(mod_rec)) {
-                predicted <- try(
-                  rec_pred(method = method,
-                           object = mod_rec,
-                           newdata = subset_x(dat, holdoutIndex),
-                           param = submod),
-                  silent = TRUE)
+      if (!model_failed(mod_rec)) {
+        predicted <- try(
+          rec_pred(
+            method = method,
+            object = mod_rec,
+            newdata = subset_x(dat, holdoutIndex),
+            param = submod
+          ),
+          silent = TRUE
+        )
 
-                if(pred_failed(predicted)) {
-                  fail_warning(settings = printed[parm,,drop = FALSE],
-                               msg  = predicted,
-                               where = "predictions",
-                               iter = names(resampleIndex)[iter],
-                               verb = ctrl$verboseIter)
+        if (pred_failed(predicted)) {
+          fail_warning(
+            settings = printed[parm, , drop = FALSE],
+            msg = predicted,
+            where = "predictions",
+            iter = names(resampleIndex)[iter],
+            verb = ctrl$verboseIter
+          )
 
-                  predicted <- fill_failed_pred(index = holdoutIndex, lev = lev, submod)
-                }
-              } else {
-                fail_warning(settings = printed[parm,,drop = FALSE],
-                             msg  = mod_rec,
-                             iter = names(resampleIndex)[iter],
-                             verb = ctrl$verboseIter)
-                ## setup a dummy results with NA values for all predictions
-                predicted <- fill_failed_pred(index = holdoutIndex, lev = lev, submod)
-              }
+          predicted <- fill_failed_pred(index = holdoutIndex, lev = lev, submod)
+        }
+      } else {
+        fail_warning(
+          settings = printed[parm, , drop = FALSE],
+          msg = mod_rec,
+          iter = names(resampleIndex)[iter],
+          verb = ctrl$verboseIter
+        )
+        ## setup a dummy results with NA values for all predictions
+        predicted <- fill_failed_pred(index = holdoutIndex, lev = lev, submod)
+      }
 
-              if(testing) print(head(predicted))
-              if(ctrl$classProbs) {
-                if(!model_failed(mod_rec)) {
-                  probValues <- rec_prob(method = method,
-                                         object = mod_rec,
-                                         newdata = subset_x(dat, holdoutIndex),
-                                         param = submod)
-                } else {
-                  probValues <- fill_failed_prob(holdoutIndex, lev, submod)
-                }
-                if(testing) print(head(probValues))
-              }
+      if (testing) {
+        print(head(predicted))
+      }
+      if (ctrl$classProbs) {
+        if (!model_failed(mod_rec)) {
+          probValues <- rec_prob(
+            method = method,
+            object = mod_rec,
+            newdata = subset_x(dat, holdoutIndex),
+            param = submod
+          )
+        } else {
+          probValues <- fill_failed_prob(holdoutIndex, lev, submod)
+        }
+        if (testing) print(head(probValues))
+      }
 
-              ##################################
+      ##################################
 
-              predicted <- trim_values(predicted, ctrl, is.null(lev))
+      predicted <- trim_values(predicted, ctrl, is.null(lev))
 
-              ##################################
+      ##################################
 
-              ho_data <- holdout_rec(mod_rec, dat, holdoutIndex)
+      ho_data <- holdout_rec(mod_rec, dat, holdoutIndex)
 
-              ##################################
+      ##################################
 
-              if(!is.null(submod)) {
-                ## merge the fixed and seq parameter values together
-                allParam <- expandParameters(info$loop[parm,,drop = FALSE], info$submodels[[parm]])
-                allParam <- allParam[complete.cases(allParam),, drop = FALSE]
+      if (!is.null(submod)) {
+        ## merge the fixed and seq parameter values together
+        allParam <- expandParameters(
+          info$loop[parm, , drop = FALSE],
+          info$submodels[[parm]]
+        )
+        allParam <- allParam[complete.cases(allParam), , drop = FALSE]
 
-                ## collate the predicitons across all the sub-models
-                predicted <- lapply(predicted,
-                                    function(x, lv, dat) {
-                                      x <- outcome_conversion(x, lv = lev)
-                                      dat$pred <- x
-                                      dat
-                                    },
-                                    lv = lev,
-                                    dat  = ho_data)
-                if(testing) print(head(predicted))
+        ## collate the predicitons across all the sub-models
+        predicted <- lapply(
+          predicted,
+          function(x, lv, dat) {
+            x <- outcome_conversion(x, lv = lev)
+            dat$pred <- x
+            dat
+          },
+          lv = lev,
+          dat = ho_data
+        )
+        if (testing) {
+          print(head(predicted))
+        }
 
-                ## same for the class probabilities
-                if(ctrl$classProbs) {
-                  for(k in seq(along.with = predicted))
-                    predicted[[k]] <- cbind(predicted[[k]], probValues[[k]])
-                }
+        ## same for the class probabilities
+        if (ctrl$classProbs) {
+          for (k in seq(along.with = predicted)) {
+            predicted[[k]] <- cbind(predicted[[k]], probValues[[k]])
+          }
+        }
 
-                if(keep_pred) {
-                  tmpPred <- predicted
-                  for(modIndex in seq(along.with = tmpPred)) {
-                    tmpPred[[modIndex]]$rowIndex <- holdoutIndex
-                    tmpPred[[modIndex]] <- merge(tmpPred[[modIndex]],
-                                                 allParam[modIndex,,drop = FALSE],
-                                                 all = TRUE)
-                  }
-                  tmpPred <- rbind.fill(tmpPred)
-                  tmpPred$Resample <- names(resampleIndex)[iter]
-                } else tmpPred <- NULL
+        if (keep_pred) {
+          tmpPred <- predicted
+          for (modIndex in seq(along.with = tmpPred)) {
+            tmpPred[[modIndex]]$rowIndex <- holdoutIndex
+            tmpPred[[modIndex]] <- merge(
+              tmpPred[[modIndex]],
+              allParam[modIndex, , drop = FALSE],
+              all = TRUE
+            )
+          }
+          tmpPred <- rbind.fill(tmpPred)
+          tmpPred$Resample <- names(resampleIndex)[iter]
+        } else {
+          tmpPred <- NULL
+        }
 
-                ## get the performance for this resample for each sub-model
-                thisResample <- lapply(predicted,
-                                       ctrl$summaryFunction,
-                                       lev = lev,
-                                       model = method)
-                if(testing) print(head(thisResample))
-                ## for classification, add the cell counts
-                if(length(lev) > 1 && length(lev) <= 50) {
-                  cells <- lapply(predicted,
-                                  function(x) flatTable(x$pred, x$obs))
-                  for(ind in seq(along.with = cells)) thisResample[[ind]] <- c(thisResample[[ind]], cells[[ind]])
-                }
-                thisResample <- do.call("rbind", thisResample)
-                thisResample <- cbind(allParam, thisResample)
+        ## get the performance for this resample for each sub-model
+        thisResample <- lapply(
+          predicted,
+          ctrl$summaryFunction,
+          lev = lev,
+          model = method
+        )
+        if (testing) {
+          print(head(thisResample))
+        }
+        ## for classification, add the cell counts
+        if (length(lev) > 1 && length(lev) <= 50) {
+          cells <- lapply(predicted, function(x) flatTable(x$pred, x$obs))
+          for (ind in seq(along.with = cells)) {
+            thisResample[[ind]] <- c(thisResample[[ind]], cells[[ind]])
+          }
+        }
+        thisResample <- do.call("rbind", thisResample)
+        thisResample <- cbind(allParam, thisResample)
+      } else {
+        pred_val <- outcome_conversion(predicted, lv = lev)
+        tmp <- ho_data
+        tmp$pred <- pred_val
+        if (ctrl$classProbs) {
+          tmp <- cbind(tmp, probValues)
+        }
 
-              } else {
-                pred_val <- outcome_conversion(predicted, lv = lev)
-                tmp <-  ho_data
-                tmp$pred <- pred_val
-                if(ctrl$classProbs) tmp <- cbind(tmp, probValues)
+        if (keep_pred) {
+          tmpPred <- tmp
+          tmpPred$rowIndex <- holdoutIndex
+          tmpPred$Resample <- names(resampleIndex)[iter]
+        } else {
+          tmpPred <- NULL
+        }
 
-                if(keep_pred) {
-                  tmpPred <- tmp
-                  tmpPred$rowIndex <- holdoutIndex
-                  tmpPred$Resample <- names(resampleIndex)[iter]
-                } else tmpPred <- NULL
+        ##################################
+        thisResample <- ctrl$summaryFunction(tmp, lev = lev, model = method)
 
-                ##################################
-                thisResample <- ctrl$summaryFunction(tmp,
-                                                     lev = lev,
-                                                     model = method)
-
-                ## if classification, get the confusion matrix
-                if(length(lev) > 1 && length(lev) <= 5)
-                  thisResample <- c(thisResample, flatTable(tmp$pred, tmp$obs))
-                thisResample <- as.data.frame(t(thisResample), stringsAsFactors = FALSE)
-                thisResample <- cbind(thisResample, info$loop[parm,,drop = FALSE])
-
-              }
-              thisResample$Resample <- names(resampleIndex)[iter]
-              if(ctrl$verboseIter) progress(printed[parm,,drop = FALSE],
-                                            names(resampleIndex), iter, FALSE)
-              list(resamples = thisResample, pred = tmpPred)
-            } ## end initial loop over resamples and models
-
+        ## if classification, get the confusion matrix
+        if (length(lev) > 1 && length(lev) <= 5) {
+          thisResample <- c(thisResample, flatTable(tmp$pred, tmp$obs))
+        }
+        thisResample <- as.data.frame(t(thisResample), stringsAsFactors = FALSE)
+        thisResample <- cbind(thisResample, info$loop[parm, , drop = FALSE])
+      }
+      thisResample$Resample <- names(resampleIndex)[iter]
+      if (ctrl$verboseIter) {
+        progress(
+          printed[parm, , drop = FALSE],
+          names(resampleIndex),
+          iter,
+          FALSE
+        )
+      }
+      list(resamples = thisResample, pred = tmpPred)
+    } ## end initial loop over resamples and models
 
   init_resamp <- rbind.fill(init_result[names(init_result) == "resamples"])
-  init_pred <- if(keep_pred)  rbind.fill(init_result[names(init_result) == "pred"]) else NULL
+  init_pred <- if (keep_pred) {
+    rbind.fill(init_result[names(init_result) == "pred"])
+  } else {
+    NULL
+  }
   names(init_resamp) <- gsub("^\\.", "", names(init_resamp))
-  if(any(!complete.cases(init_resamp[,!grepl("^cell|Resample", colnames(init_resamp)),drop = FALSE])))
+  if (
+    any(
+      !complete.cases(init_resamp[,
+        !grepl("^cell|Resample", colnames(init_resamp)),
+        drop = FALSE
+      ])
+    )
+  ) {
     warning("There were missing values in resampled performance measures.")
+  }
 
-  init_summary <- ddply(init_resamp[,!grepl("^cell|Resample", colnames(init_resamp)),drop = FALSE],
-                        gsub("^\\.", "", colnames(info$loop)),
-                        MeanSD,
-                        exclude = gsub("^\\.", "", colnames(info$loop)))
+  init_summary <- ddply(
+    init_resamp[,
+      !grepl("^cell|Resample", colnames(init_resamp)),
+      drop = FALSE
+    ],
+    gsub("^\\.", "", colnames(info$loop)),
+    MeanSD,
+    exclude = gsub("^\\.", "", colnames(info$loop))
+  )
 
   new_info <- info
   num_left <- Inf
-  for(iter in ctrl$adaptive$min:length(resampleIndex)) {
-    if(num_left > 1) {
+  for (iter in ctrl$adaptive$min:length(resampleIndex)) {
+    if (num_left > 1) {
       modelIndex <- resampleIndex[[iter]]
       holdoutIndex <- ctrl$indexOut[[iter]]
 
@@ -856,199 +1172,280 @@ train_adapt_rec <- function(rec, dat, info, method, ctrl, lev, metric, maximize,
       colnames(printed) <- gsub("^\\.", "", colnames(printed))
 
       adapt_results <-
-        foreach(parm = seq_len(nrow(new_info$loop)),
-                .combine = "c",
-                .verbose = FALSE,
-                .packages = c("methods", "caret"),
-                .errorhandling = "stop")  %op%  {
+        foreach(
+          parm = seq_len(nrow(new_info$loop)),
+          .combine = "c",
+          .verbose = FALSE,
+          .packages = c("methods", "caret"),
+          .errorhandling = "stop"
+        ) %op%
+        {
+          if (ctrl$verboseIter) {
+            progress(
+              printed[parm, , drop = FALSE],
+              names(resampleIndex),
+              iter,
+              TRUE
+            )
+          }
 
+          if (
+            is.null(new_info$submodels[[parm]]) ||
+              nrow(new_info$submodels[[parm]]) > 0
+          ) {
+            submod <- new_info$submodels[[parm]]
+          } else {
+            submod <- NULL
+          }
 
-                  if(ctrl$verboseIter)
-                    progress(printed[parm,,drop = FALSE],
-                             names(resampleIndex), iter, TRUE)
+          mod_rec <- try(
+            rec_model(
+              rec,
+              subset_x(dat, modelIndex),
+              method = method,
+              tuneValue = new_info$loop[parm, , drop = FALSE],
+              obsLevels = lev,
+              classProbs = ctrl$classProbs,
+              sampling = ctrl$sampling,
+              ...
+            ),
+            silent = TRUE
+          )
 
-                  if(is.null(new_info$submodels[[parm]]) || nrow(new_info$submodels[[parm]]) > 0) {
-                    submod <- new_info$submodels[[parm]]
-                  } else submod <- NULL
+          if (!model_failed(mod_rec)) {
+            predicted <- try(
+              rec_pred(
+                method = method,
+                object = mod_rec,
+                newdata = subset_x(dat, holdoutIndex),
+                param = submod
+              ),
+              silent = TRUE
+            )
 
-                  mod_rec <- try(
-                    rec_model(rec,
-                              subset_x(dat, modelIndex),
-                              method = method,
-                              tuneValue = new_info$loop[parm,,drop = FALSE],
-                              obsLevels = lev,
-                              classProbs = ctrl$classProbs,
-                              sampling = ctrl$sampling,
-                              ...),
-                    silent = TRUE)
+            if (pred_failed(predicted)) {
+              fail_warning(
+                settings = printed[parm, , drop = FALSE],
+                msg = predicted,
+                where = "predictions",
+                iter = names(resampleIndex)[iter],
+                verb = ctrl$verboseIter
+              )
 
-                  if(!model_failed(mod_rec)) {
-                    predicted <- try(
-                      rec_pred(method = method,
-                               object = mod_rec,
-                               newdata = subset_x(dat, holdoutIndex),
-                               param = submod),
-                      silent = TRUE)
+              predicted <- fill_failed_pred(
+                index = holdoutIndex,
+                lev = lev,
+                submod
+              )
+            }
+          } else {
+            fail_warning(
+              settings = printed[parm, , drop = FALSE],
+              msg = mod_rec,
+              iter = names(resampleIndex)[iter],
+              verb = ctrl$verboseIter
+            )
+            ## setup a dummy results with NA values for all predictions
+            predicted <- fill_failed_pred(
+              index = holdoutIndex,
+              lev = lev,
+              submod
+            )
+          }
 
-                    if(pred_failed(predicted)) {
-                      fail_warning(settings = printed[parm,,drop = FALSE],
-                                   msg  = predicted,
-                                   where = "predictions",
-                                   iter = names(resampleIndex)[iter],
-                                   verb = ctrl$verboseIter)
+          if (testing) {
+            print(head(predicted))
+          }
+          if (ctrl$classProbs) {
+            if (!model_failed(mod_rec)) {
+              probValues <- rec_prob(
+                method = method,
+                object = mod_rec,
+                newdata = subset_x(dat, holdoutIndex),
+                param = submod
+              )
+            } else {
+              probValues <- fill_failed_prob(holdoutIndex, lev, submod)
+            }
+            if (testing) print(head(probValues))
+          }
 
-                      predicted <- fill_failed_pred(index = holdoutIndex, lev = lev, submod)
-                    }
-                  } else {
-                    fail_warning(settings = printed[parm,,drop = FALSE],
-                                 msg  = mod_rec,
-                                 iter = names(resampleIndex)[iter],
-                                 verb = ctrl$verboseIter)
-                    ## setup a dummy results with NA values for all predictions
-                    predicted <- fill_failed_pred(index = holdoutIndex, lev = lev, submod)
-                  }
+          ##################################
 
-                  if(testing) print(head(predicted))
-                  if(ctrl$classProbs) {
-                    if(!model_failed(mod_rec)) {
-                      probValues <- rec_prob(method = method,
-                                             object = mod_rec,
-                                             newdata = subset_x(dat, holdoutIndex),
-                                             param = submod)
-                    } else {
-                      probValues <- fill_failed_prob(holdoutIndex, lev, submod)
-                    }
-                    if(testing) print(head(probValues))
-                  }
+          predicted <- trim_values(predicted, ctrl, is.null(lev))
 
-                  ##################################
+          ##################################
 
-                  predicted <- trim_values(predicted, ctrl, is.null(lev))
+          ho_data <- holdout_rec(mod_rec, dat, holdoutIndex)
 
-                  ##################################
+          ##################################
 
-                  ho_data <- holdout_rec(mod_rec, dat, holdoutIndex)
+          if (!is.null(submod)) {
+            ## merge the fixed and seq parameter values together
+            allParam <- expandParameters(
+              new_info$loop[parm, , drop = FALSE],
+              submod
+            )
+            allParam <- allParam[complete.cases(allParam), , drop = FALSE]
 
-                  ##################################
+            ## collate the predicitons across all the sub-models
+            predicted <- lapply(
+              predicted,
+              function(x, lv, dat) {
+                x <- outcome_conversion(x, lv = lev)
+                dat$pred <- x
+                dat
+              },
+              lv = lev,
+              dat = ho_data
+            )
 
-                  if(!is.null(submod)) {
-                    ## merge the fixed and seq parameter values together
-                    allParam <- expandParameters(new_info$loop[parm,,drop = FALSE],
-                                                 submod)
-                    allParam <- allParam[complete.cases(allParam),, drop = FALSE]
+            if (testing) {
+              print(head(predicted))
+            }
 
-                    ## collate the predicitons across all the sub-models
-                    predicted <- lapply(predicted,
-                                        function(x, lv, dat) {
-                                          x <- outcome_conversion(x, lv = lev)
-                                          dat$pred <- x
-                                          dat
-                                        },
-                                        lv = lev,
-                                        dat  = ho_data)
+            ## same for the class probabilities
+            if (ctrl$classProbs) {
+              for (k in seq(along.with = predicted)) {
+                predicted[[k]] <- cbind(predicted[[k]], probValues[[k]])
+              }
+            }
 
-                    if(testing) print(head(predicted))
+            if (keep_pred) {
+              tmpPred <- predicted
+              for (modIndex in seq(along.with = tmpPred)) {
+                tmpPred[[modIndex]]$rowIndex <- holdoutIndex
+                tmpPred[[modIndex]] <- merge(
+                  tmpPred[[modIndex]],
+                  allParam[modIndex, , drop = FALSE],
+                  all = TRUE
+                )
+              }
+              tmpPred <- rbind.fill(tmpPred)
+              tmpPred$Resample <- names(resampleIndex)[iter]
+            } else {
+              tmpPred <- NULL
+            }
 
-                    ## same for the class probabilities
-                    if(ctrl$classProbs) {
-                      for(k in seq(along.with = predicted))
-                        predicted[[k]] <- cbind(predicted[[k]], probValues[[k]])
-                    }
+            ## get the performance for this resample for each sub-model
+            thisResample <- lapply(
+              predicted,
+              ctrl$summaryFunction,
+              lev = lev,
+              model = method
+            )
+            if (testing) {
+              print(head(thisResample))
+            }
+            ## for classification, add the cell counts
+            if (length(lev) > 1 && length(lev) <= 50) {
+              cells <- lapply(predicted, function(x) flatTable(x$pred, x$obs))
+              for (ind in seq(along.with = cells)) {
+                thisResample[[ind]] <- c(thisResample[[ind]], cells[[ind]])
+              }
+            }
+            thisResample <- do.call("rbind", thisResample)
+            thisResample <- cbind(allParam, thisResample)
+          } else {
+            pred_val <- outcome_conversion(predicted, lv = lev)
+            tmp <- ho_data
+            tmp$pred <- pred_val
+            if (ctrl$classProbs) {
+              tmp <- cbind(tmp, probValues)
+            }
 
-                    if(keep_pred) {
-                      tmpPred <- predicted
-                      for(modIndex in seq(along.with = tmpPred)) {
-                        tmpPred[[modIndex]]$rowIndex <- holdoutIndex
-                        tmpPred[[modIndex]] <- merge(tmpPred[[modIndex]],
-                                                     allParam[modIndex,,drop = FALSE],
-                                                     all = TRUE)
-                      }
-                      tmpPred <- rbind.fill(tmpPred)
-                      tmpPred$Resample <- names(resampleIndex)[iter]
-                    } else tmpPred <- NULL
+            if (keep_pred) {
+              tmpPred <- tmp
+              tmpPred$rowIndex <- holdoutIndex
+              tmpPred <- merge(
+                tmpPred,
+                new_info$loop[parm, , drop = FALSE],
+                all = TRUE
+              )
+              tmpPred$Resample <- names(resampleIndex)[iter]
+            } else {
+              tmpPred <- NULL
+            }
 
-                    ## get the performance for this resample for each sub-model
-                    thisResample <- lapply(predicted,
-                                           ctrl$summaryFunction,
-                                           lev = lev,
-                                           model = method)
-                    if(testing) print(head(thisResample))
-                    ## for classification, add the cell counts
-                    if(length(lev) > 1 && length(lev) <= 50) {
-                      cells <- lapply(predicted,
-                                      function(x) flatTable(x$pred, x$obs))
-                      for(ind in seq(along.with = cells))
-                        thisResample[[ind]] <- c(thisResample[[ind]], cells[[ind]])
-                    }
-                    thisResample <- do.call("rbind", thisResample)
-                    thisResample <- cbind(allParam, thisResample)
+            ##################################
+            thisResample <- ctrl$summaryFunction(tmp, lev = lev, model = method)
 
-                  } else {
-                    pred_val <- outcome_conversion(predicted, lv = lev)
-                    tmp <-  ho_data
-                    tmp$pred <- pred_val
-                    if(ctrl$classProbs) tmp <- cbind(tmp, probValues)
-
-                    if(keep_pred) {
-                      tmpPred <- tmp
-                      tmpPred$rowIndex <- holdoutIndex
-                      tmpPred <- merge(tmpPred, new_info$loop[parm,,drop = FALSE],
-                                       all = TRUE)
-                      tmpPred$Resample <- names(resampleIndex)[iter]
-                    } else tmpPred <- NULL
-
-                    ##################################
-                    thisResample <- ctrl$summaryFunction(tmp,
-                                                         lev = lev,
-                                                         model = method)
-
-                    ## if classification, get the confusion matrix
-                    if(length(lev) > 1 && length(lev) <= 50)
-                      thisResample <- c(thisResample, flatTable(tmp$pred, tmp$obs))
-                    thisResample <- as.data.frame(t(thisResample), stringsAsFactors = FALSE)
-                    thisResample <- cbind(thisResample, new_info$loop[parm,,drop = FALSE])
-
-                  }
-                  thisResample$Resample <- names(resampleIndex)[iter]
-                  if(ctrl$verboseIter) progress(printed[parm,,drop = FALSE],
-                                                names(resampleIndex), iter, FALSE)
-                  list(resamples = thisResample, pred = tmpPred)
-                } ## end initial loop over resamples and models
-
+            ## if classification, get the confusion matrix
+            if (length(lev) > 1 && length(lev) <= 50) {
+              thisResample <- c(thisResample, flatTable(tmp$pred, tmp$obs))
+            }
+            thisResample <- as.data.frame(
+              t(thisResample),
+              stringsAsFactors = FALSE
+            )
+            thisResample <- cbind(
+              thisResample,
+              new_info$loop[parm, , drop = FALSE]
+            )
+          }
+          thisResample$Resample <- names(resampleIndex)[iter]
+          if (ctrl$verboseIter) {
+            progress(
+              printed[parm, , drop = FALSE],
+              names(resampleIndex),
+              iter,
+              FALSE
+            )
+          }
+          list(resamples = thisResample, pred = tmpPred)
+        } ## end initial loop over resamples and models
     }
 
     init_result <- c(init_result, adapt_results)
     rs <- do.call("rbind", init_result[names(init_result) == "resamples"])
 
     current_mods <- get_id(rs, as.character(method$param$parameter))
-    if(iter > ctrl$adaptive$min) {
-      latest <- do.call("rbind", adapt_results[names(adapt_results) == "resamples"])
-      latest <- latest[,as.character(method$param$parameter),drop = FALSE]
-      latest <- latest[!duplicated(latest),,drop = FALSE]
+    if (iter > ctrl$adaptive$min) {
+      latest <- do.call(
+        "rbind",
+        adapt_results[names(adapt_results) == "resamples"]
+      )
+      latest <- latest[, as.character(method$param$parameter), drop = FALSE]
+      latest <- latest[!duplicated(latest), , drop = FALSE]
 
       current_mods <- merge(current_mods, latest)
     }
     rs <- merge(rs, current_mods)
 
-    if(iter == ctrl$adaptive$min+1) {
-      rs <- filter_on_diff(rs, metric,
-                           cutoff = 0.001,
-                           maximize = maximize,
-                           verbose = ctrl$verboseIter)
+    if (iter == ctrl$adaptive$min + 1) {
+      rs <- filter_on_diff(
+        rs,
+        metric,
+        cutoff = 0.001,
+        maximize = maximize,
+        verbose = ctrl$verboseIter
+      )
     }
 
-    if(ctrl$adaptive$method == "BT") {
-      filtered_mods <- try(bt_eval(rs, metric = metric, maximize = maximize,
-                                   alpha = ctrl$adaptive$alpha),
-                           silent = TRUE)
+    if (ctrl$adaptive$method == "BT") {
+      filtered_mods <- try(
+        bt_eval(
+          rs,
+          metric = metric,
+          maximize = maximize,
+          alpha = ctrl$adaptive$alpha
+        ),
+        silent = TRUE
+      )
     } else {
-      filtered_mods <- try(gls_eval(rs, metric = metric, maximize = maximize,
-                                    alpha = ctrl$adaptive$alpha),
-                           silent = TRUE)
+      filtered_mods <- try(
+        gls_eval(
+          rs,
+          metric = metric,
+          maximize = maximize,
+          alpha = ctrl$adaptive$alpha
+        ),
+        silent = TRUE
+      )
     }
 
-    if(class(filtered_mods)[1] == "try-error") {
-      if(ctrl$verboseIter) {
+    if (class(filtered_mods)[1] == "try-error") {
+      if (ctrl$verboseIter) {
         cat("x parameter filtering failed:")
         print(filtered_mods)
         cat("\n")
@@ -1056,229 +1453,321 @@ train_adapt_rec <- function(rec, dat, info, method, ctrl, lev, metric, maximize,
       filtered_mods <- current_mods
     }
 
-    if(ctrl$verboseIter) {
+    if (ctrl$verboseIter) {
       excluded <- unique(rs$model_id)[!(unique(rs$model_id) %in% filtered_mods)]
-      if(length(excluded) > 0) {
+      if (length(excluded) > 0) {
         cat(paste("o", length(excluded), "eliminated;"))
-      } else cat("o no models eliminated;",
-                 nrow(current_mods),
-                 ifelse(nrow(current_mods) > 1, "remain\n", "remains\n"))
+      } else {
+        cat(
+          "o no models eliminated;",
+          nrow(current_mods),
+          ifelse(nrow(current_mods) > 1, "remain\n", "remains\n")
+        )
+      }
     }
 
-    current_mods <- current_mods[current_mods$model_id %in% filtered_mods,,drop = FALSE]
-    if(iter == ctrl$adaptive$min) {
+    current_mods <- current_mods[
+      current_mods$model_id %in% filtered_mods,
+      ,
+      drop = FALSE
+    ]
+    if (iter == ctrl$adaptive$min) {
       last_mods <- current_mods
     }
     current_mods$model_id <- NULL
     num_left <- nrow(current_mods)
 
-    if(ctrl$verboseIter && length(excluded) > 0)
+    if (ctrl$verboseIter && length(excluded) > 0) {
       cat(num_left, ifelse(num_left > 1, "remain\n", "remains\n"))
+    }
 
-    if(!is.null(method$loop)) {
+    if (!is.null(method$loop)) {
       new_info <- method$loop(current_mods)
-    } else new_info$loop <- current_mods
+    } else {
+      new_info$loop <- current_mods
+    }
 
     last_iter <- iter
 
-    if(num_left == 1) break
+    if (num_left == 1) break
   }
 
   ## finish up last resamples
-  if(ctrl$adaptive$complete && last_iter < length(ctrl$index)) {
+  if (ctrl$adaptive$complete && last_iter < length(ctrl$index)) {
     printed <- format(new_info$loop, digits = 4)
     colnames(printed) <- gsub("^\\.", "", colnames(printed))
 
-    final_index <- seq(along.with = resampleIndex)[(last_iter+1):length(ctrl$index)]
-    final_result <- foreach(iter = final_index,
-                            .combine = "c",
-                            .verbose = FALSE,
-                            .packages = pkgs,
-                            .errorhandling = "stop") %:%
-      foreach(parm = seq_len(nrow(new_info$loop)),
-              .combine = "c",
-              .verbose = FALSE,
-              .packages = pkgs,
-              .errorhandling = "stop")  %op% {
-                testing <- FALSE
-                if(!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds)))
-                  set.seed(ctrl$seeds[[iter]][parm])
+    final_index <- seq(along.with = resampleIndex)[
+      (last_iter + 1):length(ctrl$index)
+    ]
+    final_result <- foreach(
+      iter = final_index,
+      .combine = "c",
+      .verbose = FALSE,
+      .packages = pkgs,
+      .errorhandling = "stop"
+    ) %:%
+      foreach(
+        parm = seq_len(nrow(new_info$loop)),
+        .combine = "c",
+        .verbose = FALSE,
+        .packages = pkgs,
+        .errorhandling = "stop"
+      ) %op%
+      {
+        testing <- FALSE
+        if (!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds))) {
+          set.seed(ctrl$seeds[[iter]][parm])
+        }
 
-                loadNamespace("caret")
-                if(ctrl$verboseIter)
-                  progress(printed[parm,,drop = FALSE],
-                           names(resampleIndex), iter)
+        loadNamespace("caret")
+        if (ctrl$verboseIter) {
+          progress(printed[parm, , drop = FALSE], names(resampleIndex), iter)
+        }
 
-                modelIndex <- resampleIndex[[iter]]
-                holdoutIndex <- ctrl$indexOut[[iter]]
+        modelIndex <- resampleIndex[[iter]]
+        holdoutIndex <- ctrl$indexOut[[iter]]
 
-                if(testing) cat("pre-model\n")
+        if (testing) {
+          cat("pre-model\n")
+        }
 
-                if(is.null(info$submodels[[parm]]) || nrow(info$submodels[[parm]]) > 0) {
-                  submod <- info$submodels[[parm]]
-                } else submod <- NULL
+        if (
+          is.null(info$submodels[[parm]]) || nrow(info$submodels[[parm]]) > 0
+        ) {
+          submod <- info$submodels[[parm]]
+        } else {
+          submod <- NULL
+        }
 
-                mod_rec <- try(
-                  rec_model(rec,
-                            subset_x(dat, modelIndex),
-                            method = method,
-                            tuneValue = new_info$loop[parm,,drop = FALSE],
-                            obsLevels = lev,
-                            classProbs = ctrl$classProbs,
-                            sampling = ctrl$sampling,
-                            ...),
-                  silent = TRUE)
+        mod_rec <- try(
+          rec_model(
+            rec,
+            subset_x(dat, modelIndex),
+            method = method,
+            tuneValue = new_info$loop[parm, , drop = FALSE],
+            obsLevels = lev,
+            classProbs = ctrl$classProbs,
+            sampling = ctrl$sampling,
+            ...
+          ),
+          silent = TRUE
+        )
 
-                if(!model_failed(mod_rec)) {
-                  predicted <- try(
-                    rec_pred(method = method,
-                             object = mod_rec,
-                             newdata = subset_x(dat, holdoutIndex),
-                             param = submod),
-                    silent = TRUE)
+        if (!model_failed(mod_rec)) {
+          predicted <- try(
+            rec_pred(
+              method = method,
+              object = mod_rec,
+              newdata = subset_x(dat, holdoutIndex),
+              param = submod
+            ),
+            silent = TRUE
+          )
 
-                  if(pred_failed(predicted)) {
-                    fail_warning(settings = printed[parm,,drop = FALSE],
-                                 msg  = predicted,
-                                 where = "predictions",
-                                 iter = names(resampleIndex)[iter],
-                                 verb = ctrl$verboseIter)
+          if (pred_failed(predicted)) {
+            fail_warning(
+              settings = printed[parm, , drop = FALSE],
+              msg = predicted,
+              where = "predictions",
+              iter = names(resampleIndex)[iter],
+              verb = ctrl$verboseIter
+            )
 
-                    predicted <- fill_failed_pred(index = holdoutIndex, lev = lev, submod)
-                  }
-                } else {
-                  fail_warning(settings = printed[parm,,drop = FALSE],
-                               msg  = mod_rec,
-                               iter = names(resampleIndex)[iter],
-                               verb = ctrl$verboseIter)
-                  ## setup a dummy results with NA values for all predictions
-                  predicted <- fill_failed_pred(index = holdoutIndex, lev = lev, submod)
-                }
+            predicted <- fill_failed_pred(
+              index = holdoutIndex,
+              lev = lev,
+              submod
+            )
+          }
+        } else {
+          fail_warning(
+            settings = printed[parm, , drop = FALSE],
+            msg = mod_rec,
+            iter = names(resampleIndex)[iter],
+            verb = ctrl$verboseIter
+          )
+          ## setup a dummy results with NA values for all predictions
+          predicted <- fill_failed_pred(index = holdoutIndex, lev = lev, submod)
+        }
 
-                if(testing) print(head(predicted))
-                if(ctrl$classProbs) {
-                  if(!model_failed(mod_rec)) {
-                    probValues <- rec_prob(method = method,
-                                           object = mod_rec,
-                                           newdata = subset_x(dat, holdoutIndex),
-                                           param = submod)
-                  } else {
-                    probValues <- fill_failed_prob(holdoutIndex, lev, submod)
-                  }
-                  if(testing) print(head(probValues))
-                }
-                ##################################
+        if (testing) {
+          print(head(predicted))
+        }
+        if (ctrl$classProbs) {
+          if (!model_failed(mod_rec)) {
+            probValues <- rec_prob(
+              method = method,
+              object = mod_rec,
+              newdata = subset_x(dat, holdoutIndex),
+              param = submod
+            )
+          } else {
+            probValues <- fill_failed_prob(holdoutIndex, lev, submod)
+          }
+          if (testing) print(head(probValues))
+        }
+        ##################################
 
-                predicted <- trim_values(predicted, ctrl, is.null(lev))
+        predicted <- trim_values(predicted, ctrl, is.null(lev))
 
-                ##################################
+        ##################################
 
-                ho_data <- holdout_rec(mod_rec, dat, holdoutIndex)
+        ho_data <- holdout_rec(mod_rec, dat, holdoutIndex)
 
-                ##################################
+        ##################################
 
-                if(!is.null(submod)) {
-                  ## merge the fixed and seq parameter values together
-                  allParam <- expandParameters(new_info$loop[parm,,drop = FALSE],
-                                               new_info$submodels[[parm]])
-                  allParam <- allParam[complete.cases(allParam),, drop = FALSE]
+        if (!is.null(submod)) {
+          ## merge the fixed and seq parameter values together
+          allParam <- expandParameters(
+            new_info$loop[parm, , drop = FALSE],
+            new_info$submodels[[parm]]
+          )
+          allParam <- allParam[complete.cases(allParam), , drop = FALSE]
 
-                  ## collate the predicitons across all the sub-models
-                  predicted <- lapply(predicted,
-                                      function(x, lv, dat) {
-                                        x <- outcome_conversion(x, lv = lev)
-                                        dat$pred <- x
-                                        dat
-                                      },
-                                      lv = lev,
-                                      dat  = ho_data)
-                  if(testing) print(head(predicted))
+          ## collate the predicitons across all the sub-models
+          predicted <- lapply(
+            predicted,
+            function(x, lv, dat) {
+              x <- outcome_conversion(x, lv = lev)
+              dat$pred <- x
+              dat
+            },
+            lv = lev,
+            dat = ho_data
+          )
+          if (testing) {
+            print(head(predicted))
+          }
 
-                  ## same for the class probabilities
-                  if(ctrl$classProbs) {
-                    for(k in seq(along.with = predicted))
-                      predicted[[k]] <- cbind(predicted[[k]], probValues[[k]])
-                  }
+          ## same for the class probabilities
+          if (ctrl$classProbs) {
+            for (k in seq(along.with = predicted)) {
+              predicted[[k]] <- cbind(predicted[[k]], probValues[[k]])
+            }
+          }
 
-                  if(keep_pred) {
-                    tmpPred <- predicted
-                    for(modIndex in seq(along.with = tmpPred)) {
-                      tmpPred[[modIndex]]$rowIndex <- holdoutIndex
-                      tmpPred[[modIndex]] <- merge(tmpPred[[modIndex]],
-                                                   allParam[modIndex,,drop = FALSE],
-                                                   all = TRUE)
-                    }
-                    tmpPred <- rbind.fill(tmpPred)
-                    tmpPred$Resample <- names(resampleIndex)[iter]
-                  } else tmpPred <- NULL
+          if (keep_pred) {
+            tmpPred <- predicted
+            for (modIndex in seq(along.with = tmpPred)) {
+              tmpPred[[modIndex]]$rowIndex <- holdoutIndex
+              tmpPred[[modIndex]] <- merge(
+                tmpPred[[modIndex]],
+                allParam[modIndex, , drop = FALSE],
+                all = TRUE
+              )
+            }
+            tmpPred <- rbind.fill(tmpPred)
+            tmpPred$Resample <- names(resampleIndex)[iter]
+          } else {
+            tmpPred <- NULL
+          }
 
-                  ## get the performance for this resample for each sub-model
-                  thisResample <- lapply(predicted,
-                                         ctrl$summaryFunction,
-                                         lev = lev,
-                                         model = method)
-                  if(testing) print(head(thisResample))
-                  ## for classification, add the cell counts
-                  if(length(lev) > 1 && length(lev) <= 50) {
-                    cells <- lapply(predicted,
-                                    function(x) flatTable(x$pred, x$obs))
-                    for(ind in seq(along.with = cells))
-                      thisResample[[ind]] <- c(thisResample[[ind]], cells[[ind]])
-                  }
-                  thisResample <- do.call("rbind", thisResample)
-                  thisResample <- cbind(allParam, thisResample)
+          ## get the performance for this resample for each sub-model
+          thisResample <- lapply(
+            predicted,
+            ctrl$summaryFunction,
+            lev = lev,
+            model = method
+          )
+          if (testing) {
+            print(head(thisResample))
+          }
+          ## for classification, add the cell counts
+          if (length(lev) > 1 && length(lev) <= 50) {
+            cells <- lapply(predicted, function(x) flatTable(x$pred, x$obs))
+            for (ind in seq(along.with = cells)) {
+              thisResample[[ind]] <- c(thisResample[[ind]], cells[[ind]])
+            }
+          }
+          thisResample <- do.call("rbind", thisResample)
+          thisResample <- cbind(allParam, thisResample)
+        } else {
+          pred_val <- outcome_conversion(predicted, lv = lev)
+          tmp <- ho_data
+          tmp$pred <- pred_val
+          if (ctrl$classProbs) {
+            tmp <- cbind(tmp, probValues)
+          }
 
-                } else {
-                  pred_val <- outcome_conversion(predicted, lv = lev)
-                  tmp <-  ho_data
-                  tmp$pred <- pred_val
-                  if(ctrl$classProbs) tmp <- cbind(tmp, probValues)
+          if (keep_pred) {
+            tmpPred <- tmp
+            tmpPred$rowIndex <- holdoutIndex
+            tmpPred <- merge(
+              tmpPred,
+              new_info$loop[parm, , drop = FALSE],
+              all = TRUE
+            )
+            tmpPred$Resample <- names(resampleIndex)[iter]
+          } else {
+            tmpPred <- NULL
+          }
 
-                  if(keep_pred) {
-                    tmpPred <- tmp
-                    tmpPred$rowIndex <- holdoutIndex
-                    tmpPred <- merge(tmpPred, new_info$loop[parm,,drop = FALSE],
-                                     all = TRUE)
-                    tmpPred$Resample <- names(resampleIndex)[iter]
-                  } else tmpPred <- NULL
+          ##################################
+          thisResample <- ctrl$summaryFunction(tmp, lev = lev, model = method)
 
-                  ##################################
-                  thisResample <- ctrl$summaryFunction(tmp,
-                                                       lev = lev,
-                                                       model = method)
-
-                  ## if classification, get the confusion matrix
-                  if(length(lev) > 1 && length(lev) <= 50)
-                    thisResample <- c(thisResample, flatTable(tmp$pred, tmp$obs))
-                  thisResample <- as.data.frame(t(thisResample), stringsAsFactors = FALSE)
-                  thisResample <- cbind(thisResample, new_info$loop[parm,,drop = FALSE])
-
-                }
-                thisResample$Resample <- names(resampleIndex)[iter]
-                if(ctrl$verboseIter) progress(printed[parm,,drop = FALSE],
-                                              names(resampleIndex), iter, FALSE)
-                list(resamples = thisResample, pred = tmpPred)
-              } ## end final loop to finish cleanup resamples and models
+          ## if classification, get the confusion matrix
+          if (length(lev) > 1 && length(lev) <= 50) {
+            thisResample <- c(thisResample, flatTable(tmp$pred, tmp$obs))
+          }
+          thisResample <- as.data.frame(
+            t(thisResample),
+            stringsAsFactors = FALSE
+          )
+          thisResample <- cbind(
+            thisResample,
+            new_info$loop[parm, , drop = FALSE]
+          )
+        }
+        thisResample$Resample <- names(resampleIndex)[iter]
+        if (ctrl$verboseIter) {
+          progress(
+            printed[parm, , drop = FALSE],
+            names(resampleIndex),
+            iter,
+            FALSE
+          )
+        }
+        list(resamples = thisResample, pred = tmpPred)
+      } ## end final loop to finish cleanup resamples and models
     init_result <- c(init_result, final_result)
   }
 
   resamples <- rbind.fill(init_result[names(init_result) == "resamples"])
-  pred <- if(keep_pred)  rbind.fill(init_result[names(init_result) == "pred"]) else NULL
+  pred <- if (keep_pred) {
+    rbind.fill(init_result[names(init_result) == "pred"])
+  } else {
+    NULL
+  }
   names(resamples) <- gsub("^\\.", "", names(resamples))
 
-  if(any(!complete.cases(resamples[,!grepl("^cell|Resample", colnames(resamples)),drop = FALSE])))
+  if (
+    any(
+      !complete.cases(resamples[,
+        !grepl("^cell|Resample", colnames(resamples)),
+        drop = FALSE
+      ])
+    )
+  ) {
     warning("There were missing values in resampled performance measures.")
+  }
 
-  out <- ddply(resamples[,!grepl("^cell|Resample", colnames(resamples)),drop = FALSE],
-               gsub("^\\.", "", colnames(info$loop)),
-               MeanSD,
-               exclude = gsub("^\\.", "", colnames(info$loop)))
-  num_resamp <- ddply(resamples,
-                      gsub("^\\.", "", colnames(info$loop)),
-                      function(x) c(Num_Resamples = nrow(x)))
+  out <- ddply(
+    resamples[, !grepl("^cell|Resample", colnames(resamples)), drop = FALSE],
+    gsub("^\\.", "", colnames(info$loop)),
+    MeanSD,
+    exclude = gsub("^\\.", "", colnames(info$loop))
+  )
+  num_resamp <- ddply(
+    resamples,
+    gsub("^\\.", "", colnames(info$loop)),
+    function(x) c(Num_Resamples = nrow(x))
+  )
   out <- merge(out, num_resamp)
 
-  list(performance = out, resamples = resamples, predictions = if(keep_pred) pred else NULL)
+  list(
+    performance = out,
+    resamples = resamples,
+    predictions = if (keep_pred) pred else NULL
+  )
 }
-
-

--- a/R/trim.R
+++ b/R/trim.R
@@ -17,7 +17,9 @@ trim.train <- function(object, ...) {
     "times"
   )
   for (i in removals) {
-    if (i %in% names(object)) object[i] <- NULL
+    if (i %in% names(object)) {
+      object[i] <- NULL
+    }
   }
   c_removals <- c(
     'method',
@@ -41,7 +43,9 @@ trim.train <- function(object, ...) {
     'yLimits'
   )
   for (i in c_removals) {
-    if (i %in% names(object$control)) object$control[i] <- NULL
+    if (i %in% names(object$control)) {
+      object$control[i] <- NULL
+    }
   }
   if (!is.null(object$modelInfo$trim)) {
     object$finalModel <- object$modelInfo$trim(object$finalModel)

--- a/R/trim.R
+++ b/R/trim.R
@@ -2,19 +2,49 @@ trim <- function(object, ...) UseMethod("trim")
 
 #' @export
 trim.train <- function(object, ...) {
-  removals <- c("results", "pred", "bestTune", "call", "dots",
-                "metric", "trainingData", "resample", "resampledCM",
-                "perfNames", "maxmimize", "times")
-  for(i in removals)
-    if(i %in% names(object)) object[i] <- NULL
-  c_removals <- c('method', 'number', 'repeats', 'p', 'initialWindow', 
-                  'horizon', 'fixedWindow', 'verboseIter', 'returnData', 
-                  'returnResamp', 'savePredictions', 'summaryFunction', 
-                  'selectionFunction', 'index', 'indexOut', 'indexFinal',
-                  'timingSamps', 'trim', 'yLimits')
-  for(i in c_removals)
-    if(i %in% names(object$control)) object$control[i] <- NULL  
-  if(!is.null(object$modelInfo$trim))
+  removals <- c(
+    "results",
+    "pred",
+    "bestTune",
+    "call",
+    "dots",
+    "metric",
+    "trainingData",
+    "resample",
+    "resampledCM",
+    "perfNames",
+    "maxmimize",
+    "times"
+  )
+  for (i in removals) {
+    if (i %in% names(object)) object[i] <- NULL
+  }
+  c_removals <- c(
+    'method',
+    'number',
+    'repeats',
+    'p',
+    'initialWindow',
+    'horizon',
+    'fixedWindow',
+    'verboseIter',
+    'returnData',
+    'returnResamp',
+    'savePredictions',
+    'summaryFunction',
+    'selectionFunction',
+    'index',
+    'indexOut',
+    'indexFinal',
+    'timingSamps',
+    'trim',
+    'yLimits'
+  )
+  for (i in c_removals) {
+    if (i %in% names(object$control)) object$control[i] <- NULL
+  }
+  if (!is.null(object$modelInfo$trim)) {
     object$finalModel <- object$modelInfo$trim(object$finalModel)
+  }
   object
 }

--- a/R/twoClassSim.R
+++ b/R/twoClassSim.R
@@ -154,10 +154,10 @@
 #' Statistics, 41(6), 1247-1259.
 #' @keywords models
 #' @examples
-#' 
+#'
 #' example <- twoClassSim(100, linearVars = 1)
 #' splom(~ example[, 1:6], groups = example$Class)
-#' 
+#'
 #' @export twoClassSim
 twoClassSim <- function(
   n = 100,

--- a/R/updates.R
+++ b/R/updates.R
@@ -25,11 +25,11 @@
 #' @seealso [train()], [trainControl()]
 #' @keywords models
 #' @examplesIf !caret:::is_cran_check()
-#' 
+#'
 #' data(iris)
 #' TrainData <- iris[, 1:4]
 #' TrainClasses <- iris[, 5]
-#' 
+#'
 #' knnFit1 <- train(
 #'   TrainData,
 #'   TrainClasses,
@@ -38,11 +38,11 @@
 #'   tuneLength = 10,
 #'   trControl = trainControl(method = "cv")
 #' )
-#' 
+#'
 #' update(knnFit1, list(.k = 3))
 #' @export
 update.train <- function(object, param = NULL, ...) {
-  if(is.null(param)) {
+  if (is.null(param)) {
     if (all(names(object) != "modelInfo")) {
       funcs <- try(getModelInfo(object$method)[[1]], silent = TRUE)
       if (class(funcs)[1] == "list" && length(funcs) > 0) {
@@ -56,48 +56,72 @@ update.train <- function(object, param = NULL, ...) {
             "Alternatively, do not update caret beyond version 5.17-7."
           )
         )
-      } else
+      } else {
         stop(
           paste(
             "This appears to be from an old version of caret",
             "and the model type is unknown to the new version"
           )
         )
+      }
     }
   } else {
     ## check for original data
-    if (is.null(object$trainingData))
-      stop("original training data is needed; use returnData = TRUE in trainControl()")
+    if (is.null(object$trainingData)) {
+      stop(
+        "original training data is needed; use returnData = TRUE in trainControl()"
+      )
+    }
 
-    if(is.list(param)) param <- as.data.frame(param, stringsAsFactors = TRUE)
+    if (is.list(param)) {
+      param <- as.data.frame(param, stringsAsFactors = TRUE)
+    }
     dotNames <- hasDots(param, object$modelInfo)
-    if(dotNames) colnames(param) <- gsub("^\\.", "", colnames(param))
+    if (dotNames) {
+      colnames(param) <- gsub("^\\.", "", colnames(param))
+    }
 
-    if (!is.data.frame(param))
+    if (!is.data.frame(param)) {
       stop("param should be a data frame or a named list")
-    if (nrow(param) > 1)
+    }
+    if (nrow(param) > 1) {
       stop("only one set of parameters should be specified")
+    }
 
     paramNames <- as.character(object$modelInfo$parameter$parameter)
-    if (length(paramNames) != ncol(param))
-      stop(paste("Parameters should be", paste(paramNames, sep = "", collapse = ", ")))
-    if (any(sort(names(param)) != sort(paste(paramNames, sep = ""))))
-      stop(paste("Parameters should be", paste(paramNames, sep = "", collapse = ", ")))
+    if (length(paramNames) != ncol(param)) {
+      stop(paste(
+        "Parameters should be",
+        paste(paramNames, sep = "", collapse = ", ")
+      ))
+    }
+    if (any(sort(names(param)) != sort(paste(paramNames, sep = "")))) {
+      stop(paste(
+        "Parameters should be",
+        paste(paramNames, sep = "", collapse = ", ")
+      ))
+    }
 
     ## get pre-processing options
     if (!is.null(object$preProcess)) {
       ppOpt <- list(options = object$preProcess$method)
-      if(length(object$control$preProcOptions) > 0) ppOpt <- c(ppOpt,object$control$preProcOptions)
-    } else ppOpt <- NULL
+      if (length(object$control$preProcOptions) > 0) {
+        ppOpt <- c(ppOpt, object$control$preProcOptions)
+      }
+    } else {
+      ppOpt <- NULL
+    }
 
     ## refit model with new parameters
     args <-
-      list(method = object$modelInfo,
-           tuneValue = param,
-           obsLevels = levels(object$trainingData$.outcome),
-           pp = ppOpt,
-           last = TRUE,
-           classProbs = object$control$classProbs)
+      list(
+        method = object$modelInfo,
+        tuneValue = param,
+        obsLevels = levels(object$trainingData$.outcome),
+        pp = ppOpt,
+        last = TRUE,
+        classProbs = object$control$classProbs
+      )
 
     if (inherits(object, "train.recipe")) {
       args$x <-
@@ -117,23 +141,27 @@ update.train <- function(object, param = NULL, ...) {
       } else {
         args["obsLevels"] <- list(NULL)
       }
-
     } else {
       args$x <-
-        object$trainingData[, !(colnames(object$trainingData) %in% c(".outcome", ".weights"))]
+        object$trainingData[,
+          !(colnames(object$trainingData) %in% c(".outcome", ".weights"))
+        ]
       args$y <- object$trainingData$.outcome
     }
 
     if (any(names(object$trainingData) == ".weights")) {
       args$wts <- object$trainingData$.weights
-    } else args <- c(args, list(wts = NULL))
+    } else {
+      args <- c(args, list(wts = NULL))
+    }
 
-    if (length(object$dots) > 0) args <- c(args, object$dots)
+    if (length(object$dots) > 0) {
+      args <- c(args, object$dots)
+    }
     finalFinalModel <- do.call("createModel", args)
     object$finalModel <- finalFinalModel$fit
     object$preProcess <- finalFinalModel$preProc
     object$bestTune <- param
-
 
     ## modify objects so print method reflects update
     object$update <- param

--- a/R/varImp.R
+++ b/R/varImp.R
@@ -241,15 +241,15 @@ GarsonWeights <- function(object) {
     rm(Pij, Qij, Sj)
   }
 
-  colnames(imp) <- if (!is.null(colnames(object$residuals))) {
-    colnames(object$residuals)
+  if (!is.null(colnames(object$residuals))) {
+    colnames(imp) <- colnames(object$residuals)
   } else {
-    paste("Y", 1:object$n[3], sep = "")
+    colnames(imp) <- paste("Y", 1:object$n[3], sep = "")
   }
-  rownames(imp) <- if (!is.null(object$coefnames)) {
-    object$coefnames
+  if (!is.null(object$coefnames)) {
+    rownames(imp) <- object$coefnames
   } else {
-    paste("X", 1:object$n[1], sep = "")
+    rownames(imp) <- paste("X", 1:object$n[1], sep = "")
   }
   imp
 }
@@ -280,15 +280,15 @@ GarsonWeights_FCNN4R <- function(object, xnames = NULL, ynames = NULL) {
     imp[, output] <- Sj / sum(Sj) * 100
     rm(Pij, Qij, Sj)
   }
-  rownames(imp) <- if (is.null(xnames)) {
-    paste("X", 1:dims[1], sep = "")
+  if (is.null(xnames)) {
+    rownames(imp) <- paste("X", 1:dims[1], sep = "")
   } else {
-    xnames
+    rownames(imp) <- xnames
   }
-  colnames(imp) <- if (is.null(ynames)) {
-    paste("Y", 1:dims[3], sep = "")
+  if (is.null(ynames)) {
+    colnames(imp) <- paste("Y", 1:dims[3], sep = "")
   } else {
-    ynames
+    colnames(imp) <- ynames
   }
   imp
 }

--- a/R/varImp.R
+++ b/R/varImp.R
@@ -186,21 +186,12 @@ GarsonWeights <- function(object) {
     ## S. (2003). Review and comparison of methods to study the
     ## contribution of variables in artificial neural network
     ## models. ecological modelling, 160(3), 249-264.
+    # fmt: skip
     i2h <- matrix(
-      c(
-        -1.67624,
-        3.29022,
-        1.32466,
-        -0.51874,
-        -0.22921,
-        -0.25526,
-        -4.01764,
-        2.12486,
-        -0.08168,
-        -1.75691,
-        -1.44702,
-        0.58286
-      ),
+      c(-1.67624,  3.29022,  1.32466,
+        -0.51874, -0.22921, -0.25526,
+        -4.01764,  2.12486, -0.08168,
+        -1.75691, -1.44702,  0.58286),
       ncol = 3,
       byrow = TRUE
     )

--- a/R/varImp.train.R
+++ b/R/varImp.train.R
@@ -1,40 +1,49 @@
 #' @rdname varImp
 #' @export
-"varImp.train" <- function(object, useModel = TRUE, nonpara = TRUE, scale = TRUE, ...) {
+"varImp.train" <- function(
+  object,
+  useModel = TRUE,
+  nonpara = TRUE,
+  scale = TRUE,
+  ...
+) {
   code <- object$modelInfo
-  if(is.null(code$varImp)) useModel <- FALSE
-  if(useModel) {
+  if (is.null(code$varImp)) {
+    useModel <- FALSE
+  }
+  if (useModel) {
     checkInstall(code$library)
-    for(i in seq(along.with = code$library))
+    for (i in seq(along.with = code$library)) {
       do.call("requireNamespaceQuietStop", list(package = code$library[i]))
+    }
     imp <- code$varImp(object$finalModel, ...)
     modelName <- object$method
   } else {
-    if(inherits(object, "train.recipe")) {
+    if (inherits(object, "train.recipe")) {
       x_dat <- recipes::juice(object$recipe, all_predictors())
       x_dat <- as.data.frame(x_dat, stringsAsFactors = FALSE)
       y_dat <- recipes::juice(object$recipe, all_outcomes())
       y_dat <- getElement(y_dat, names(y_dat))
     } else {
       isX <- which(!(colnames(object$trainingData) %in% ".outcome"))
-      x_dat <- object$trainingData[, isX,drop = FALSE]
+      x_dat <- object$trainingData[, isX, drop = FALSE]
       y_dat <- object$trainingData[, -isX]
     }
-    imp <- filterVarImp(x_dat, y_dat,
-                        nonpara = nonpara,
-                        ...)
-    modelName <- ifelse(is.factor(y_dat),
-                        "ROC curve",
-                        ifelse(nonpara, "loess r-squared", "Linear model"))
+    imp <- filterVarImp(x_dat, y_dat, nonpara = nonpara, ...)
+    modelName <- ifelse(
+      is.factor(y_dat),
+      "ROC curve",
+      ifelse(nonpara, "loess r-squared", "Linear model")
+    )
   }
-  if(scale) {
-    if(class(object$finalModel)[1] == "pamrtrained") imp <- abs(imp)
+  if (scale) {
+    if (class(object$finalModel)[1] == "pamrtrained") {
+      imp <- abs(imp)
+    }
     imp <- imp - min(imp, na.rm = TRUE)
-    imp <- imp/max(imp, na.rm = TRUE)*100
+    imp <- imp / max(imp, na.rm = TRUE) * 100
   }
-  out <- list(importance = imp,
-              model = modelName,
-              calledFrom = "varImp")
-  
+  out <- list(importance = imp, model = modelName, calledFrom = "varImp")
+
   structure(out, class = "varImp.train")
 }

--- a/R/workflows.R
+++ b/R/workflows.R
@@ -4,8 +4,20 @@
 ### functions inside of caret cannot be found despite using the
 ### ".packages" argument or even calling the caret package via library().
 
-getOper <- function(x) if (x) `%dopar%` else `%do%`
-getTrainOper <- function(x) if (x) `%dopar%` else `%do%`
+getOper <- function(x) {
+  if (x) {
+    `%dopar%`
+  } else {
+    `%do%`
+  }
+}
+getTrainOper <- function(x) {
+  if (x) {
+    `%dopar%`
+  } else {
+    `%do%`
+  }
+}
 
 
 #' @rdname caret-internal
@@ -207,7 +219,9 @@ nominalTrainWorkflow <- function(
         } else {
           probValues <- fill_failed_prob(holdoutIndex, lev, submod)
         }
-        if (testing) print(head(probValues))
+        if (testing) {
+          print(head(probValues))
+        }
       }
 
       ##################################
@@ -416,10 +430,10 @@ nominalTrainWorkflow <- function(
     out <- merge(out, apparent)
     const <- 1 - exp(-1)
     sapply(perfNames, function(perfName) {
-      perfOut <- if (ctrl$method == "boot_all") {
-        paste0(perfName, "_632")
+      if (ctrl$method == "boot_all") {
+        perfOut <- paste0(perfName, "_632")
       } else {
-        perfName
+        perfOut <- perfName
       }
       out[, perfOut] <<- (const * out[, perfName]) +
         ((1 - const) * out[, paste(perfName, "Apparent", sep = "")])
@@ -450,10 +464,10 @@ nominalTrainWorkflow <- function(
       ## Remove unnecessary values
       out[, paste0(perfName, "Orig")] <<- NULL
       out[, paste0(perfName, "Boot")] <<- NULL
-      perfOut <- if (ctrl$method == "boot_all") {
-        paste0(perfName, "_OptBoot")
+      if (ctrl$method == "boot_all") {
+        perfOut <- paste0(perfName, "_OptBoot")
       } else {
-        perfName
+        perfOut <- perfName
       }
       ## Update estimates
       out[, paste0(perfName, "Optimism")] <<- optimism
@@ -595,7 +609,9 @@ looTrainWorkflow <- function(
         } else {
           probValues <- fill_failed_prob(holdoutIndex, lev, submod)
         }
-        if (testing) print(head(probValues))
+        if (testing) {
+          print(head(probValues))
+        }
       }
 
       predicted <- trim_values(predicted, ctrl, is.null(lev))
@@ -803,10 +819,10 @@ nominalSbfWorkflow <- function(x, y, ppOpts, ctrl, lev, ...) {
     }
 
   resamples <- rbind.fill(result[names(result) == "resamples"])
-  pred <- if (ctrl$saveDetails) {
-    rbind.fill(result[names(result) == "pred"])
+  if (ctrl$saveDetails) {
+    pred <- rbind.fill(result[names(result) == "pred"])
   } else {
-    NULL
+    pred <- NULL
   }
   performance <- MeanSD(resamples[,
     !grepl("Resample", colnames(resamples)),
@@ -935,10 +951,10 @@ nominalRfeWorkflow <- function(x, y, sizes, ppOpts, ctrl, lev, ...) {
         holdoutIndex <- modelIndex
       }
 
-      seeds <- if (!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds))) {
-        ctrl$seeds[[iter]]
+      if (!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds))) {
+        seeds <- ctrl$seeds[[iter]]
       } else {
-        NA
+        seeds <- NA
       }
       rfeResults <- rfeIter(
         subset_x(x, modelIndex),
@@ -1046,10 +1062,10 @@ looRfeWorkflow <- function(x, y, sizes, ppOpts, ctrl, lev, ...) {
       modelIndex <- resampleIndex[[iter]]
       holdoutIndex <- -unique(resampleIndex[[iter]])
 
-      seeds <- if (!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds))) {
-        ctrl$seeds[[iter]]
+      if (!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds))) {
+        seeds <- ctrl$seeds[[iter]]
       } else {
-        NA
+        seeds <- NA
       }
       rfeResults <- rfeIter(
         subset_x(x, modelIndex),

--- a/R/workflows.R
+++ b/R/workflows.R
@@ -1,55 +1,71 @@
-
 ### In this file, there are a lot of functions from packages that are
 ### referenced using `getFromNamespace`. For some
 ### reason, with _some_ parallel processing technologies and foreach,
 ### functions inside of caret cannot be found despite using the
 ### ".packages" argument or even calling the caret package via library().
 
-getOper <- function(x) if(x)  `%dopar%` else  `%do%`
-getTrainOper <- function(x) if(x)  `%dopar%` else  `%do%`
+getOper <- function(x) if (x) `%dopar%` else `%do%`
+getTrainOper <- function(x) if (x) `%dopar%` else `%do%`
 
 
 #' @rdname caret-internal
 #' @export
 #' @keywords internal
-progress <- function(x, names, iter, start = TRUE)
-{
-  text <- paste(ifelse(start, "+ ", "- "),
-                names[iter], ": ",
-                paste(colnames(x), x, sep = "=", collapse = ", "),
-                sep = "")
+progress <- function(x, names, iter, start = TRUE) {
+  text <- paste(
+    ifelse(start, "+ ", "- "),
+    names[iter],
+    ": ",
+    paste(colnames(x), x, sep = "=", collapse = ", "),
+    sep = ""
+  )
   cat(text, "\n")
 }
 
 #' @rdname caret-internal
 #' @export
-MeanSD <- function(x, exclude = NULL)
-{
-  if(!is.null(exclude)) x <- x[, !(colnames(x) %in% exclude), drop = FALSE]
+MeanSD <- function(x, exclude = NULL) {
+  if (!is.null(exclude)) {
+    x <- x[, !(colnames(x) %in% exclude), drop = FALSE]
+  }
   out <- c(colMeans(x, na.rm = TRUE), sapply(x, sd, na.rm = TRUE))
-  names(out)[-(seq_len(ncol(x)))] <- paste(names(out)[-(seq_len(ncol(x)))], "SD", sep = "")
+  names(out)[-(seq_len(ncol(x)))] <- paste(
+    names(out)[-(seq_len(ncol(x)))],
+    "SD",
+    sep = ""
+  )
   out
 }
 
 #' @rdname caret-internal
 #' @export
-expandParameters <- function(fixed, seq)
-{
-  if(is.null(seq)) return(fixed)
+expandParameters <- function(fixed, seq) {
+  if (is.null(seq)) {
+    return(fixed)
+  }
 
   isSeq <- names(fixed) %in% names(seq)
   out <- fixed
-  for(i in seq_len(nrow(seq)))
-  {
+  for (i in seq_len(nrow(seq))) {
     tmp <- fixed
-    tmp[,isSeq] <- seq[i,]
+    tmp[, isSeq] <- seq[i, ]
     out <- rbind(out, tmp)
   }
   out
 }
 
-nominalTrainWorkflow <- function(x, y, wts, info, method, ppOpts, ctrl, lev, testing = FALSE, ...)
-{
+nominalTrainWorkflow <- function(
+  x,
+  y,
+  wts,
+  info,
+  method,
+  ppOpts,
+  ctrl,
+  lev,
+  testing = FALSE,
+  ...
+) {
   loadNamespace("caret")
   ppp <- list(options = ppOpts)
   ppp <- c(ppp, ctrl$preProcOptions)
@@ -61,30 +77,48 @@ nominalTrainWorkflow <- function(x, y, wts, info, method, ppOpts, ctrl, lev, tes
   ## fitting and predicting the full data set.
 
   resampleIndex <- ctrl$index
-  if(ctrl$method %in% c("boot632", "optimism_boot", "boot_all"))
-  {
+  if (ctrl$method %in% c("boot632", "optimism_boot", "boot_all")) {
     resampleIndex <- c(list("AllData" = rep(0, nrow(x))), resampleIndex)
-    ctrl$indexOut <- c(list("AllData" = rep(0, nrow(x))),  ctrl$indexOut)
-    if(!is.null(ctrl$indexExtra)) ctrl$indexExtra <- c(list("AllData" = NULL), ctrl$indexExtra)
+    ctrl$indexOut <- c(list("AllData" = rep(0, nrow(x))), ctrl$indexOut)
+    if (!is.null(ctrl$indexExtra)) {
+      ctrl$indexExtra <- c(list("AllData" = NULL), ctrl$indexExtra)
+    }
   }
   `%op%` <- getOper(ctrl$allowParallel && getDoParWorkers() > 1)
-  keep_pred <- isTRUE(ctrl$savePredictions) || ctrl$savePredictions %in% c("all", "final")
+  keep_pred <- isTRUE(ctrl$savePredictions) ||
+    ctrl$savePredictions %in% c("all", "final")
   pkgs <- c("methods", "caret")
-  if(!is.null(method$library)) pkgs <- c(pkgs, method$library)
+  if (!is.null(method$library)) {
+    pkgs <- c(pkgs, method$library)
+  }
   export <- c()
 
-  result <- foreach(iter = seq(along.with = resampleIndex), .combine = "c", .verbose = FALSE, .export = export, .packages = "caret") %:%
-    foreach(parm = seq_len(nrow(info$loop)), .combine = "c", .verbose = FALSE, .export = export , .packages = "caret")  %op%
+  result <- foreach(
+    iter = seq(along.with = resampleIndex),
+    .combine = "c",
+    .verbose = FALSE,
+    .export = export,
+    .packages = "caret"
+  ) %:%
+    foreach(
+      parm = seq_len(nrow(info$loop)),
+      .combine = "c",
+      .verbose = FALSE,
+      .export = export,
+      .packages = "caret"
+    ) %op%
     {
-      if(!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds))) set.seed(ctrl$seeds[[iter]][parm])
+      if (!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds))) {
+        set.seed(ctrl$seeds[[iter]][parm])
+      }
 
       loadNamespace("caret")
       lapply(pkgs, requireNamespaceQuietStop)
-      if(ctrl$verboseIter) progress(printed[parm,,drop = FALSE],
-                                    names(resampleIndex), iter)
+      if (ctrl$verboseIter) {
+        progress(printed[parm, , drop = FALSE], names(resampleIndex), iter)
+      }
 
-      if(names(resampleIndex)[iter] != "AllData") {
-
+      if (names(resampleIndex)[iter] != "AllData") {
         modelIndex <- resampleIndex[[iter]]
         holdoutIndex <- ctrl$indexOut[[iter]]
       } else {
@@ -92,67 +126,88 @@ nominalTrainWorkflow <- function(x, y, wts, info, method, ppOpts, ctrl, lev, tes
         holdoutIndex <- modelIndex
       }
 
-      if(testing) cat("pre-model\n")
+      if (testing) {
+        cat("pre-model\n")
+      }
 
-      if(!is.null(info$submodels[[parm]]) && nrow(info$submodels[[parm]]) > 0) {
+      if (
+        !is.null(info$submodels[[parm]]) && nrow(info$submodels[[parm]]) > 0
+      ) {
         submod <- info$submodels[[parm]]
-      } else submod <- NULL
+      } else {
+        submod <- NULL
+      }
 
       mod <- try(
-        createModel(x = subset_x(x, modelIndex),
-                    y = y[modelIndex],
-                    wts = wts[modelIndex],
-                    method = method,
-                    tuneValue = info$loop[parm,,drop = FALSE],
-                    obsLevels = lev,
-                    pp = ppp,
-                    classProbs = ctrl$classProbs,
-                    sampling = ctrl$sampling,
-                    ...),
-        silent = TRUE)
+        createModel(
+          x = subset_x(x, modelIndex),
+          y = y[modelIndex],
+          wts = wts[modelIndex],
+          method = method,
+          tuneValue = info$loop[parm, , drop = FALSE],
+          obsLevels = lev,
+          pp = ppp,
+          classProbs = ctrl$classProbs,
+          sampling = ctrl$sampling,
+          ...
+        ),
+        silent = TRUE
+      )
 
-      if(testing) print(mod)
+      if (testing) {
+        print(mod)
+      }
 
-      if(!model_failed(mod)) {
-          predicted <- try(
-          predictionFunction(method = method,
-                             modelFit = mod$fit,
-                             newdata = subset_x(x, holdoutIndex),
-                             preProc = mod$preProc,
-                             param = submod),
-          silent = TRUE)
+      if (!model_failed(mod)) {
+        predicted <- try(
+          predictionFunction(
+            method = method,
+            modelFit = mod$fit,
+            newdata = subset_x(x, holdoutIndex),
+            preProc = mod$preProc,
+            param = submod
+          ),
+          silent = TRUE
+        )
 
-        if(pred_failed(predicted)) {
-          fail_warning(settings = printed[parm,,drop = FALSE],
-                       msg  = predicted,
-                       where = "predictions",
-                       iter = names(resampleIndex)[iter],
-                       verb = ctrl$verboseIter)
+        if (pred_failed(predicted)) {
+          fail_warning(
+            settings = printed[parm, , drop = FALSE],
+            msg = predicted,
+            where = "predictions",
+            iter = names(resampleIndex)[iter],
+            verb = ctrl$verboseIter
+          )
 
           predicted <- fill_failed_pred(index = holdoutIndex, lev = lev, submod)
-
         }
       } else {
-        fail_warning(settings = printed[parm,,drop = FALSE],
-                     msg  = mod,
-                     iter = names(resampleIndex)[iter],
-                     verb = ctrl$verboseIter)
+        fail_warning(
+          settings = printed[parm, , drop = FALSE],
+          msg = mod,
+          iter = names(resampleIndex)[iter],
+          verb = ctrl$verboseIter
+        )
         predicted <- fill_failed_pred(index = holdoutIndex, lev = lev, submod)
       }
 
-      if(testing) print(head(predicted))
+      if (testing) {
+        print(head(predicted))
+      }
 
-      if(ctrl$classProbs) {
-        if(!model_failed(mod)) {
-          probValues <- probFunction(method = method,
-                                     modelFit = mod$fit,
-                                     newdata = subset_x(x, holdoutIndex),
-                                     preProc = mod$preProc,
-                                     param = submod)
-       } else {
+      if (ctrl$classProbs) {
+        if (!model_failed(mod)) {
+          probValues <- probFunction(
+            method = method,
+            modelFit = mod$fit,
+            newdata = subset_x(x, holdoutIndex),
+            preProc = mod$preProc,
+            param = submod
+          )
+        } else {
           probValues <- fill_failed_prob(holdoutIndex, lev, submod)
         }
-        if(testing) print(head(probValues))
+        if (testing) print(head(probValues))
       }
 
       ##################################
@@ -161,174 +216,272 @@ nominalTrainWorkflow <- function(x, y, wts, info, method, ppOpts, ctrl, lev, tes
 
       ##################################
 
-      if(!is.null(submod))
-      {
+      if (!is.null(submod)) {
         ## merge the fixed and seq parameter values together
-        allParam <- expandParameters(info$loop[parm,,drop = FALSE], info$submodels[[parm]])
-        allParam <- allParam[complete.cases(allParam),, drop = FALSE]
+        allParam <- expandParameters(
+          info$loop[parm, , drop = FALSE],
+          info$submodels[[parm]]
+        )
+        allParam <- allParam[complete.cases(allParam), , drop = FALSE]
 
         ## collate the predicitons across all the sub-models
-        predicted <- lapply(predicted,
-                            function(x, y, wts, lv, rows) {
-                              x <- outcome_conversion(x, lv = lev)
-                              out <- data.frame(pred = x, obs = y, stringsAsFactors = FALSE)
-                              if(!is.null(wts)) out$weights <- wts
-                              out$rowIndex <- rows
-                              out
-                            },
-                            y = y[holdoutIndex],
-                            wts = wts[holdoutIndex],
-                            lv = lev,
-                            rows = holdoutIndex)
+        predicted <- lapply(
+          predicted,
+          function(x, y, wts, lv, rows) {
+            x <- outcome_conversion(x, lv = lev)
+            out <- data.frame(pred = x, obs = y, stringsAsFactors = FALSE)
+            if (!is.null(wts)) {
+              out$weights <- wts
+            }
+            out$rowIndex <- rows
+            out
+          },
+          y = y[holdoutIndex],
+          wts = wts[holdoutIndex],
+          lv = lev,
+          rows = holdoutIndex
+        )
 
-        if(ctrl$classProbs)
+        if (ctrl$classProbs) {
           predicted <- mapply(cbind, predicted, probValues, SIMPLIFY = FALSE)
+        }
 
-        if(keep_pred) {
+        if (keep_pred) {
           tmpPred <- predicted
-          for(modIndex in seq(along.with = tmpPred)) {
-            tmpPred[[modIndex]] <- merge(tmpPred[[modIndex]],
-                                         allParam[modIndex,,drop = FALSE],
-                                         all = TRUE)
+          for (modIndex in seq(along.with = tmpPred)) {
+            tmpPred[[modIndex]] <- merge(
+              tmpPred[[modIndex]],
+              allParam[modIndex, , drop = FALSE],
+              all = TRUE
+            )
           }
           tmpPred <- rbind.fill(tmpPred)
           tmpPred$Resample <- names(resampleIndex)[iter]
-        } else tmpPred <- NULL
+        } else {
+          tmpPred <- NULL
+        }
 
         ## get the performance for this resample for each sub-model
-        thisResample <- lapply(predicted,
-                               ctrl$summaryFunction,
-                               lev = lev,
-                               model = method)
-        if(testing) print(head(thisResample))
+        thisResample <- lapply(
+          predicted,
+          ctrl$summaryFunction,
+          lev = lev,
+          model = method
+        )
+        if (testing) {
+          print(head(thisResample))
+        }
         ## for classification, add the cell counts
-        if(length(lev) > 1 && length(lev) <= 50) {
-          cells <- lapply(predicted,
-                          function(x) flatTable(x$pred, x$obs))
-          for(ind in seq(along.with = cells)) thisResample[[ind]] <- c(thisResample[[ind]], cells[[ind]])
+        if (length(lev) > 1 && length(lev) <= 50) {
+          cells <- lapply(predicted, function(x) flatTable(x$pred, x$obs))
+          for (ind in seq(along.with = cells)) {
+            thisResample[[ind]] <- c(thisResample[[ind]], cells[[ind]])
+          }
         }
         thisResample <- do.call("rbind", thisResample)
         thisResample <- cbind(allParam, thisResample)
-
       } else {
-        if(is.factor(y)) predicted <- outcome_conversion(predicted, lv = lev)
-        tmp <-  data.frame(pred = predicted,
-                           obs = y[holdoutIndex],
-                           stringsAsFactors = FALSE)
+        if (is.factor(y)) {
+          predicted <- outcome_conversion(predicted, lv = lev)
+        }
+        tmp <- data.frame(
+          pred = predicted,
+          obs = y[holdoutIndex],
+          stringsAsFactors = FALSE
+        )
         ## Sometimes the code above does not coerce the first
         ## columnn to be named "pred" so force it
         names(tmp)[1] <- "pred"
-        if(!is.null(wts)) tmp$weights <- wts[holdoutIndex]
-        if(ctrl$classProbs) tmp <- cbind(tmp, probValues)
+        if (!is.null(wts)) {
+          tmp$weights <- wts[holdoutIndex]
+        }
+        if (ctrl$classProbs) {
+          tmp <- cbind(tmp, probValues)
+        }
         tmp$rowIndex <- holdoutIndex
 
-        if(keep_pred) {
+        if (keep_pred) {
           tmpPred <- tmp
           tmpPred$rowIndex <- holdoutIndex
-          tmpPred <- merge(tmpPred, info$loop[parm,,drop = FALSE],
-                           all = TRUE)
+          tmpPred <- merge(tmpPred, info$loop[parm, , drop = FALSE], all = TRUE)
           tmpPred$Resample <- names(resampleIndex)[iter]
-        } else tmpPred <- NULL
+        } else {
+          tmpPred <- NULL
+        }
 
         ##################################
 
-        thisResample <- ctrl$summaryFunction(tmp,
-                                             lev = lev,
-                                             model = method)
+        thisResample <- ctrl$summaryFunction(tmp, lev = lev, model = method)
 
         ## if classification, get the confusion matrix
-        if(length(lev) > 1 && length(lev) <= 50)
+        if (length(lev) > 1 && length(lev) <= 50) {
           thisResample <- c(thisResample, flatTable(tmp$pred, tmp$obs))
+        }
         thisResample <- as.data.frame(t(thisResample), stringsAsFactors = FALSE)
-        thisResample <- cbind(thisResample, info$loop[parm,,drop = FALSE])
+        thisResample <- cbind(thisResample, info$loop[parm, , drop = FALSE])
       }
       thisResample$Resample <- names(resampleIndex)[iter]
 
-      thisResampleExtra <- optimism_xy(ctrl, x, y, wts, iter, lev, method, mod, predicted,
-                                       submod, info$loop[parm,, drop = FALSE])
+      thisResampleExtra <- optimism_xy(
+        ctrl,
+        x,
+        y,
+        wts,
+        iter,
+        lev,
+        method,
+        mod,
+        predicted,
+        submod,
+        info$loop[parm, , drop = FALSE]
+      )
 
-      if(ctrl$verboseIter) progress(printed[parm,,drop = FALSE],
-                                    names(resampleIndex), iter, FALSE)
+      if (ctrl$verboseIter) {
+        progress(
+          printed[parm, , drop = FALSE],
+          names(resampleIndex),
+          iter,
+          FALSE
+        )
+      }
 
-      if(testing) print(thisResample)
-      list(resamples = thisResample, pred = tmpPred, resamplesExtra = thisResampleExtra)
+      if (testing) {
+        print(thisResample)
+      }
+      list(
+        resamples = thisResample,
+        pred = tmpPred,
+        resamplesExtra = thisResampleExtra
+      )
     }
 
   resamples <- rbind.fill(result[names(result) == "resamples"])
   pred <- rbind.fill(result[names(result) == "pred"])
   resamplesExtra <- rbind.fill(result[names(result) == "resamplesExtra"])
-  if(ctrl$method %in% c("boot632", "optimism_boot", "boot_all"))
-  {
+  if (ctrl$method %in% c("boot632", "optimism_boot", "boot_all")) {
     perfNames <- names(resamples)
-    perfNames <- perfNames[!(perfNames %in% c("Resample", as.character(method$parameters$parameter)))]
+    perfNames <- perfNames[
+      !(perfNames %in% c("Resample", as.character(method$parameters$parameter)))
+    ]
     perfNames <- perfNames[!grepl("^\\.cell[0-9]", perfNames)]
     apparent <- subset(resamples, Resample == "AllData")
-    apparent <- apparent[,!grepl("^\\.cell|Resample", colnames(apparent)),drop = FALSE]
-    names(apparent)[which(names(apparent) %in% perfNames)] <- paste(names(apparent)[which(names(apparent) %in% perfNames)],
-                                                                    "Apparent", sep = "")
+    apparent <- apparent[,
+      !grepl("^\\.cell|Resample", colnames(apparent)),
+      drop = FALSE
+    ]
+    names(apparent)[which(names(apparent) %in% perfNames)] <- paste(
+      names(apparent)[which(names(apparent) %in% perfNames)],
+      "Apparent",
+      sep = ""
+    )
     names(apparent) <- gsub("^\\.", "", names(apparent))
-    if(any(!complete.cases(apparent[,!grepl("^cell|Resample", colnames(apparent)),drop = FALSE])))
-    {
+    if (
+      any(
+        !complete.cases(apparent[,
+          !grepl("^cell|Resample", colnames(apparent)),
+          drop = FALSE
+        ])
+      )
+    ) {
       warning("There were missing values in the apparent performance measures.")
     }
     resamples <- subset(resamples, Resample != "AllData")
-    if(!is.null(pred))
-    {
+    if (!is.null(pred)) {
       predHat <- subset(pred, Resample == "AllData")
       pred <- subset(pred, Resample != "AllData")
     }
   }
   names(resamples) <- gsub("^\\.", "", names(resamples))
 
-  if(any(!complete.cases(resamples[,!grepl("^cell|Resample", colnames(resamples)),drop = FALSE])))
-  {
+  if (
+    any(
+      !complete.cases(resamples[,
+        !grepl("^cell|Resample", colnames(resamples)),
+        drop = FALSE
+      ])
+    )
+  ) {
     warning("There were missing values in resampled performance measures.")
   }
 
-  out <- ddply(resamples[,!grepl("^cell|Resample", colnames(resamples)),drop = FALSE],
-               ## TODO check this for seq models
-               gsub("^\\.", "", colnames(info$loop)),
-               MeanSD,
-               exclude = gsub("^\\.", "", colnames(info$loop)))
+  out <- ddply(
+    resamples[, !grepl("^cell|Resample", colnames(resamples)), drop = FALSE],
+    ## TODO check this for seq models
+    gsub("^\\.", "", colnames(info$loop)),
+    MeanSD,
+    exclude = gsub("^\\.", "", colnames(info$loop))
+  )
 
-  if(ctrl$method %in% c("boot632", "boot_all")) {
+  if (ctrl$method %in% c("boot632", "boot_all")) {
     out <- merge(out, apparent)
     const <- 1 - exp(-1)
     sapply(perfNames, function(perfName) {
-      perfOut <- if(ctrl$method == "boot_all") paste0(perfName, "_632") else perfName
-      out[, perfOut] <<- (const * out[, perfName]) +  ((1-const) * out[, paste(perfName, "Apparent", sep = "")])
+      perfOut <- if (ctrl$method == "boot_all") {
+        paste0(perfName, "_632")
+      } else {
+        perfName
+      }
+      out[, perfOut] <<- (const * out[, perfName]) +
+        ((1 - const) * out[, paste(perfName, "Apparent", sep = "")])
       NULL
     })
   }
 
-  if(ctrl$method %in% c("optimism_boot", "boot_all")) {
+  if (ctrl$method %in% c("optimism_boot", "boot_all")) {
     out <- merge(out, apparent)
-    out <- merge(out, ddply(resamplesExtra[, !grepl("Resample", colnames(resamplesExtra)), drop = FALSE],
-                            colnames(info$loop),
-                            function(df, exclude) {
-                              colMeans(df[, setdiff(colnames(df), exclude), drop = FALSE])
-                            },
-                            exclude = colnames(info$loop)))
+    out <- merge(
+      out,
+      ddply(
+        resamplesExtra[,
+          !grepl("Resample", colnames(resamplesExtra)),
+          drop = FALSE
+        ],
+        colnames(info$loop),
+        function(df, exclude) {
+          colMeans(df[, setdiff(colnames(df), exclude), drop = FALSE])
+        },
+        exclude = colnames(info$loop)
+      )
+    )
     sapply(perfNames, function(perfName) {
-      optimism <- out[ , paste0(perfName, "Orig")] - out[ , paste0(perfName, "Boot")]
-      final_estimate <- out[ , paste0(perfName, "Apparent")] + optimism
+      optimism <- out[, paste0(perfName, "Orig")] -
+        out[, paste0(perfName, "Boot")]
+      final_estimate <- out[, paste0(perfName, "Apparent")] + optimism
       ## Remove unnecessary values
-      out[ , paste0(perfName, "Orig")] <<- NULL
-      out[ , paste0(perfName, "Boot")] <<- NULL
-      perfOut <- if(ctrl$method == "boot_all") paste0(perfName, "_OptBoot") else perfName
+      out[, paste0(perfName, "Orig")] <<- NULL
+      out[, paste0(perfName, "Boot")] <<- NULL
+      perfOut <- if (ctrl$method == "boot_all") {
+        paste0(perfName, "_OptBoot")
+      } else {
+        perfName
+      }
       ## Update estimates
-      out[ , paste0(perfName, "Optimism")] <<- optimism
-      out[ , perfOut] <<- final_estimate
+      out[, paste0(perfName, "Optimism")] <<- optimism
+      out[, perfOut] <<- final_estimate
       NULL
     })
   }
 
-  list(performance = out, resamples = resamples, predictions = if(keep_pred) pred else NULL)
+  list(
+    performance = out,
+    resamples = resamples,
+    predictions = if (keep_pred) pred else NULL
+  )
 }
 
 
-looTrainWorkflow <- function(x, y, wts, info, method, ppOpts, ctrl, lev, testing = FALSE, ...)
-{
+looTrainWorkflow <- function(
+  x,
+  y,
+  wts,
+  info,
+  method,
+  ppOpts,
+  ctrl,
+  lev,
+  testing = FALSE,
+  ...
+) {
   loadNamespace("caret")
 
   ppp <- list(options = ppOpts)
@@ -340,132 +493,193 @@ looTrainWorkflow <- function(x, y, wts, info, method, ppOpts, ctrl, lev, testing
   `%op%` <- getOper(ctrl$allowParallel && getDoParWorkers() > 1)
 
   pkgs <- c("methods", "caret")
-  if(!is.null(method$library)) pkgs <- c(pkgs, method$library)
+  if (!is.null(method$library)) {
+    pkgs <- c(pkgs, method$library)
+  }
 
-  result <- foreach(iter = seq(along.with = ctrl$index), .combine = "rbind", .verbose = FALSE, .errorhandling = "stop", .packages = "caret") %:%
-    foreach(parm = seq_len(nrow(info$loop)), .combine = "rbind", .verbose = FALSE, .errorhandling = "stop", .packages = "caret") %op% {
-
-      if(!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds))) set.seed(ctrl$seeds[[iter]][parm])
-      if(testing) cat("after loops\n")
+  result <- foreach(
+    iter = seq(along.with = ctrl$index),
+    .combine = "rbind",
+    .verbose = FALSE,
+    .errorhandling = "stop",
+    .packages = "caret"
+  ) %:%
+    foreach(
+      parm = seq_len(nrow(info$loop)),
+      .combine = "rbind",
+      .verbose = FALSE,
+      .errorhandling = "stop",
+      .packages = "caret"
+    ) %op%
+    {
+      if (!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds))) {
+        set.seed(ctrl$seeds[[iter]][parm])
+      }
+      if (testing) {
+        cat("after loops\n")
+      }
       loadNamespace("caret")
       lapply(pkgs, requireNamespaceQuietStop)
-      if(ctrl$verboseIter) progress(printed[parm,,drop = FALSE],
-                                    names(ctrl$index), iter, TRUE)
-      if(is.null(info$submodels[[parm]]) || nrow(info$submodels[[parm]]) > 0) {
+      if (ctrl$verboseIter) {
+        progress(printed[parm, , drop = FALSE], names(ctrl$index), iter, TRUE)
+      }
+      if (is.null(info$submodels[[parm]]) || nrow(info$submodels[[parm]]) > 0) {
         submod <- info$submodels[[parm]]
-      } else submod <- NULL
+      } else {
+        submod <- NULL
+      }
 
       mod <- try(
-        createModel(x = subset_x(x, ctrl$index[[iter]]),
-                    y = y[ctrl$index[[iter]] ],
-                    wts = wts[ctrl$index[[iter]] ],
-                    method = method,
-                    tuneValue = info$loop[parm,,drop = FALSE],
-                    obsLevels = lev,
-                    pp = ppp,
-                    classProbs = ctrl$classProbs,
-                    sampling = ctrl$sampling,
-                    ...),
-        silent = TRUE)
+        createModel(
+          x = subset_x(x, ctrl$index[[iter]]),
+          y = y[ctrl$index[[iter]]],
+          wts = wts[ctrl$index[[iter]]],
+          method = method,
+          tuneValue = info$loop[parm, , drop = FALSE],
+          obsLevels = lev,
+          pp = ppp,
+          classProbs = ctrl$classProbs,
+          sampling = ctrl$sampling,
+          ...
+        ),
+        silent = TRUE
+      )
 
       holdoutIndex <- ctrl$indexOut[[iter]]
 
-      if(!model_failed(mod)) {
+      if (!model_failed(mod)) {
         predicted <- try(
-          predictionFunction(method = method,
-                             modelFit = mod$fit,
-                             newdata = subset_x(x, -ctrl$index[[iter]]),
-                             preProc = mod$preProc,
-                             param = submod),
-          silent = TRUE)
+          predictionFunction(
+            method = method,
+            modelFit = mod$fit,
+            newdata = subset_x(x, -ctrl$index[[iter]]),
+            preProc = mod$preProc,
+            param = submod
+          ),
+          silent = TRUE
+        )
 
-        if(pred_failed(predicted)) {
-          fail_warning(settings = printed[parm,,drop = FALSE],
-                       msg  = predicted,
-                       where = "predictions",
-                       iter = names(ctrl$index)[iter],
-                       verb = ctrl$verboseIter)
+        if (pred_failed(predicted)) {
+          fail_warning(
+            settings = printed[parm, , drop = FALSE],
+            msg = predicted,
+            where = "predictions",
+            iter = names(ctrl$index)[iter],
+            verb = ctrl$verboseIter
+          )
 
           predicted <- fill_failed_pred(index = holdoutIndex, lev = lev, submod)
         }
       } else {
-        fail_warning(settings = printed[parm,,drop = FALSE],
-                     msg  = mod,
-                     iter = names(ctrl$index)[iter],
-                     verb = ctrl$verboseIter)
+        fail_warning(
+          settings = printed[parm, , drop = FALSE],
+          msg = mod,
+          iter = names(ctrl$index)[iter],
+          verb = ctrl$verboseIter
+        )
         predicted <- fill_failed_pred(index = holdoutIndex, lev = lev, submod)
       }
 
-      if(testing) print(head(predicted))
-      if(ctrl$classProbs) {
-        if(!model_failed(mod)) {
-          probValues <- probFunction(method = method,
-                                     modelFit = mod$fit,
-                                     newdata = subset_x(x, holdoutIndex),
-                                     preProc = mod$preProc,
-                                     param = submod)
+      if (testing) {
+        print(head(predicted))
+      }
+      if (ctrl$classProbs) {
+        if (!model_failed(mod)) {
+          probValues <- probFunction(
+            method = method,
+            modelFit = mod$fit,
+            newdata = subset_x(x, holdoutIndex),
+            preProc = mod$preProc,
+            param = submod
+          )
         } else {
           probValues <- fill_failed_prob(holdoutIndex, lev, submod)
         }
-        if(testing) print(head(probValues))
+        if (testing) print(head(probValues))
       }
 
       predicted <- trim_values(predicted, ctrl, is.null(lev))
 
       ##################################
 
-      if(!is.null(info$submodels)) {
+      if (!is.null(info$submodels)) {
         ## collate the predictions across all the sub-models
-        predicted <- lapply(predicted,
-                            function(x, y, wts, lv, rows) {
-                              x <- outcome_conversion(x, lv = lev)
-                              out <- data.frame(pred = x, obs = y, stringsAsFactors = FALSE)
-                              if(!is.null(wts)) out$weights <- wts
-                              out$rowIndex <- rows
-                              out
-                            },
-                            y = y[holdoutIndex],
-                            wts = wts[holdoutIndex],
-                            lv = lev,
-                            rows = seq(along.with = y)[holdoutIndex])
-        if(testing) print(head(predicted))
+        predicted <- lapply(
+          predicted,
+          function(x, y, wts, lv, rows) {
+            x <- outcome_conversion(x, lv = lev)
+            out <- data.frame(pred = x, obs = y, stringsAsFactors = FALSE)
+            if (!is.null(wts)) {
+              out$weights <- wts
+            }
+            out$rowIndex <- rows
+            out
+          },
+          y = y[holdoutIndex],
+          wts = wts[holdoutIndex],
+          lv = lev,
+          rows = seq(along.with = y)[holdoutIndex]
+        )
+        if (testing) {
+          print(head(predicted))
+        }
 
         ## same for the class probabilities
-        if(ctrl$classProbs)
-          for(k in seq(along.with = predicted))
+        if (ctrl$classProbs) {
+          for (k in seq(along.with = predicted)) {
             predicted[[k]] <- cbind(predicted[[k]], probValues[[k]])
+          }
+        }
         predicted <- do.call("rbind", predicted)
-        allParam <- expandParameters(info$loop[parm,,drop = FALSE], submod)
+        allParam <- expandParameters(info$loop[parm, , drop = FALSE], submod)
         rownames(predicted) <- NULL
         predicted <- cbind(predicted, allParam)
         ## if saveDetails then save and export 'predicted'
       } else {
         predicted <- outcome_conversion(predicted, lv = lev)
-        predicted <-  data.frame(pred = predicted,
-                                 obs = y[holdoutIndex],
-                                 stringsAsFactors = FALSE)
-        if(!is.null(wts)) predicted$weights <- wts[holdoutIndex]
-        if(ctrl$classProbs) predicted <- cbind(predicted, probValues)
+        predicted <- data.frame(
+          pred = predicted,
+          obs = y[holdoutIndex],
+          stringsAsFactors = FALSE
+        )
+        if (!is.null(wts)) {
+          predicted$weights <- wts[holdoutIndex]
+        }
+        if (ctrl$classProbs) {
+          predicted <- cbind(predicted, probValues)
+        }
         predicted$rowIndex <- seq(along.with = y)[holdoutIndex]
-        predicted <- cbind(predicted, info$loop[parm,,drop = FALSE])
-
+        predicted <- cbind(predicted, info$loop[parm, , drop = FALSE])
       }
-      if(ctrl$verboseIter) progress(printed[parm,,drop = FALSE],
-                                    names(ctrl$index), iter, FALSE)
+      if (ctrl$verboseIter) {
+        progress(printed[parm, , drop = FALSE], names(ctrl$index), iter, FALSE)
+      }
       predicted
     }
 
   names(result) <- gsub("^\\.", "", names(result))
-  out <- ddply(result,
-               as.character(method$parameter$parameter),
-               ctrl$summaryFunction,
-               lev = lev,
-               model = method)
+  out <- ddply(
+    result,
+    as.character(method$parameter$parameter),
+    ctrl$summaryFunction,
+    lev = lev,
+    model = method
+  )
   list(performance = out, predictions = result)
 }
 
-oobTrainWorkflow <- function(x, y, wts, info, method, ppOpts, ctrl, lev, testing = FALSE, ...)
-{
+oobTrainWorkflow <- function(
+  x,
+  y,
+  wts,
+  info,
+  method,
+  ppOpts,
+  ctrl,
+  lev,
+  testing = FALSE,
+  ...
+) {
   loadNamespace("caret")
   ppp <- list(options = ppOpts)
   ppp <- c(ppp, ctrl$preProcOptions)
@@ -473,32 +687,49 @@ oobTrainWorkflow <- function(x, y, wts, info, method, ppOpts, ctrl, lev, testing
   colnames(printed) <- gsub("^\\.", "", colnames(printed))
   `%op%` <- getOper(ctrl$allowParallel && getDoParWorkers() > 1)
   pkgs <- c("methods", "caret")
-  if(!is.null(method$library)) pkgs <- c(pkgs, method$library)
-  result <- foreach(parm = seq_len(nrow(info$loop)), .combine = "rbind", .packages = "caret") %op%
-  {
-    loadNamespace("caret")
-    lapply(pkgs, requireNamespaceQuietStop)
-    if(ctrl$verboseIter) progress(printed[parm,,drop = FALSE], "", 1, TRUE)
-
-    if(!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds))) set.seed(ctrl$seeds[[1L]][parm])
-
-    mod <- createModel(x = x,
-                       y = y,
-                       wts = wts,
-                       method = method,
-                       tuneValue = info$loop[parm,,drop = FALSE],
-                       obsLevels = lev,
-                       pp = ppp,
-                       classProbs = ctrl$classProbs,
-                       sampling = ctrl$sampling,
-                       ...)
-
-    out <- method$oob(mod$fit)
-
-    if(ctrl$verboseIter) progress(printed[parm,,drop = FALSE], "", 1, FALSE)
-
-    cbind(as.data.frame(t(out), stringsAsFactors = TRUE), info$loop[parm,,drop = FALSE])
+  if (!is.null(method$library)) {
+    pkgs <- c(pkgs, method$library)
   }
+  result <- foreach(
+    parm = seq_len(nrow(info$loop)),
+    .combine = "rbind",
+    .packages = "caret"
+  ) %op%
+    {
+      loadNamespace("caret")
+      lapply(pkgs, requireNamespaceQuietStop)
+      if (ctrl$verboseIter) {
+        progress(printed[parm, , drop = FALSE], "", 1, TRUE)
+      }
+
+      if (!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds))) {
+        set.seed(ctrl$seeds[[1L]][parm])
+      }
+
+      mod <- createModel(
+        x = x,
+        y = y,
+        wts = wts,
+        method = method,
+        tuneValue = info$loop[parm, , drop = FALSE],
+        obsLevels = lev,
+        pp = ppp,
+        classProbs = ctrl$classProbs,
+        sampling = ctrl$sampling,
+        ...
+      )
+
+      out <- method$oob(mod$fit)
+
+      if (ctrl$verboseIter) {
+        progress(printed[parm, , drop = FALSE], "", 1, FALSE)
+      }
+
+      cbind(
+        as.data.frame(t(out), stringsAsFactors = TRUE),
+        info$loop[parm, , drop = FALSE]
+      )
+    }
   names(result) <- gsub("^\\.", "", names(result))
   result
 }
@@ -511,9 +742,9 @@ nominalSbfWorkflow <- function(x, y, ppOpts, ctrl, lev, ...) {
   ppp <- c(ppp, ctrl$preProcOptions)
 
   resampleIndex <- ctrl$index
-  if(ctrl$method %in% c("boot632")){
+  if (ctrl$method %in% c("boot632")) {
     resampleIndex <- c(list("AllData" = rep(0, nrow(x))), resampleIndex)
-    ctrl$indexOut <- c(list("AllData" = rep(0, nrow(x))),  ctrl$indexOut)
+    ctrl$indexOut <- c(list("AllData" = rep(0, nrow(x))), ctrl$indexOut)
   }
 
   `%op%` <- getOper(ctrl$allowParallel && getDoParWorkers() > 1)
@@ -522,71 +753,98 @@ nominalSbfWorkflow <- function(x, y, ppOpts, ctrl, lev, ...) {
     .combine = "c",
     .verbose = FALSE,
     .errorhandling = "stop",
-    .packages = c("caret")) %op% {
-      if (!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds)))
+    .packages = c("caret")
+  ) %op%
+    {
+      if (!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds))) {
         set.seed(ctrl$seeds[iter])
+      }
 
-    loadNamespace("caret")
-    requireNamespaceQuietStop("methods")
-    if(names(resampleIndex)[iter] != "AllData") {
-      modelIndex <- resampleIndex[[iter]]
-      holdoutIndex <- ctrl$indexOut[[iter]]
-    } else {
-      modelIndex <- seq_len(nrow(x))
-      holdoutIndex <- modelIndex
+      loadNamespace("caret")
+      requireNamespaceQuietStop("methods")
+      if (names(resampleIndex)[iter] != "AllData") {
+        modelIndex <- resampleIndex[[iter]]
+        holdoutIndex <- ctrl$indexOut[[iter]]
+      } else {
+        modelIndex <- seq_len(nrow(x))
+        holdoutIndex <- modelIndex
+      }
+
+      sbfResults <- sbfIter(
+        x = subset_x(x, modelIndex),
+        y = y[modelIndex],
+        testX = subset_x(x, holdoutIndex),
+        testY = y[holdoutIndex],
+        sbfControl = ctrl,
+        ...
+      )
+      if (ctrl$saveDetails) {
+        tmpPred <- sbfResults$pred
+        tmpPred$Resample <- names(resampleIndex)[iter]
+        tmpPred$rowIndex <- seq(along.with = y)[unique(holdoutIndex)]
+      } else {
+        tmpPred <- NULL
+      }
+      resamples <- ctrl$functions$summary(sbfResults$pred, lev = lev)
+      if (is.factor(y) && length(lev) <= 50) {
+        resamples <- c(
+          resamples,
+          flatTable(sbfResults$pred$pred, sbfResults$pred$obs)
+        )
+      }
+      resamples <- data.frame(t(resamples))
+      resamples$Resample <- names(resampleIndex)[iter]
+
+      list(
+        resamples = resamples,
+        selectedVars = sbfResults$variables,
+        pred = tmpPred
+      )
     }
 
-    sbfResults <- sbfIter(x = subset_x(x, modelIndex),
-                          y = y[modelIndex],
-                          testX = subset_x(x, holdoutIndex),
-                          testY = y[holdoutIndex],
-                          sbfControl = ctrl,
-                          ...)
-    if(ctrl$saveDetails) {
-      tmpPred <- sbfResults$pred
-      tmpPred$Resample <- names(resampleIndex)[iter]
-      tmpPred$rowIndex <- seq(along.with = y)[unique(holdoutIndex)]
-    } else tmpPred <- NULL
-    resamples <- ctrl$functions$summary(sbfResults$pred, lev = lev)
-    if(is.factor(y) && length(lev) <= 50)
-      resamples <- c(resamples, flatTable(sbfResults$pred$pred, sbfResults$pred$obs))
-    resamples <- data.frame(t(resamples))
-    resamples$Resample <- names(resampleIndex)[iter]
-
-    list(resamples = resamples, selectedVars = sbfResults$variables, pred = tmpPred)
-  }
-
   resamples <- rbind.fill(result[names(result) == "resamples"])
-  pred <- if(ctrl$saveDetails) rbind.fill(result[names(result) == "pred"]) else NULL
-  performance <- MeanSD(resamples[,!grepl("Resample", colnames(resamples)),drop = FALSE])
+  pred <- if (ctrl$saveDetails) {
+    rbind.fill(result[names(result) == "pred"])
+  } else {
+    NULL
+  }
+  performance <- MeanSD(resamples[,
+    !grepl("Resample", colnames(resamples)),
+    drop = FALSE
+  ])
 
-  if(ctrl$method %in% c("boot632")) {
+  if (ctrl$method %in% c("boot632")) {
     modelIndex <- seq_len(nrow(x))
     holdoutIndex <- modelIndex
-    appResults <- sbfIter(subset_x(x, modelIndex),
-                          y[modelIndex],
-                          subset_x(x, holdoutIndex),
-                          y[holdoutIndex],
-                          ctrl,
-                          ...)
+    appResults <- sbfIter(
+      subset_x(x, modelIndex),
+      y[modelIndex],
+      subset_x(x, holdoutIndex),
+      y[holdoutIndex],
+      ctrl,
+      ...
+    )
     apparent <- ctrl$functions$summary(appResults$pred, lev = lev)
     perfNames <- names(apparent)
     perfNames <- perfNames[perfNames != "Resample"]
 
-    const <- 1-exp(-1)
+    const <- 1 - exp(-1)
 
-    for(p in seq(along.with = perfNames))
+    for (p in seq(along.with = perfNames)) {
       performance[perfNames[p]] <-
-      (const * performance[perfNames[p]]) +  ((1-const) * apparent[perfNames[p]])
+        (const * performance[perfNames[p]]) +
+        ((1 - const) * apparent[perfNames[p]])
+    }
   }
 
   list(
     performance = performance,
     everything = result,
-    predictions = if (ctrl$saveDetails)
+    predictions = if (ctrl$saveDetails) {
       pred
-    else
+    } else {
       NULL
+    }
   )
 }
 
@@ -605,160 +863,207 @@ looSbfWorkflow <- function(x, y, ppOpts, ctrl, lev, ...) {
     .combine = "c",
     .verbose = FALSE,
     .errorhandling = "stop",
-    .packages = "caret") %op% {
+    .packages = "caret"
+  ) %op%
+    {
+      if (!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds))) {
+        set.seed(ctrl$seeds[iter])
+      }
 
-    if(!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds)))
-      set.seed(ctrl$seeds[iter])
+      loadNamespace("caret")
+      requireNamespaceQuietStop("methods")
+      modelIndex <- resampleIndex[[iter]]
+      holdoutIndex <- -unique(resampleIndex[[iter]])
 
-    loadNamespace("caret")
-    requireNamespaceQuietStop("methods")
-    modelIndex <- resampleIndex[[iter]]
-    holdoutIndex <- -unique(resampleIndex[[iter]])
+      sbfResults <- sbfIter(
+        subset_x(x, modelIndex),
+        y[modelIndex],
+        subset_x(x, holdoutIndex),
+        y[holdoutIndex],
+        ctrl,
+        ...
+      )
 
-    sbfResults <- sbfIter(subset_x(x, modelIndex),
-                          y[modelIndex],
-                          subset_x(x, holdoutIndex),
-                          y[holdoutIndex],
-                          ctrl,
-                          ...)
-
-    sbfResults
-  }
+      sbfResults
+    }
   resamples <- do.call("rbind", result[names(result) == "pred"])
   performance <- ctrl$functions$summary(resamples, lev = lev)
 
   list(
     performance = performance,
     everything = result,
-    predictions = if (ctrl$saveDetails)
+    predictions = if (ctrl$saveDetails) {
       resamples
-    else
+    } else {
       NULL
+    }
   )
 }
 
 
 ################################################################################################
 
-nominalRfeWorkflow <- function(x, y, sizes, ppOpts, ctrl, lev, ...)
-{
+nominalRfeWorkflow <- function(x, y, sizes, ppOpts, ctrl, lev, ...) {
   loadNamespace("caret")
   ppp <- list(options = ppOpts)
   ppp <- c(ppp, ctrl$preProcOptions)
 
   resampleIndex <- ctrl$index
-  if(ctrl$method %in% c("boot632")) {
+  if (ctrl$method %in% c("boot632")) {
     resampleIndex <- c(list("AllData" = rep(0, nrow(x))), resampleIndex)
-    ctrl$indexOut <- c(list("AllData" = rep(0, nrow(x))),  ctrl$indexOut)
+    ctrl$indexOut <- c(list("AllData" = rep(0, nrow(x))), ctrl$indexOut)
   }
 
   `%op%` <- getOper(ctrl$allowParallel && getDoParWorkers() > 1)
-  result <- foreach(iter = seq(along.with = resampleIndex), .combine = "c", .verbose = FALSE, .errorhandling = "stop", .packages = "caret") %op%
-  {
-    loadNamespace("caret")
-    requireNamespace("plyr")
-    requireNamespace("methods")
-
-    if(names(resampleIndex)[iter] != "AllData") {
-      modelIndex <- resampleIndex[[iter]]
-      holdoutIndex <- ctrl$indexOut[[iter]]
-    } else {
-      modelIndex <- seq_len(nrow(x))
-      holdoutIndex <- modelIndex
-    }
-
-    seeds <- if(!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds))) ctrl$seeds[[iter]] else NA
-    rfeResults <- rfeIter(subset_x(x, modelIndex),
-                          y[modelIndex],
-                          subset_x(x, holdoutIndex),
-                          y[holdoutIndex],
-                          sizes,
-                          ctrl,
-                          label = names(resampleIndex)[iter],
-                          seeds = seeds,
-                          ...)
-    resamples <- plyr::ddply(rfeResults$pred, .(Variables), ctrl$functions$summary, lev = lev)
-
-    if(ctrl$saveDetails)
+  result <- foreach(
+    iter = seq(along.with = resampleIndex),
+    .combine = "c",
+    .verbose = FALSE,
+    .errorhandling = "stop",
+    .packages = "caret"
+  ) %op%
     {
-      rfeResults$pred$Resample <- names(resampleIndex)[iter]
-      ## If the user did not have nrow(x) in 'sizes', rfeIter added it.
-      ## So, we need to find out how many set of predictions there are:
-      nReps <- length(table(rfeResults$pred$Variables))
-      rfeResults$pred$rowIndex <- rep(seq(along.with = y)[unique(holdoutIndex)], nReps)
-    }
+      loadNamespace("caret")
+      requireNamespace("plyr")
+      requireNamespace("methods")
 
-    if(is.factor(y) && length(lev) <= 50) {
-      cells <- plyr::ddply(rfeResults$pred, .(Variables), function(x) flatTable(x$pred, x$obs))
-      resamples <- merge(resamples, cells)
-    }
+      if (names(resampleIndex)[iter] != "AllData") {
+        modelIndex <- resampleIndex[[iter]]
+        holdoutIndex <- ctrl$indexOut[[iter]]
+      } else {
+        modelIndex <- seq_len(nrow(x))
+        holdoutIndex <- modelIndex
+      }
 
-    resamples$Resample <- names(resampleIndex)[iter]
-    vars <- do.call("rbind", rfeResults$finalVariables)
-    vars$Resample <- names(resampleIndex)[iter]
-    list(resamples = resamples, selectedVars = vars, predictions = if(ctrl$saveDetails) rfeResults$pred else NULL)
-  }
+      seeds <- if (!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds))) {
+        ctrl$seeds[[iter]]
+      } else {
+        NA
+      }
+      rfeResults <- rfeIter(
+        subset_x(x, modelIndex),
+        y[modelIndex],
+        subset_x(x, holdoutIndex),
+        y[holdoutIndex],
+        sizes,
+        ctrl,
+        label = names(resampleIndex)[iter],
+        seeds = seeds,
+        ...
+      )
+      resamples <- plyr::ddply(
+        rfeResults$pred,
+        .(Variables),
+        ctrl$functions$summary,
+        lev = lev
+      )
+
+      if (ctrl$saveDetails) {
+        rfeResults$pred$Resample <- names(resampleIndex)[iter]
+        ## If the user did not have nrow(x) in 'sizes', rfeIter added it.
+        ## So, we need to find out how many set of predictions there are:
+        nReps <- length(table(rfeResults$pred$Variables))
+        rfeResults$pred$rowIndex <- rep(
+          seq(along.with = y)[unique(holdoutIndex)],
+          nReps
+        )
+      }
+
+      if (is.factor(y) && length(lev) <= 50) {
+        cells <- plyr::ddply(rfeResults$pred, .(Variables), function(x) {
+          flatTable(x$pred, x$obs)
+        })
+        resamples <- merge(resamples, cells)
+      }
+
+      resamples$Resample <- names(resampleIndex)[iter]
+      vars <- do.call("rbind", rfeResults$finalVariables)
+      vars$Resample <- names(resampleIndex)[iter]
+      list(
+        resamples = resamples,
+        selectedVars = vars,
+        predictions = if (ctrl$saveDetails) rfeResults$pred else NULL
+      )
+    }
   resamples <- do.call("rbind", result[names(result) == "resamples"])
   rownames(resamples) <- NULL
 
-  if(ctrl$method %in% c("boot632"))
-  {
+  if (ctrl$method %in% c("boot632")) {
     perfNames <- names(resamples)
     perfNames <- perfNames[!(perfNames %in% c("Resample", "Variables"))]
     perfNames <- perfNames[!grepl("^cell[0-9]", perfNames)]
     apparent <- subset(resamples, Resample == "AllData")
-    apparent <- apparent[,!grepl("^\\.cell|Resample", colnames(apparent)),drop = FALSE]
-    names(apparent)[which(names(apparent) %in% perfNames)] <- paste(names(apparent)[which(names(apparent) %in% perfNames)],
-                                                                    "Apparent", sep = "")
+    apparent <- apparent[,
+      !grepl("^\\.cell|Resample", colnames(apparent)),
+      drop = FALSE
+    ]
+    names(apparent)[which(names(apparent) %in% perfNames)] <- paste(
+      names(apparent)[which(names(apparent) %in% perfNames)],
+      "Apparent",
+      sep = ""
+    )
     names(apparent) <- gsub("^\\.", "", names(apparent))
     resamples <- subset(resamples, Resample != "AllData")
   }
 
-  externPerf <- plyr::ddply(resamples[,!grepl("\\.cell|Resample", colnames(resamples)),drop = FALSE],
-                      .(Variables),
-                      MeanSD,
-                      exclude = "Variables")
-  if(ctrl$method %in% c("boot632"))
-  {
+  externPerf <- plyr::ddply(
+    resamples[, !grepl("\\.cell|Resample", colnames(resamples)), drop = FALSE],
+    .(Variables),
+    MeanSD,
+    exclude = "Variables"
+  )
+  if (ctrl$method %in% c("boot632")) {
     externPerf <- merge(externPerf, apparent)
-    for(p in seq(along.with = perfNames))
-    {
-      const <- 1-exp(-1)
-      externPerf[, perfNames[p]] <- (const * externPerf[, perfNames[p]]) +  ((1-const) * externPerf[, paste(perfNames[p],"Apparent", sep = "")])
+    for (p in seq(along.with = perfNames)) {
+      const <- 1 - exp(-1)
+      externPerf[, perfNames[p]] <- (const * externPerf[, perfNames[p]]) +
+        ((1 - const) * externPerf[, paste(perfNames[p], "Apparent", sep = "")])
     }
-    externPerf <- externPerf[, !(names(externPerf) %in% paste(perfNames,"Apparent", sep = ""))]
+    externPerf <- externPerf[,
+      !(names(externPerf) %in% paste(perfNames, "Apparent", sep = ""))
+    ]
   }
   list(performance = externPerf, everything = result)
 }
 
-looRfeWorkflow <- function(x, y, sizes, ppOpts, ctrl, lev, ...)
-{
+looRfeWorkflow <- function(x, y, sizes, ppOpts, ctrl, lev, ...) {
   loadNamespace("caret")
   ppp <- list(options = ppOpts)
   ppp <- c(ppp, ctrl$preProcOptions)
 
   resampleIndex <- ctrl$index
   `%op%` <- getOper(ctrl$allowParallel && getDoParWorkers() > 1)
-  result <- foreach(iter = seq(along.with = resampleIndex), .combine = "c", .verbose = FALSE, .errorhandling = "stop", .packages = "caret") %op%
-  {
-    loadNamespace("caret")
-    requireNamespaceQuietStop("methods")
-    modelIndex <- resampleIndex[[iter]]
-    holdoutIndex <- -unique(resampleIndex[[iter]])
+  result <- foreach(
+    iter = seq(along.with = resampleIndex),
+    .combine = "c",
+    .verbose = FALSE,
+    .errorhandling = "stop",
+    .packages = "caret"
+  ) %op%
+    {
+      loadNamespace("caret")
+      requireNamespaceQuietStop("methods")
+      modelIndex <- resampleIndex[[iter]]
+      holdoutIndex <- -unique(resampleIndex[[iter]])
 
-    seeds <- if(!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds))) ctrl$seeds[[iter]] else NA
-    rfeResults <- rfeIter(subset_x(x, modelIndex),
-                          y[modelIndex],
-                          subset_x(x, holdoutIndex),
-                          y[holdoutIndex],
-                          sizes,
-                          ctrl,
-                          seeds = seeds,
-                          ...)
-    rfeResults
-  }
+      seeds <- if (!(length(ctrl$seeds) == 1 && is.na(ctrl$seeds))) {
+        ctrl$seeds[[iter]]
+      } else {
+        NA
+      }
+      rfeResults <- rfeIter(
+        subset_x(x, modelIndex),
+        y[modelIndex],
+        subset_x(x, holdoutIndex),
+        y[holdoutIndex],
+        sizes,
+        ctrl,
+        seeds = seeds,
+        ...
+      )
+      rfeResults
+    }
   preds <- do.call("rbind", result[names(result) == "pred"])
   resamples <- ddply(preds, .(Variables), ctrl$functions$summary, lev = lev)
   list(performance = resamples, everything = result)
 }
-

--- a/tests/testthat/test-dummyVar.R
+++ b/tests/testthat/test-dummyVar.R
@@ -175,6 +175,8 @@ test_that("dummyVars print method", {
   # scrub the formula's environment address, which is not deterministic
   expect_snapshot(
     print(dummyVars(~ Species + Sepal.Length, data = iris)),
-    transform = function(x) sub("<environment: 0x[0-9a-f]+>", "<environment>", x)
+    transform = function(x) {
+      sub("<environment: 0x[0-9a-f]+>", "<environment>", x)
+    }
   )
 })

--- a/tests/testthat/test-ptypes.R
+++ b/tests/testthat/test-ptypes.R
@@ -19,14 +19,24 @@ test_that("ptypes for x/y interface", {
   skip_on_cran()
   none <- trainControl(method = "none")
 
-  xy_plain <- train(x = mtcars_x, y = mtcars$mpg, method = "lm", trControl = none)
+  xy_plain <- train(
+    x = mtcars_x,
+    y = mtcars$mpg,
+    method = "lm",
+    trControl = none
+  )
   xy_oned <- train(
     x = mtcars[, "wt", drop = FALSE],
     y = mtcars$mpg,
     method = "lm",
     trControl = none
   )
-  xy_dmmy <- train(x = sac_x_train, y = sac_y_train, method = "lm", trControl = none)
+  xy_dmmy <- train(
+    x = sac_x_train,
+    y = sac_y_train,
+    method = "lm",
+    trControl = none
+  )
 
   expect_equal(xy_plain$ptype, mtcars_0)
   expect_equal(xy_oned$ptype, wt_0)

--- a/tests/testthat/test-trim.R
+++ b/tests/testthat/test-trim.R
@@ -633,4 +633,3 @@ test_that('train/earth regression', {
   # the earth trim fix (separate PR, branch fix-earth-trim) is merged.
   # expect_lt(object.size(reg_trim), object.size(reg_notrim))
 })
-

--- a/tests/testthat/test-updates.R
+++ b/tests/testthat/test-updates.R
@@ -41,7 +41,12 @@ test_that("safs updating", {
       trControl = trainControl(method = "cv")
     )
   new_iter <- ifelse(sa_xy$optIter == 1, 2, 1)
-  sa_xy_2 <- update(sa_xy, iter = new_iter, x = updates_dat[, -updates_y_ind], y = updates_dat$y)
+  sa_xy_2 <- update(
+    sa_xy,
+    iter = new_iter,
+    x = updates_dat[, -updates_y_ind],
+    y = updates_dat$y
+  )
   expect_true(diff_coef(sa_xy, sa_xy_2))
   expect_snapshot(update(sa_xy, iter = new_iter), error = TRUE)
 
@@ -84,7 +89,12 @@ test_that("gafs updating", {
       trControl = trainControl(method = "cv")
     )
   new_iter <- ifelse(ga_xy$optIter == 1, 2, 1)
-  ga_xy_2 <- update(ga_xy, iter = new_iter, x = updates_dat[, -updates_y_ind], y = updates_dat$y)
+  ga_xy_2 <- update(
+    ga_xy,
+    iter = new_iter,
+    x = updates_dat[, -updates_y_ind],
+    y = updates_dat$y
+  )
   expect_true(diff_coef(ga_xy, ga_xy_2))
   expect_snapshot(update(ga_xy, iter = new_iter), error = TRUE)
 


### PR DESCRIPTION
Run `air format` (air 0.9.0) across the package source (R/) and tests (tests/). 

To stop air exploding large pre-computed value vectors into one element per line, add `# fmt: skip`:
- R/caretTheme.R
- R/varImp.R

(Test expected-value vectors were already guarded with `# fmt: skip`.) inst/model_sources/files (239 model-definition files) are out of scope.