### PR TITLE
Apply air formatting to inst/ R files

### DIFF
--- a/inst/bookdown/make_files.R
+++ b/inst/bookdown/make_files.R
@@ -9,5 +9,6 @@ registerDoMC(cores = parallel::detectCores(logical = TRUE))
 
 render_book("index.Rmd", "bookdown::gitbook")
 
-if (!interactive()) 
+if (!interactive()) {
   q("no")
+}

--- a/inst/model_sources/files/ANFIS.R
+++ b/inst/model_sources/files/ANFIS.R
@@ -1,49 +1,57 @@
-modelInfo <- list(label = "Adaptive-Network-Based Fuzzy Inference System",
-                  library = "frbs",
-                  type = "Regression",
-                  parameters = data.frame(parameter = c('num.labels', 'max.iter'),
-                                          class = c("numeric", "numeric"),
-                                          label = c('#Fuzzy Terms', 'Max. Iterations')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(num.labels = 1+(1:len)*2, max.iter = 10)
-                    } else {
-                      out <- data.frame(num.labels = sample(1:10, replace = TRUE, size = len),
-                                        max.iter = sample(1:20, replace = TRUE, size = len))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    args <- list(data.train = as.matrix(cbind(x, y)),
-                                 method.type = "ANFIS")
-                    
-                    theDots <- list(...)
-                    if(any(names(theDots) == "control")) {
-                      theDots$control$num.labels <- param$num.labels                  
-                      theDots$control$max.iter <- param$max.iter
-                    } else theDots$control <- list(num.labels = param$num.labels,                  
-                                                   max.iter = param$max.iter,
-                                                   max.iter = 10,
-                                                   step.size = 0.01, 
-                                                   type.tnorm = "MIN",
-                                                   type.snorm = "MAX", 
-                                                   type.implication.func = "ZADEH",
-                                                   name="sim-0")    
-                  
-                    if(!(any(names(theDots) == "range.data"))) {
-                      args$range.data <- apply(args$data.train, 2, extendrange)
-                    }
-                    do.call(frbs::frbs.learn, c(args, theDots))
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    predict(modelFit, newdata)[,1]
-                  },
-                  prob = NULL,
-                  predictors = function(x, ...){
-                    x$colnames.var[x$colnames.var %in% as.vector(x$rule)]
-                  },
-                  tags = c("Rule-Based Model"),
-                  levels = NULL,
-                  sort = function(x) x[order(x$num.labels),])
-                    
+modelInfo <- list(
+  label = "Adaptive-Network-Based Fuzzy Inference System",
+  library = "frbs",
+  type = "Regression",
+  parameters = data.frame(
+    parameter = c('num.labels', 'max.iter'),
+    class = c("numeric", "numeric"),
+    label = c('#Fuzzy Terms', 'Max. Iterations')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(num.labels = 1 + (1:len) * 2, max.iter = 10)
+    } else {
+      out <- data.frame(
+        num.labels = sample(1:10, replace = TRUE, size = len),
+        max.iter = sample(1:20, replace = TRUE, size = len)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    args <- list(data.train = as.matrix(cbind(x, y)), method.type = "ANFIS")
+
+    theDots <- list(...)
+    if (any(names(theDots) == "control")) {
+      theDots$control$num.labels <- param$num.labels
+      theDots$control$max.iter <- param$max.iter
+    } else {
+      theDots$control <- list(
+        num.labels = param$num.labels,
+        max.iter = param$max.iter,
+        max.iter = 10,
+        step.size = 0.01,
+        type.tnorm = "MIN",
+        type.snorm = "MAX",
+        type.implication.func = "ZADEH",
+        name = "sim-0"
+      )
+    }
+
+    if (!(any(names(theDots) == "range.data"))) {
+      args$range.data <- apply(args$data.train, 2, extendrange)
+    }
+    do.call(frbs::frbs.learn, c(args, theDots))
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)[, 1]
+  },
+  prob = NULL,
+  predictors = function(x, ...) {
+    x$colnames.var[x$colnames.var %in% as.vector(x$rule)]
+  },
+  tags = c("Rule-Based Model"),
+  levels = NULL,
+  sort = function(x) x[order(x$num.labels), ]
+)

--- a/inst/model_sources/files/AdaBag.R
+++ b/inst/model_sources/files/AdaBag.R
@@ -1,107 +1,141 @@
-modelInfo <- list(label = "Bagged AdaBoost",
-                  library = c("adabag", "plyr"),
-                  loop = function(grid) {     
-                    loop <- plyr::ddply(grid, c("maxdepth"),
-                                  function(x) c(mfinal = max(x$mfinal)))
-                    submodels <- vector(mode = "list", length = nrow(loop))
-                    for(i in seq(along = loop$mfinal)) {
-                      index <- which(grid$maxdepth == loop$maxdepth[i])
-                      trees <- grid[index, "mfinal",drop = FALSE] 
-                      submodels[[i]] <- data.frame(mfinal = trees[trees != loop$mfinal[i]])
-                    }    
-                    list(loop = loop, submodels = submodels)
-                  },
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = c('mfinal', 'maxdepth'),
-                                          class = c("numeric", "numeric"),
-                                          label = c('#Trees', 'Max Tree Depth')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(mfinal = floor((1:len) * 50),
-                                         maxdepth = seq(1, len))
-                    } else {
-                      out <- data.frame(mfinal = sample(1:100, replace = TRUE, size = len),
-                                        maxdepth = sample(1:30, replace = TRUE, size = len))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    theDots <- list(...)
-                    
-                    if(any(names(theDots) == "control")) {
-                      theDots$control$maxdepth <- param$maxdepth 
-                      ctl <- theDots$control
-                      theDots$control <- NULL
-                      
-                    } else ctl <- rpart::rpart.control(maxdepth = param$maxdepth,
-                                                cp=-1,minsplit=0,xval=0) 
-                    
-                    if (!is.data.frame(x) | inherits(x, "tbl_df"))
-                      x <- as.data.frame(x, stringsAsFactors = TRUE)
-                    
-                    modelArgs <- c(list(formula = as.formula(.outcome ~ .),
-                                        data = x,
-                                        mfinal = param$mfinal,            
-                                        control = ctl),
-                                   theDots)
-                    modelArgs$data$.outcome <- y
-                    out <- do.call(adabag::bagging, modelArgs)                    
-                    out     
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if (!is.data.frame(newdata) | inherits(newdata, "tbl_df"))
-                      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    ## The predict function requires the outcome! Trick it by
-                    ## adding bogus data
-                    newdata$.outcome <- factor(rep(modelFit$obsLevels[1], nrow(newdata)), 
-                                               levels = modelFit$obsLevels)
-                    out <- predict(modelFit, newdata, 
-                                   newmfinal = modelFit$tuneValue$mfinal)$class
-                    
-                    if(!is.null(submodels)) {
-                      tmp <- vector(mode = "list", length = length(submodels$mfinal)+1)
-                      tmp[[1]] <- out
-                      for(i in seq(along = submodels$mfinal)) {
-                        tmp[[i+1]] <- predict(modelFit, newdata, 
-                                              newmfinal = submodels$mfinal[[i]])$class
-                      }
-                      out <- tmp
-                    }       
-                    out  
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL){
-                    if (!is.data.frame(newdata) | inherits(newdata, "tbl_df"))
-                      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    ## The predict function requires the outcome! Trick it by
-                    ## adding bogus data
-                    newdata$.outcome <- factor(rep(modelFit$obsLevels[1], nrow(newdata)), 
-                                               levels = modelFit$obsLevels)
-                    out <- predict(modelFit, newdata)$prob
-                    colnames(out) <- modelFit$obsLevels
-                    
-                    if(!is.null(submodels)) {
-                      tmp <- vector(mode = "list", length = length(submodels$mfinal)+1)
-                      tmp[[1]] <- out
-                      for(i in seq(along = submodels$mfinal)) {
-                        tmp[[i+1]] <- predict(modelFit, newdata,  
-                                              newmfinal = submodels$mfinal[[i]])$prob
-                        colnames(tmp[[i+1]]) <- modelFit$obsLevels
-                      }
-                      out <- lapply(tmp, as.data.frame)
-                    }
-                    
-                    out 
-                  },
-                  varImp = function(object, ...){
-                    imps <- data.frame(Overall = object$importance)
-                    rownames(imps) <- names(object$importance)
-                    imps
-                  },
-                  levels = function(x) x$obsLevels,
-                  predictors = function(x, ...) names(x$importance)[x$importance != 0],
-                  tags = c("Tree-Based Model", "Ensemble Model", "Boosting", "Bagging",
-                           "Implicit Feature Selection", "Handle Missing Predictor Data"),
-                  sort = function(x) x[order(x$mfinal, x$maxdepth),])
+modelInfo <- list(
+  label = "Bagged AdaBoost",
+  library = c("adabag", "plyr"),
+  loop = function(grid) {
+    loop <- plyr::ddply(grid, c("maxdepth"), function(x) {
+      c(mfinal = max(x$mfinal))
+    })
+    submodels <- vector(mode = "list", length = nrow(loop))
+    for (i in seq(along = loop$mfinal)) {
+      index <- which(grid$maxdepth == loop$maxdepth[i])
+      trees <- grid[index, "mfinal", drop = FALSE]
+      submodels[[i]] <- data.frame(mfinal = trees[trees != loop$mfinal[i]])
+    }
+    list(loop = loop, submodels = submodels)
+  },
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = c('mfinal', 'maxdepth'),
+    class = c("numeric", "numeric"),
+    label = c('#Trees', 'Max Tree Depth')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(mfinal = floor((1:len) * 50), maxdepth = seq(1, len))
+    } else {
+      out <- data.frame(
+        mfinal = sample(1:100, replace = TRUE, size = len),
+        maxdepth = sample(1:30, replace = TRUE, size = len)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    theDots <- list(...)
 
+    if (any(names(theDots) == "control")) {
+      theDots$control$maxdepth <- param$maxdepth
+      ctl <- theDots$control
+      theDots$control <- NULL
+    } else {
+      ctl <- rpart::rpart.control(
+        maxdepth = param$maxdepth,
+        cp = -1,
+        minsplit = 0,
+        xval = 0
+      )
+    }
 
+    if (!is.data.frame(x) | inherits(x, "tbl_df")) {
+      x <- as.data.frame(x, stringsAsFactors = TRUE)
+    }
 
+    modelArgs <- c(
+      list(
+        formula = as.formula(.outcome ~ .),
+        data = x,
+        mfinal = param$mfinal,
+        control = ctl
+      ),
+      theDots
+    )
+    modelArgs$data$.outcome <- y
+    out <- do.call(adabag::bagging, modelArgs)
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata) | inherits(newdata, "tbl_df")) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    ## The predict function requires the outcome! Trick it by
+    ## adding bogus data
+    newdata$.outcome <- factor(
+      rep(modelFit$obsLevels[1], nrow(newdata)),
+      levels = modelFit$obsLevels
+    )
+    out <- predict(
+      modelFit,
+      newdata,
+      newmfinal = modelFit$tuneValue$mfinal
+    )$class
+
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = length(submodels$mfinal) + 1)
+      tmp[[1]] <- out
+      for (i in seq(along = submodels$mfinal)) {
+        tmp[[i + 1]] <- predict(
+          modelFit,
+          newdata,
+          newmfinal = submodels$mfinal[[i]]
+        )$class
+      }
+      out <- tmp
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata) | inherits(newdata, "tbl_df")) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    ## The predict function requires the outcome! Trick it by
+    ## adding bogus data
+    newdata$.outcome <- factor(
+      rep(modelFit$obsLevels[1], nrow(newdata)),
+      levels = modelFit$obsLevels
+    )
+    out <- predict(modelFit, newdata)$prob
+    colnames(out) <- modelFit$obsLevels
+
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = length(submodels$mfinal) + 1)
+      tmp[[1]] <- out
+      for (i in seq(along = submodels$mfinal)) {
+        tmp[[i + 1]] <- predict(
+          modelFit,
+          newdata,
+          newmfinal = submodels$mfinal[[i]]
+        )$prob
+        colnames(tmp[[i + 1]]) <- modelFit$obsLevels
+      }
+      out <- lapply(tmp, as.data.frame)
+    }
+
+    out
+  },
+  varImp = function(object, ...) {
+    imps <- data.frame(Overall = object$importance)
+    rownames(imps) <- names(object$importance)
+    imps
+  },
+  levels = function(x) x$obsLevels,
+  predictors = function(x, ...) names(x$importance)[x$importance != 0],
+  tags = c(
+    "Tree-Based Model",
+    "Ensemble Model",
+    "Boosting",
+    "Bagging",
+    "Implicit Feature Selection",
+    "Handle Missing Predictor Data"
+  ),
+  sort = function(x) x[order(x$mfinal, x$maxdepth), ]
+)

--- a/inst/model_sources/files/AdaBoost.M1.R
+++ b/inst/model_sources/files/AdaBoost.M1.R
@@ -1,109 +1,150 @@
-modelInfo <- list(label = "AdaBoost.M1",
-                  library = c("adabag", "plyr"),
-                  loop = function(grid) {     
-                    loop <- plyr::ddply(grid, c("coeflearn", "maxdepth"),
-                                  function(x) c(mfinal = max(x$mfinal)))
-                    submodels <- vector(mode = "list", length = nrow(loop))
-                    for(i in seq(along = loop$mfinal)) {
-                      index <- which(grid$maxdepth == loop$maxdepth[i] & 
-                                       grid$coeflearn == loop$coeflearn[i])
-                      trees <- grid[index, "mfinal"] 
-                      submodels[[i]] <- data.frame(mfinal = trees[trees != loop$mfinal[i]])
-                    }    
-                    list(loop = loop, submodels = submodels)
-                  },
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = c('mfinal', 'maxdepth', 'coeflearn'),
-                                          class = c("numeric", "numeric", "character"),
-                                          label = c('#Trees', 'Max Tree Depth', 'Coefficient Type')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    types <- c("Breiman", "Freund", "Zhu")
-                    if(search == "grid") {
-                      out <- expand.grid(mfinal = floor((1:len) * 50),
-                                         maxdepth = seq(1, len),         
-                                         coeflearn = types)
-                    } else {
-                      out <- data.frame(mfinal = sample(1:100, replace = TRUE, size = len),
-                                        maxdepth = sample(1:30, replace = TRUE, size = len),
-                                        coeflearn = sample(types, replace = TRUE, size = len))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    theDots <- list(...)
-                    
-                    if(any(names(theDots) == "control")) {
-                      theDots$control$maxdepth <- param$maxdepth 
-                      ctl <- theDots$control
-                      theDots$control <- NULL
-                      
-                    } else ctl <- rpart::rpart.control(maxdepth = param$maxdepth,
-                                                cp=-1,minsplit=0,xval=0) 
-                    
-                    if (!is.data.frame(x) | inherits(x, "tbl_df"))
-                      x <- as.data.frame(x, stringsAsFactors = TRUE)
-                    
-                    modelArgs <- c(list(formula = as.formula(.outcome ~ .),
-                                        data = x,
-                                        mfinal = param$mfinal,
-                                        coeflearn = as.character(param$coeflearn),              
-                                        control = ctl),
-                                   theDots)
-                    modelArgs$data$.outcome <- y
-                    out <- do.call(adabag::boosting, modelArgs)                    
-                    out     
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if (!is.data.frame(newdata) | inherits(newdata, "tbl_df"))
-                      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    ## The predict function requires the outcome! Trick it by
-                    ## adding bogus data
-                    newdata$.outcome <- factor(rep(modelFit$obsLevels[1], nrow(newdata)), 
-                                               levels = modelFit$obsLevels)
-                    out <- predict(modelFit, newdata, 
-                                   newmfinal = modelFit$tuneValue$mfinal)$class
-                    
-                    if(!is.null(submodels)) {
-                      tmp <- vector(mode = "list", length = length(submodels$mfinal)+1)
-                      tmp[[1]] <- out
-                      for(i in seq(along = submodels$mfinal)) {
-                        tmp[[i+1]] <- predict(modelFit, newdata, 
-                                              newmfinal = submodels$mfinal[[i]])$class
-                      }
-                      out <- tmp
-                    }       
-                    out  
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL){
-                    if (!is.data.frame(newdata) | inherits(newdata, "tbl_df"))
-                      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    ## The predict function requires the outcome! Trick it by
-                    ## adding bogus data
-                    newdata$.outcome <- factor(rep(modelFit$obsLevels[1], nrow(newdata)), 
-                                               levels = modelFit$obsLevels)
-                    out <- predict(modelFit, newdata)$prob
-                    colnames(out) <- modelFit$obsLevels
-                    
-                    if(!is.null(submodels)) {
-                      tmp <- vector(mode = "list", length = length(submodels$mfinal)+1)
-                      tmp[[1]] <- out
-                      for(i in seq(along = submodels$mfinal)) {
-                        tmp[[i+1]] <- predict(modelFit, newdata,  
-                                              newmfinal = submodels$mfinal[[i]])$prob
-                        colnames(tmp[[i+1]]) <- modelFit$obsLevels
-                      }
-                      out <- lapply(tmp, as.data.frame)
-                    }
-                    
-                    out 
-                  },
-                  levels = function(x) x$obsLevels,
-                  varImp = function(object, ...){
-                    imps <- data.frame(Overall = object$importance)
-                    rownames(imps) <- names(object$importance)
-                    imps
-                  },
-                  predictors = function(x, ...) names(x$importance)[x$importance != 0],
-                  tags = c("Tree-Based Model", "Ensemble Model", "Boosting", 
-                           "Implicit Feature Selection", "Handle Missing Predictor Data"),
-                  sort = function(x) x[order(x$mfinal, x$maxdepth),])
+modelInfo <- list(
+  label = "AdaBoost.M1",
+  library = c("adabag", "plyr"),
+  loop = function(grid) {
+    loop <- plyr::ddply(grid, c("coeflearn", "maxdepth"), function(x) {
+      c(mfinal = max(x$mfinal))
+    })
+    submodels <- vector(mode = "list", length = nrow(loop))
+    for (i in seq(along = loop$mfinal)) {
+      index <- which(
+        grid$maxdepth == loop$maxdepth[i] &
+          grid$coeflearn == loop$coeflearn[i]
+      )
+      trees <- grid[index, "mfinal"]
+      submodels[[i]] <- data.frame(mfinal = trees[trees != loop$mfinal[i]])
+    }
+    list(loop = loop, submodels = submodels)
+  },
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = c('mfinal', 'maxdepth', 'coeflearn'),
+    class = c("numeric", "numeric", "character"),
+    label = c('#Trees', 'Max Tree Depth', 'Coefficient Type')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    types <- c("Breiman", "Freund", "Zhu")
+    if (search == "grid") {
+      out <- expand.grid(
+        mfinal = floor((1:len) * 50),
+        maxdepth = seq(1, len),
+        coeflearn = types
+      )
+    } else {
+      out <- data.frame(
+        mfinal = sample(1:100, replace = TRUE, size = len),
+        maxdepth = sample(1:30, replace = TRUE, size = len),
+        coeflearn = sample(types, replace = TRUE, size = len)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    theDots <- list(...)
+
+    if (any(names(theDots) == "control")) {
+      theDots$control$maxdepth <- param$maxdepth
+      ctl <- theDots$control
+      theDots$control <- NULL
+    } else {
+      ctl <- rpart::rpart.control(
+        maxdepth = param$maxdepth,
+        cp = -1,
+        minsplit = 0,
+        xval = 0
+      )
+    }
+
+    if (!is.data.frame(x) | inherits(x, "tbl_df")) {
+      x <- as.data.frame(x, stringsAsFactors = TRUE)
+    }
+
+    modelArgs <- c(
+      list(
+        formula = as.formula(.outcome ~ .),
+        data = x,
+        mfinal = param$mfinal,
+        coeflearn = as.character(param$coeflearn),
+        control = ctl
+      ),
+      theDots
+    )
+    modelArgs$data$.outcome <- y
+    out <- do.call(adabag::boosting, modelArgs)
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata) | inherits(newdata, "tbl_df")) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    ## The predict function requires the outcome! Trick it by
+    ## adding bogus data
+    newdata$.outcome <- factor(
+      rep(modelFit$obsLevels[1], nrow(newdata)),
+      levels = modelFit$obsLevels
+    )
+    out <- predict(
+      modelFit,
+      newdata,
+      newmfinal = modelFit$tuneValue$mfinal
+    )$class
+
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = length(submodels$mfinal) + 1)
+      tmp[[1]] <- out
+      for (i in seq(along = submodels$mfinal)) {
+        tmp[[i + 1]] <- predict(
+          modelFit,
+          newdata,
+          newmfinal = submodels$mfinal[[i]]
+        )$class
+      }
+      out <- tmp
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata) | inherits(newdata, "tbl_df")) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    ## The predict function requires the outcome! Trick it by
+    ## adding bogus data
+    newdata$.outcome <- factor(
+      rep(modelFit$obsLevels[1], nrow(newdata)),
+      levels = modelFit$obsLevels
+    )
+    out <- predict(modelFit, newdata)$prob
+    colnames(out) <- modelFit$obsLevels
+
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = length(submodels$mfinal) + 1)
+      tmp[[1]] <- out
+      for (i in seq(along = submodels$mfinal)) {
+        tmp[[i + 1]] <- predict(
+          modelFit,
+          newdata,
+          newmfinal = submodels$mfinal[[i]]
+        )$prob
+        colnames(tmp[[i + 1]]) <- modelFit$obsLevels
+      }
+      out <- lapply(tmp, as.data.frame)
+    }
+
+    out
+  },
+  levels = function(x) x$obsLevels,
+  varImp = function(object, ...) {
+    imps <- data.frame(Overall = object$importance)
+    rownames(imps) <- names(object$importance)
+    imps
+  },
+  predictors = function(x, ...) names(x$importance)[x$importance != 0],
+  tags = c(
+    "Tree-Based Model",
+    "Ensemble Model",
+    "Boosting",
+    "Implicit Feature Selection",
+    "Handle Missing Predictor Data"
+  ),
+  sort = function(x) x[order(x$mfinal, x$maxdepth), ]
+)

--- a/inst/model_sources/files/BstLm.R
+++ b/inst/model_sources/files/BstLm.R
@@ -36,9 +36,15 @@ modelInfo <- list(
     }
 
     theDots <- list(...)
-    modDist <- if (is.factor(y)) "hinge" else "gaussian"
+    if (is.factor(y)) {
+      modDist <- "hinge"
+    } else {
+      modDist <- "gaussian"
+    }
 
-    y <- if (is.factor(y)) ifelse(y == lev[1], 1, -1) else y
+    if (is.factor(y)) {
+      y <- ifelse(y == lev[1], 1, -1)
+    }
 
     if (any(names(theDots) == "ctrl")) {
       theDots$ctrl$mstop <- param$mstop

--- a/inst/model_sources/files/BstLm.R
+++ b/inst/model_sources/files/BstLm.R
@@ -1,80 +1,117 @@
-modelInfo <- list(label = "Boosted Linear Model", 
-                  library = c("bst", "plyr"),
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('mstop', 'nu'),
-                                          class = c("numeric", "numeric"),
-                                          label = c('# Boosting Iterations', 'Shrinkage')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(mstop = floor((1:len) * 50), nu = .1)
-                    } else {
-                      out <- data.frame(mstop = floor(runif(len, min = 1, max = 500)),        
-                                        nu = runif(len, min = .001, max = .6))
-                    }
-                    out
-                  },
-                  loop = function(grid) {   
-                    loop <- plyr::ddply(grid, plyr::`.`(nu), function(x) c(mstop = max(x$mstop)))
-                    submodels <- vector(mode = "list", length = nrow(loop))
-                    for(i in seq(along = loop$mstop))
-                    {
-                      index <- which(grid$nu == loop$nu[i])
-                      subTrees <- grid[index, "mstop"] 
-                      submodels[[i]] <- data.frame(mstop = subTrees[subTrees != loop$mstop[i]])
-                    }      
-                    list(loop = loop, submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    if(!is.data.frame(x) | inherits(x, "tbl_df")) 
-                      x <- as.data.frame(x, stringsAsFactors = TRUE)
-                    
-                    theDots <- list(...)
-                    modDist <- if(is.factor(y)) "hinge" else "gaussian"
-                    
-                    y <- if(is.factor(y)) ifelse(y == lev[1], 1, -1) else y
-                    
-                    if(any(names(theDots) == "ctrl")) {
-                      theDots$ctrl$mstop <- param$mstop
-                      theDots$ctrl$nu <- param$nu
-                    } else {
-                      theDots$ctrl <- bst::bst_control(mstop = param$mstop, nu = param$nu)
-                    }
-                    
-                    modArgs <- list(x = x, y = y, family = modDist, learner = "ls")
-                    modArgs <- c(modArgs, theDots)
-                    
-                    out <- do.call(bst::bst, modArgs)
-                    out$call <- quote(redacted)
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata) | inherits(newdata, "tbl_df")) 
-                      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    if(modelFit$problemType == "Classification") {
-                      out <- predict(modelFit, newdata, type = "class", mstop = modelFit$submodels$mstop)
-                      out <- ifelse(out == 1, modelFit$obsLevels[1], modelFit$obsLevels[2])
-                    } else {
-                      out <- predict(modelFit, newdata, type = "response", mstop = modelFit$submodels$mstop)
-                    }
-                    
-                    if(!is.null(submodels)) {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
-                      
-                      for(j in seq(along = submodels$mstop)) {
-                        if(modelFit$problemType == "Classification") {
-                          bstPred <- predict(modelFit, newdata, type = "class", mstop = submodels$mstop[j])
-                          tmp[[j+1]] <- ifelse(bstPred == 1, modelFit$obsLevels[1], modelFit$obsLevels[2])
-                        } else {
-                          tmp[[j+1]]  <- predict(modelFit, newdata, type = "response", mstop = submodels$mstop[j])
-                        }
-                      }
-                      out <- tmp
-                    }
-                    out         
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("Linear Regression", "Ensemble Model", "Boosting",
-                           "Implicit Feature Selection"),
-                  prob = NULL,
-                  sort = function(x) x[order(x$mstop, x$nu),] )
+modelInfo <- list(
+  label = "Boosted Linear Model",
+  library = c("bst", "plyr"),
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c('mstop', 'nu'),
+    class = c("numeric", "numeric"),
+    label = c('# Boosting Iterations', 'Shrinkage')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(mstop = floor((1:len) * 50), nu = .1)
+    } else {
+      out <- data.frame(
+        mstop = floor(runif(len, min = 1, max = 500)),
+        nu = runif(len, min = .001, max = .6)
+      )
+    }
+    out
+  },
+  loop = function(grid) {
+    loop <- plyr::ddply(grid, plyr::`.`(nu), function(x) {
+      c(mstop = max(x$mstop))
+    })
+    submodels <- vector(mode = "list", length = nrow(loop))
+    for (i in seq(along = loop$mstop)) {
+      index <- which(grid$nu == loop$nu[i])
+      subTrees <- grid[index, "mstop"]
+      submodels[[i]] <- data.frame(mstop = subTrees[subTrees != loop$mstop[i]])
+    }
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (!is.data.frame(x) | inherits(x, "tbl_df")) {
+      x <- as.data.frame(x, stringsAsFactors = TRUE)
+    }
+
+    theDots <- list(...)
+    modDist <- if (is.factor(y)) "hinge" else "gaussian"
+
+    y <- if (is.factor(y)) ifelse(y == lev[1], 1, -1) else y
+
+    if (any(names(theDots) == "ctrl")) {
+      theDots$ctrl$mstop <- param$mstop
+      theDots$ctrl$nu <- param$nu
+    } else {
+      theDots$ctrl <- bst::bst_control(mstop = param$mstop, nu = param$nu)
+    }
+
+    modArgs <- list(x = x, y = y, family = modDist, learner = "ls")
+    modArgs <- c(modArgs, theDots)
+
+    out <- do.call(bst::bst, modArgs)
+    out$call <- quote(redacted)
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata) | inherits(newdata, "tbl_df")) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    if (modelFit$problemType == "Classification") {
+      out <- predict(
+        modelFit,
+        newdata,
+        type = "class",
+        mstop = modelFit$submodels$mstop
+      )
+      out <- ifelse(out == 1, modelFit$obsLevels[1], modelFit$obsLevels[2])
+    } else {
+      out <- predict(
+        modelFit,
+        newdata,
+        type = "response",
+        mstop = modelFit$submodels$mstop
+      )
+    }
+
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
+
+      for (j in seq(along = submodels$mstop)) {
+        if (modelFit$problemType == "Classification") {
+          bstPred <- predict(
+            modelFit,
+            newdata,
+            type = "class",
+            mstop = submodels$mstop[j]
+          )
+          tmp[[j + 1]] <- ifelse(
+            bstPred == 1,
+            modelFit$obsLevels[1],
+            modelFit$obsLevels[2]
+          )
+        } else {
+          tmp[[j + 1]] <- predict(
+            modelFit,
+            newdata,
+            type = "response",
+            mstop = submodels$mstop[j]
+          )
+        }
+      }
+      out <- tmp
+    }
+    out
+  },
+  levels = function(x) x$obsLevels,
+  tags = c(
+    "Linear Regression",
+    "Ensemble Model",
+    "Boosting",
+    "Implicit Feature Selection"
+  ),
+  prob = NULL,
+  sort = function(x) x[order(x$mstop, x$nu), ]
+)

--- a/inst/model_sources/files/C5.0.R
+++ b/inst/model_sources/files/C5.0.R
@@ -1,92 +1,124 @@
-modelInfo <- list(label = "C5.0", 
-                  library = c("C50", "plyr"),
-                  loop = function(grid) {     
-                    loop <- plyr::ddply(grid, c("model", "winnow"),
-                                  function(x) c(trials = max(x$trials)))                 
-                    
-                    submodels <- vector(mode = "list", length = nrow(loop))
-                    for(i in seq(along = loop$trials))
-                    {
-                      index <- which(grid$model == loop$model[i] & 
-                                       grid$winnow == loop$winnow[i])
-                      trials <- grid[index, "trials"] 
-                      submodels[[i]] <- data.frame(trials = trials[trials != loop$trials[i]])
-                    }     
-                    list(loop = loop, submodels = submodels)
-                  },
-                  type = "Classification",
-                  parameters = data.frame(parameter = c('trials', 'model', 'winnow'),
-                                          class = c("numeric", "character", "logical"),
-                                          label = c('# Boosting Iterations', 'Model Type', 'Winnow')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      c5seq <- if(len == 1)  1 else  c(1, 10*((2:min(len, 11)) - 1))
-                      out <- expand.grid(trials = c5seq, model = c("tree", "rules"), winnow = c(TRUE, FALSE))
-                    } else {
-                      out <- data.frame(trials = sample(1:100, replace = TRUE, size = len),
-                                        model = sample(c("tree", "rules"), replace = TRUE, size = len),
-                                        winnow = sample(c(TRUE, FALSE), replace = TRUE, size = len))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    theDots <- list(...)
-                    
-                    if(any(names(theDots) == "control"))
-                    {                           
-                      theDots$control$winnow <- param$winnow
-                    } else theDots$control <- C50::C5.0Control(winnow = param$winnow)
-                    argList <- list(x = x, y = y, weights = wts, trials = param$trials,
-                                    rules = param$model == "rules")
-                    argList <- c(argList, theDots)
-                    do.call(C50:::C5.0.default, argList)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata)
-                    
-                    if(!is.null(submodels))
-                    {
-                      tmp <- out
-                      out <- vector(mode = "list", length = nrow(submodels) + 1)
-                      out[[1]] <- tmp
-                      
-                      for(j in seq(along = submodels$trials))
-                        out[[j+1]] <- as.character(predict(modelFit, newdata, trial = submodels$trials[j]))
-                    }
-                    out              
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata, type= "prob")
-                    
-                    if(!is.null(submodels))
-                    {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
-                      
-                      for(j in seq(along = submodels$trials))
-                      {
-                        tmp[[j+1]] <- predict(modelFit, newdata, type= "prob", trials = submodels$trials[j])
-                      }
-                      out <- tmp
-                    }
-                    out
-                  },
-                  levels = function(x) x$obsLevels,
-                  predictors = function(x, ...) {
-                    vars <- C50::C5imp(x, metric = "splits")
-                    rownames(vars)[vars$Overall > 0]
-                  },
-                  varImp = function(object, ...) C50::C5imp(object, ...),
-                  tags = c("Tree-Based Model", "Rule-Based Model", "Implicit Feature Selection",
-                           "Boosting", "Ensemble Model", "Handle Missing Predictor Data", "Accepts Case Weights"),
-                  sort = function(x) {
-                    x$model <- factor(as.character(x$model), levels = c("rules", "tree"))
-                    x[order(x$trials, x$model, !x$winnow),]
-                  },
-                  trim = function(x) {
-                    x$boostResults <- NULL
-                    x$size <- NULL
-                    x$call <- NULL
-                    x$output <- NULL
-                    x
-                  })
+modelInfo <- list(
+  label = "C5.0",
+  library = c("C50", "plyr"),
+  loop = function(grid) {
+    loop <- plyr::ddply(grid, c("model", "winnow"), function(x) {
+      c(trials = max(x$trials))
+    })
+
+    submodels <- vector(mode = "list", length = nrow(loop))
+    for (i in seq(along = loop$trials)) {
+      index <- which(
+        grid$model == loop$model[i] &
+          grid$winnow == loop$winnow[i]
+      )
+      trials <- grid[index, "trials"]
+      submodels[[i]] <- data.frame(trials = trials[trials != loop$trials[i]])
+    }
+    list(loop = loop, submodels = submodels)
+  },
+  type = "Classification",
+  parameters = data.frame(
+    parameter = c('trials', 'model', 'winnow'),
+    class = c("numeric", "character", "logical"),
+    label = c('# Boosting Iterations', 'Model Type', 'Winnow')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      c5seq <- if (len == 1) 1 else c(1, 10 * ((2:min(len, 11)) - 1))
+      out <- expand.grid(
+        trials = c5seq,
+        model = c("tree", "rules"),
+        winnow = c(TRUE, FALSE)
+      )
+    } else {
+      out <- data.frame(
+        trials = sample(1:100, replace = TRUE, size = len),
+        model = sample(c("tree", "rules"), replace = TRUE, size = len),
+        winnow = sample(c(TRUE, FALSE), replace = TRUE, size = len)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    theDots <- list(...)
+
+    if (any(names(theDots) == "control")) {
+      theDots$control$winnow <- param$winnow
+    } else {
+      theDots$control <- C50::C5.0Control(winnow = param$winnow)
+    }
+    argList <- list(
+      x = x,
+      y = y,
+      weights = wts,
+      trials = param$trials,
+      rules = param$model == "rules"
+    )
+    argList <- c(argList, theDots)
+    do.call(C50:::C5.0.default, argList)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata)
+
+    if (!is.null(submodels)) {
+      tmp <- out
+      out <- vector(mode = "list", length = nrow(submodels) + 1)
+      out[[1]] <- tmp
+
+      for (j in seq(along = submodels$trials)) {
+        out[[j + 1]] <- as.character(predict(
+          modelFit,
+          newdata,
+          trial = submodels$trials[j]
+        ))
+      }
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata, type = "prob")
+
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
+
+      for (j in seq(along = submodels$trials)) {
+        tmp[[j + 1]] <- predict(
+          modelFit,
+          newdata,
+          type = "prob",
+          trials = submodels$trials[j]
+        )
+      }
+      out <- tmp
+    }
+    out
+  },
+  levels = function(x) x$obsLevels,
+  predictors = function(x, ...) {
+    vars <- C50::C5imp(x, metric = "splits")
+    rownames(vars)[vars$Overall > 0]
+  },
+  varImp = function(object, ...) C50::C5imp(object, ...),
+  tags = c(
+    "Tree-Based Model",
+    "Rule-Based Model",
+    "Implicit Feature Selection",
+    "Boosting",
+    "Ensemble Model",
+    "Handle Missing Predictor Data",
+    "Accepts Case Weights"
+  ),
+  sort = function(x) {
+    x$model <- factor(as.character(x$model), levels = c("rules", "tree"))
+    x[order(x$trials, x$model, !x$winnow), ]
+  },
+  trim = function(x) {
+    x$boostResults <- NULL
+    x$size <- NULL
+    x$call <- NULL
+    x$output <- NULL
+    x
+  }
+)

--- a/inst/model_sources/files/C5.0.R
+++ b/inst/model_sources/files/C5.0.R
@@ -25,7 +25,11 @@ modelInfo <- list(
   ),
   grid = function(x, y, len = NULL, search = "grid") {
     if (search == "grid") {
-      c5seq <- if (len == 1) 1 else c(1, 10 * ((2:min(len, 11)) - 1))
+      if (len == 1) {
+        c5seq <- 1
+      } else {
+        c5seq <- c(1, 10 * ((2:min(len, 11)) - 1))
+      }
       out <- expand.grid(
         trials = c5seq,
         model = c("tree", "rules"),

--- a/inst/model_sources/files/C5.0Cost.R
+++ b/inst/model_sources/files/C5.0Cost.R
@@ -1,94 +1,129 @@
-modelInfo <- list(label = "Cost-Sensitive C5.0",
-                  library = c("C50", "plyr"),
-                  loop = function(grid) {     
-                    loop <- plyr::ddply(grid, c("model", "winnow", "cost"),
-                                  function(x) c(trials = max(x$trials)))                 
-                    
-                    submodels <- vector(mode = "list", length = nrow(loop))
-                    for(i in seq(along = loop$trials))
-                    {
-                      index <- which(grid$model == loop$model[i] & 
-                                     grid$winnow == loop$winnow[i],
-                                     grid$cost == loop$cost[i])
-                      trials <- grid[index, "trials"] 
-                      submodels[[i]] <- data.frame(trials = trials[trials != loop$trials[i]])
-                    }     
-                    list(loop = loop, submodels = submodels)
-                  },
-                  type = "Classification",
-                  parameters = data.frame(parameter = c('trials', 'model', 'winnow', "cost"),
-                                          class = c("numeric", "character", "logical", "numeric"),
-                                          label = c('# Boosting Iterations', 'Model Type', 'Winnow', "Cost")),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    c5seq <- if(len == 1)  1 else  c(1, 10*((2:min(len, 11)) - 1))
-                    expand.grid(trials = c5seq, model = c("tree", "rules"), 
-                                winnow = c(TRUE, FALSE),
-                                cost = 1:2)
-                    if(search == "grid") {
-                      c5seq <- if(len == 1)  1 else  c(1, 10*((2:min(len, 11)) - 1))
-                      out <- expand.grid(trials = c5seq, model = c("tree", "rules"), 
-                                         winnow = c(TRUE, FALSE), cost = 1:2)
-                    } else {
-                      out <- data.frame(trials = sample(1:100, replace = TRUE, size = len),
-                                        model = sample(c("tree", "rules"), replace = TRUE, size = len),
-                                        winnow = sample(c(TRUE, FALSE), replace = TRUE, size = len),
-                                        cost = runif(len, min = 1, max = 20))
-                    }
-                    out    
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    theDots <- list(...)
-                    
-                    if(any(names(theDots) == "control"))
-                    {                           
-                      theDots$control$winnow <- param$winnow
-                    } else theDots$control <- C50::C5.0Control(winnow = param$winnow)
-                    
-                    argList <- list(x = x, y = y, weights = wts, trials = param$trials,
-                                    rules = param$model == "rules")
-                    
-                    cmat <-matrix(c(0, param$cost, 1, 0), ncol = 2)
-                    rownames(cmat) <- colnames(cmat) <- levels(y)
-                    if(any(names(theDots) == "cost")){
-                      warning("For 'C5.0Cost', the costs are a tuning parameter")
-                      theDots$costs <- cmat
-                    } else argList$costs <- cmat
-                    
-                    argList <- c(argList, theDots)
-                    do.call(C50:::C5.0.default, argList)
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata)
-                    
-                    if(!is.null(submodels))
-                    {
-                      tmp <- out
-                      out <- vector(mode = "list", length = nrow(submodels) + 1)
-                      out[[1]] <- tmp
-                      
-                      for(j in seq(along = submodels$trials))
-                        out[[j+1]] <- as.character(predict(modelFit, newdata, trial = submodels$trials[j]))
-                    }
-                    out              
-                  },
-                  prob = NULL,
-                  predictors = function(x, ...) {
-                    vars <- C50::C5imp(x, metric = "splits")
-                    rownames(vars)[vars$Overall > 0]
-                  },
-                  levels = function(x) x$obsLevels,
-                  varImp = function(object, ...) C50::C5imp(object, ...),
-                  tags = c("Tree-Based Model", "Rule-Based Model", "Implicit Feature Selection",
-                  	       "Boosting", "Ensemble Model", "Cost Sensitive Learning", "Two Class Only", 
-                           "Handle Missing Predictor Data", "Accepts Case Weights"),
-                  sort = function(x){
-                    x$model <- factor(as.character(x$model), levels = c("rules", "tree"))
-                    x[order(x$trials, x$model, !x$winnow, x$cost),]
-                  },
-                  trim = function(x) {
-                    x$boostResults <- NULL
-                    x$size <- NULL
-                    x$call <- NULL
-                    x$output <- NULL
-                    x
-                  })
+modelInfo <- list(
+  label = "Cost-Sensitive C5.0",
+  library = c("C50", "plyr"),
+  loop = function(grid) {
+    loop <- plyr::ddply(grid, c("model", "winnow", "cost"), function(x) {
+      c(trials = max(x$trials))
+    })
+
+    submodels <- vector(mode = "list", length = nrow(loop))
+    for (i in seq(along = loop$trials)) {
+      index <- which(
+        grid$model == loop$model[i] &
+          grid$winnow == loop$winnow[i],
+        grid$cost == loop$cost[i]
+      )
+      trials <- grid[index, "trials"]
+      submodels[[i]] <- data.frame(trials = trials[trials != loop$trials[i]])
+    }
+    list(loop = loop, submodels = submodels)
+  },
+  type = "Classification",
+  parameters = data.frame(
+    parameter = c('trials', 'model', 'winnow', "cost"),
+    class = c("numeric", "character", "logical", "numeric"),
+    label = c('# Boosting Iterations', 'Model Type', 'Winnow', "Cost")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    c5seq <- if (len == 1) 1 else c(1, 10 * ((2:min(len, 11)) - 1))
+    expand.grid(
+      trials = c5seq,
+      model = c("tree", "rules"),
+      winnow = c(TRUE, FALSE),
+      cost = 1:2
+    )
+    if (search == "grid") {
+      c5seq <- if (len == 1) 1 else c(1, 10 * ((2:min(len, 11)) - 1))
+      out <- expand.grid(
+        trials = c5seq,
+        model = c("tree", "rules"),
+        winnow = c(TRUE, FALSE),
+        cost = 1:2
+      )
+    } else {
+      out <- data.frame(
+        trials = sample(1:100, replace = TRUE, size = len),
+        model = sample(c("tree", "rules"), replace = TRUE, size = len),
+        winnow = sample(c(TRUE, FALSE), replace = TRUE, size = len),
+        cost = runif(len, min = 1, max = 20)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    theDots <- list(...)
+
+    if (any(names(theDots) == "control")) {
+      theDots$control$winnow <- param$winnow
+    } else {
+      theDots$control <- C50::C5.0Control(winnow = param$winnow)
+    }
+
+    argList <- list(
+      x = x,
+      y = y,
+      weights = wts,
+      trials = param$trials,
+      rules = param$model == "rules"
+    )
+
+    cmat <- matrix(c(0, param$cost, 1, 0), ncol = 2)
+    rownames(cmat) <- colnames(cmat) <- levels(y)
+    if (any(names(theDots) == "cost")) {
+      warning("For 'C5.0Cost', the costs are a tuning parameter")
+      theDots$costs <- cmat
+    } else {
+      argList$costs <- cmat
+    }
+
+    argList <- c(argList, theDots)
+    do.call(C50:::C5.0.default, argList)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata)
+
+    if (!is.null(submodels)) {
+      tmp <- out
+      out <- vector(mode = "list", length = nrow(submodels) + 1)
+      out[[1]] <- tmp
+
+      for (j in seq(along = submodels$trials)) {
+        out[[j + 1]] <- as.character(predict(
+          modelFit,
+          newdata,
+          trial = submodels$trials[j]
+        ))
+      }
+    }
+    out
+  },
+  prob = NULL,
+  predictors = function(x, ...) {
+    vars <- C50::C5imp(x, metric = "splits")
+    rownames(vars)[vars$Overall > 0]
+  },
+  levels = function(x) x$obsLevels,
+  varImp = function(object, ...) C50::C5imp(object, ...),
+  tags = c(
+    "Tree-Based Model",
+    "Rule-Based Model",
+    "Implicit Feature Selection",
+    "Boosting",
+    "Ensemble Model",
+    "Cost Sensitive Learning",
+    "Two Class Only",
+    "Handle Missing Predictor Data",
+    "Accepts Case Weights"
+  ),
+  sort = function(x) {
+    x$model <- factor(as.character(x$model), levels = c("rules", "tree"))
+    x[order(x$trials, x$model, !x$winnow, x$cost), ]
+  },
+  trim = function(x) {
+    x$boostResults <- NULL
+    x$size <- NULL
+    x$call <- NULL
+    x$output <- NULL
+    x
+  }
+)

--- a/inst/model_sources/files/C5.0Cost.R
+++ b/inst/model_sources/files/C5.0Cost.R
@@ -25,7 +25,11 @@ modelInfo <- list(
     label = c('# Boosting Iterations', 'Model Type', 'Winnow', "Cost")
   ),
   grid = function(x, y, len = NULL, search = "grid") {
-    c5seq <- if (len == 1) 1 else c(1, 10 * ((2:min(len, 11)) - 1))
+    if (len == 1) {
+      c5seq <- 1
+    } else {
+      c5seq <- c(1, 10 * ((2:min(len, 11)) - 1))
+    }
     expand.grid(
       trials = c5seq,
       model = c("tree", "rules"),
@@ -33,7 +37,11 @@ modelInfo <- list(
       cost = 1:2
     )
     if (search == "grid") {
-      c5seq <- if (len == 1) 1 else c(1, 10 * ((2:min(len, 11)) - 1))
+      if (len == 1) {
+        c5seq <- 1
+      } else {
+        c5seq <- c(1, 10 * ((2:min(len, 11)) - 1))
+      }
       out <- expand.grid(
         trials = c5seq,
         model = c("tree", "rules"),

--- a/inst/model_sources/files/C5.0Rules.R
+++ b/inst/model_sources/files/C5.0Rules.R
@@ -1,29 +1,43 @@
-modelInfo <- list(label = "Single C5.0 Ruleset", 
-                  library = "C50",
-                  loop = NULL,
-                  type = "Classification",
-                  parameters = data.frame(parameter = c('parameter'),
-                                          class = c("character"),
-                                          label = c('none')),
-                  grid = function(x, y, len = NULL, search = "grid") data.frame(parameter = "none"),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) 
-                    C50:::C5.0.default(x = x, y = y, weights = wts, rules = TRUE, ...),
-                  predict = function(modelFit, newdata, submodels = NULL) 
-                    predict(modelFit, newdata),
-                  prob = function(modelFit, newdata, submodels = NULL) 
-                    predict(modelFit, newdata, type= "prob"),
-                  predictors = function(x, ...) {
-                    vars <- C50::C5imp(x, metric = "splits")
-                    rownames(vars)[vars$Overall > 0]
-                  },
-                  levels = function(x) x$obsLevels,
-                  varImp = function(object, ...) C50::C5imp(object, ...),
-                  tags = c("Rule-Based Model", "Implicit Feature Selection", "Handle Missing Predictor Data", "Accepts Case Weights"),
-                  trim = function(x) {
-                    x$boostResults <- NULL
-                    x$size <- NULL
-                    x$call <- NULL
-                    x$output <- NULL
-                    x
-                  },
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Single C5.0 Ruleset",
+  library = "C50",
+  loop = NULL,
+  type = "Classification",
+  parameters = data.frame(
+    parameter = c('parameter'),
+    class = c("character"),
+    label = c('none')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(parameter = "none")
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    C50:::C5.0.default(x = x, y = y, weights = wts, rules = TRUE, ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata, type = "prob")
+  },
+  predictors = function(x, ...) {
+    vars <- C50::C5imp(x, metric = "splits")
+    rownames(vars)[vars$Overall > 0]
+  },
+  levels = function(x) x$obsLevels,
+  varImp = function(object, ...) C50::C5imp(object, ...),
+  tags = c(
+    "Rule-Based Model",
+    "Implicit Feature Selection",
+    "Handle Missing Predictor Data",
+    "Accepts Case Weights"
+  ),
+  trim = function(x) {
+    x$boostResults <- NULL
+    x$size <- NULL
+    x$call <- NULL
+    x$output <- NULL
+    x
+  },
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/C5.0Tree.R
+++ b/inst/model_sources/files/C5.0Tree.R
@@ -1,30 +1,43 @@
-modelInfo <- list(label = "Single C5.0 Tree", 
-                  library = "C50",
-                  loop = NULL,
-                  type = "Classification",
-                  parameters = data.frame(parameter = c('parameter'),
-                                          class = c("character"),
-                                          label = c('none')),
-                  grid = function(x, y, len = NULL, search = "grid") data.frame(parameter = "none"),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) 
-                    C50:::C5.0.default(x = x, y = y, weights = wts, ...),
-                  predict = function(modelFit, newdata, submodels = NULL) 
-                    predict(modelFit, newdata),
-                  prob = function(modelFit, newdata, submodels = NULL) 
-                    predict(modelFit, newdata, type= "prob"),
-                  predictors = function(x, ...) {
-                    vars <- C50::C5imp(x, metric = "splits")
-                    rownames(vars)[vars$Overall > 0]
-                  },
-                  levels = function(x) x$obsLevels,
-                  varImp = function(object, ...) C50::C5imp(object, ...),
-                  tags = c("Tree-Based Model", "Implicit Feature Selection", 
-                           "Handle Missing Predictor Data", "Accepts Case Weights"),
-                  sort = function(x) x[order(x[,1]),],
-                  trim = function(x) {
-                    x$boostResults <- NULL
-                    x$size <- NULL
-                    x$call <- NULL
-                    x$output <- NULL
-                    x
-                  })
+modelInfo <- list(
+  label = "Single C5.0 Tree",
+  library = "C50",
+  loop = NULL,
+  type = "Classification",
+  parameters = data.frame(
+    parameter = c('parameter'),
+    class = c("character"),
+    label = c('none')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(parameter = "none")
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    C50:::C5.0.default(x = x, y = y, weights = wts, ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata, type = "prob")
+  },
+  predictors = function(x, ...) {
+    vars <- C50::C5imp(x, metric = "splits")
+    rownames(vars)[vars$Overall > 0]
+  },
+  levels = function(x) x$obsLevels,
+  varImp = function(object, ...) C50::C5imp(object, ...),
+  tags = c(
+    "Tree-Based Model",
+    "Implicit Feature Selection",
+    "Handle Missing Predictor Data",
+    "Accepts Case Weights"
+  ),
+  sort = function(x) x[order(x[, 1]), ],
+  trim = function(x) {
+    x$boostResults <- NULL
+    x$size <- NULL
+    x$call <- NULL
+    x$output <- NULL
+    x
+  }
+)

--- a/inst/model_sources/files/CSimca.R
+++ b/inst/model_sources/files/CSimca.R
@@ -1,18 +1,24 @@
-modelInfo <- list(label = "SIMCA",
-                  library = c("rrcov","rrcovHD"),
-                  loop = NULL,
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = 'parameter',
-                                          class = "character",
-                                          label = 'parameter'),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    data.frame(parameter = "none")
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) 
-                    rrcovHD::CSimca(x, y, ...),
-                  predict = function(modelFit, newdata, submodels = NULL) 
-                    rrcov::predict(modelFit, newdata)@classification,
-                  prob = NULL,
-                  tags = c('Robust Model'),
-                  levels = function(x) names(x@prior),
-                  sort = function(x) x)
+modelInfo <- list(
+  label = "SIMCA",
+  library = c("rrcov", "rrcovHD"),
+  loop = NULL,
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = 'parameter',
+    class = "character",
+    label = 'parameter'
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(parameter = "none")
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    rrcovHD::CSimca(x, y, ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    rrcov::predict(modelFit, newdata)@classification
+  },
+  prob = NULL,
+  tags = c('Robust Model'),
+  levels = function(x) names(x@prior),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/DENFIS.R
+++ b/inst/model_sources/files/DENFIS.R
@@ -1,47 +1,54 @@
-modelInfo <- list(label = "Dynamic Evolving Neural-Fuzzy Inference System ",
-                  library = "frbs",
-                  type = "Regression",
-                  parameters = data.frame(parameter = c('Dthr', 'max.iter'),
-                                          class = c("numeric", "numeric"),
-                                          label = c('Threshold', 'Max. Iterations')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(Dthr = seq(.1, .5, length = len),      
-                                         max.iter = 100) 
-                    } else {
-                      out <- data.frame(Dthr = runif(len, min = 0, max = 1),
-                                        max.iter = sample(1:20, replace = TRUE, size = len))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    args <- list(data.train = as.matrix(cbind(x, y)),
-                                 method.type = "DENFIS")
-                    
-                    theDots <- list(...)
-                    if(any(names(theDots) == "control")) {
-                      theDots$control$Dthr <- param$Dthr                  
-                      theDots$control$max.iter <- param$max.iter
-                    } else theDots$control <- list(Dthr = param$Dthr,                  
-                                                   max.iter = param$max.iter,
-                                                   step.size = 0.01, 
-                                                   d = 2,
-                                                   method.type = "DENFIS",
-                                                   name="sim-0")   
-                    if(!(any(names(theDots) == "range.data"))) {
-                      args$range.data <- apply(args$data.train, 2, extendrange)
-                    }
-                    do.call(frbs::frbs.learn, c(args, theDots))
-                    
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    predict(modelFit, newdata)[, 1]
-                  },
-                  prob = NULL,
-                  predictors = function(x, ...){
-                    x$colnames.var[x$colnames.var %in% as.vector(x$rule)]
-                  },
-                  tags = c("Rule-Based Model"),
-                  levels = NULL,
-                  sort = function(x) x[order(x$Dthr),])
+modelInfo <- list(
+  label = "Dynamic Evolving Neural-Fuzzy Inference System ",
+  library = "frbs",
+  type = "Regression",
+  parameters = data.frame(
+    parameter = c('Dthr', 'max.iter'),
+    class = c("numeric", "numeric"),
+    label = c('Threshold', 'Max. Iterations')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(Dthr = seq(.1, .5, length = len), max.iter = 100)
+    } else {
+      out <- data.frame(
+        Dthr = runif(len, min = 0, max = 1),
+        max.iter = sample(1:20, replace = TRUE, size = len)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    args <- list(data.train = as.matrix(cbind(x, y)), method.type = "DENFIS")
+
+    theDots <- list(...)
+    if (any(names(theDots) == "control")) {
+      theDots$control$Dthr <- param$Dthr
+      theDots$control$max.iter <- param$max.iter
+    } else {
+      theDots$control <- list(
+        Dthr = param$Dthr,
+        max.iter = param$max.iter,
+        step.size = 0.01,
+        d = 2,
+        method.type = "DENFIS",
+        name = "sim-0"
+      )
+    }
+    if (!(any(names(theDots) == "range.data"))) {
+      args$range.data <- apply(args$data.train, 2, extendrange)
+    }
+    do.call(frbs::frbs.learn, c(args, theDots))
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)[, 1]
+  },
+  prob = NULL,
+  predictors = function(x, ...) {
+    x$colnames.var[x$colnames.var %in% as.vector(x$rule)]
+  },
+  tags = c("Rule-Based Model"),
+  levels = NULL,
+  sort = function(x) x[order(x$Dthr), ]
+)

--- a/inst/model_sources/files/FH.GBML.R
+++ b/inst/model_sources/files/FH.GBML.R
@@ -1,51 +1,63 @@
-modelInfo <- list(label = "Fuzzy Rules Using Genetic Cooperative-Competitive Learning and Pittsburgh",
-                  library = "frbs",
-                  type = "Classification",
-                  parameters = data.frame(parameter = c('max.num.rule', 'popu.size', 'max.gen'),
-                                          class = rep("numeric", 3),
-                                          label = c('Max. #Rules', 'Population Size',
-                                                    'Max. Generations')),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- expand.grid(max.num.rule = 1+(1:len)*2,      
-                                         popu.size = 10,
-                                         max.gen = 10)
-                    } else {
-                      out <- data.frame(max.gen = sample(1:20, size = len, replace = TRUE),
-                                        popu.size = sample(seq(2, 20, by = 2), size = len, replace = TRUE),
-                                        max.num.rule = sample(1:20, size = len, replace = TRUE))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    args <- list(data.train = as.matrix(cbind(x, as.numeric(y))),
-                                 method.type = "FH.GBML")
-                    theDots <- list(...)
-                    if(any(names(theDots) == "control")) {
-                      theDots$control$max.num.rule <- param$max.num.rule                  
-                      theDots$control$popu.size <- param$popu.size
-                      theDots$control$max.gen <- param$max.gen
-                    } else theDots$control <- list(max.num.rule = param$max.num.rule,                  
-                                                   popu.size  = param$popu.size,
-                                                   max.gen    = param$max.gen,
-                                                   persen_cross = 0.6,
-                                                   persen_mutant = 0.3,
-                                                   p.dcare = 0.5,
-                                                   p.gccl = 0.5,
-                                                   num.class = length(unique(y)),
-                                                   name="sim-0")  
-                    
-                    do.call(frbs::frbs.learn, c(args, theDots))
-                    
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    modelFit$obsLevels[predict(modelFit, newdata)]
-                  },
-                  prob = NULL,
-                  predictors = function(x, ...){
-                    x$colnames.var[x$colnames.var %in% as.vector(x$rule)]
-                  },
-                  tags = c("Rule-Based Model"),
-                  levels = NULL,
-                  sort = function(x) x[order(x$max.num.rule),])
+modelInfo <- list(
+  label = "Fuzzy Rules Using Genetic Cooperative-Competitive Learning and Pittsburgh",
+  library = "frbs",
+  type = "Classification",
+  parameters = data.frame(
+    parameter = c('max.num.rule', 'popu.size', 'max.gen'),
+    class = rep("numeric", 3),
+    label = c('Max. #Rules', 'Population Size', 'Max. Generations')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        max.num.rule = 1 + (1:len) * 2,
+        popu.size = 10,
+        max.gen = 10
+      )
+    } else {
+      out <- data.frame(
+        max.gen = sample(1:20, size = len, replace = TRUE),
+        popu.size = sample(seq(2, 20, by = 2), size = len, replace = TRUE),
+        max.num.rule = sample(1:20, size = len, replace = TRUE)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    args <- list(
+      data.train = as.matrix(cbind(x, as.numeric(y))),
+      method.type = "FH.GBML"
+    )
+    theDots <- list(...)
+    if (any(names(theDots) == "control")) {
+      theDots$control$max.num.rule <- param$max.num.rule
+      theDots$control$popu.size <- param$popu.size
+      theDots$control$max.gen <- param$max.gen
+    } else {
+      theDots$control <- list(
+        max.num.rule = param$max.num.rule,
+        popu.size = param$popu.size,
+        max.gen = param$max.gen,
+        persen_cross = 0.6,
+        persen_mutant = 0.3,
+        p.dcare = 0.5,
+        p.gccl = 0.5,
+        num.class = length(unique(y)),
+        name = "sim-0"
+      )
+    }
+
+    do.call(frbs::frbs.learn, c(args, theDots))
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    modelFit$obsLevels[predict(modelFit, newdata)]
+  },
+  prob = NULL,
+  predictors = function(x, ...) {
+    x$colnames.var[x$colnames.var %in% as.vector(x$rule)]
+  },
+  tags = c("Rule-Based Model"),
+  levels = NULL,
+  sort = function(x) x[order(x$max.num.rule), ]
+)

--- a/inst/model_sources/files/FIR.DM.R
+++ b/inst/model_sources/files/FIR.DM.R
@@ -1,48 +1,55 @@
-modelInfo <- list(label = "Fuzzy Inference Rules by Descent Method",
-                  library = "frbs",
-                  type = "Regression",
-                  parameters = data.frame(parameter = c('num.labels', 'max.iter'),
-                                          class = c("numeric", "numeric"),
-                                          label = c('#Fuzzy Terms', 'Max. Iterations')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(num.labels = 1+(1:len)*2,      
-                                         max.iter = 100)
-                    } else {
-                      out <- data.frame(max.iter = sample(1:20, replace = TRUE, size = len),
-                                        num.labels = sample(2:20, size = len, replace = TRUE))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    args <- list(data.train = as.matrix(cbind(x, y)),
-                                 method.type = "FIR.DM")
-                    
-                    theDots <- list(...)
-                    if(any(names(theDots) == "control")) {
-                      theDots$control$num.labels <- param$num.labels                  
-                      theDots$control$max.iter <- param$max.iter
-                    } else theDots$control <- list(num.labels = param$num.labels,                  
-                                                   max.iter = param$max.iter,
-                                                   step.size = 0.01, 
-                                                   type.tnorm = "MIN", 
-                                                   type.snorm = "MAX",
-                                                   type.implication.func = "ZADEH",
-                                                   name="sim-0")     
-                    if(!(any(names(theDots) == "range.data"))) {
-                      args$range.data <- apply(args$data.train, 2, extendrange)
-                    }
-                    do.call(frbs::frbs.learn, c(args, theDots))
-                    
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    predict(modelFit, newdata)[, 1]
-                  },
-                  prob = NULL,
-                  predictors = function(x, ...){
-                    x$colnames.var[x$colnames.var %in% as.vector(x$rule)]
-                  },
-                  tags = c("Rule-Based Model"),
-                  levels = NULL,
-                  sort = function(x) x[order(x$num.labels),])
+modelInfo <- list(
+  label = "Fuzzy Inference Rules by Descent Method",
+  library = "frbs",
+  type = "Regression",
+  parameters = data.frame(
+    parameter = c('num.labels', 'max.iter'),
+    class = c("numeric", "numeric"),
+    label = c('#Fuzzy Terms', 'Max. Iterations')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(num.labels = 1 + (1:len) * 2, max.iter = 100)
+    } else {
+      out <- data.frame(
+        max.iter = sample(1:20, replace = TRUE, size = len),
+        num.labels = sample(2:20, size = len, replace = TRUE)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    args <- list(data.train = as.matrix(cbind(x, y)), method.type = "FIR.DM")
+
+    theDots <- list(...)
+    if (any(names(theDots) == "control")) {
+      theDots$control$num.labels <- param$num.labels
+      theDots$control$max.iter <- param$max.iter
+    } else {
+      theDots$control <- list(
+        num.labels = param$num.labels,
+        max.iter = param$max.iter,
+        step.size = 0.01,
+        type.tnorm = "MIN",
+        type.snorm = "MAX",
+        type.implication.func = "ZADEH",
+        name = "sim-0"
+      )
+    }
+    if (!(any(names(theDots) == "range.data"))) {
+      args$range.data <- apply(args$data.train, 2, extendrange)
+    }
+    do.call(frbs::frbs.learn, c(args, theDots))
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)[, 1]
+  },
+  prob = NULL,
+  predictors = function(x, ...) {
+    x$colnames.var[x$colnames.var %in% as.vector(x$rule)]
+  },
+  tags = c("Rule-Based Model"),
+  levels = NULL,
+  sort = function(x) x[order(x$num.labels), ]
+)

--- a/inst/model_sources/files/FRBCS.CHI.R
+++ b/inst/model_sources/files/FRBCS.CHI.R
@@ -1,49 +1,59 @@
-modelInfo <- list(label = "Fuzzy Rules Using Chi's Method",
-                  library = "frbs",
-                  type = "Classification",
-                  parameters = data.frame(parameter = c('num.labels', 'type.mf'),
-                                          class = c("numeric", "character"),
-                                          label = c('#Fuzzy Terms', 'Membership Function')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    type <- c("GAUSSIAN", "TRAPEZOID", "TRIANGLE")
-                    if(search == "grid") {
-                      out <- expand.grid(num.labels = 1+(1:len)*2,      
-                                         type.mf = type)
-                    } else {
-                      out <- data.frame(type.mf = sample(type, size = len, replace = TRUE),
-                                        num.labels = sample(2:20, size = len, replace = TRUE))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    args <- list(data.train = as.matrix(cbind(x, as.numeric(y))),
-                                 method.type = "FRBCS.CHI")
-                    
-                    theDots <- list(...)
-                    if(any(names(theDots) == "control")) {
-                      theDots$control$num.labels <- param$num.labels                  
-                      theDots$control$type.mf <- param$type.mf
-                    } else theDots$control <- list(num.labels  = param$num.labels,                  
-                                                   type.mf     = param$type.mf,
-                                                   type.tnorm = "MIN",
-                                                   type.snorm = "MAX", 
-                                                   type.implication.func = "ZADEH",
-                                                   num.class = length(unique(y)),
-                                                   name="sim-0")    
-                    if(!(any(names(theDots) == "range.data"))) {
-                      args$range.data <- apply(args$data.train, 2, extendrange)
-                    }
-                    do.call(frbs::frbs.learn, c(args, theDots))
-                    
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    modelFit$obsLevels[predict(modelFit, newdata)[,1]]
-                  },
-                  prob = NULL,
-                  predictors = function(x, ...){
-                    x$colnames.var[x$colnames.var %in% as.vector(x$rule)]
-                  },
-                  tags = c("Rule-Based Model"),
-                  levels = NULL,
-                  sort = function(x) x[order(x$num.labels),])
+modelInfo <- list(
+  label = "Fuzzy Rules Using Chi's Method",
+  library = "frbs",
+  type = "Classification",
+  parameters = data.frame(
+    parameter = c('num.labels', 'type.mf'),
+    class = c("numeric", "character"),
+    label = c('#Fuzzy Terms', 'Membership Function')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    type <- c("GAUSSIAN", "TRAPEZOID", "TRIANGLE")
+    if (search == "grid") {
+      out <- expand.grid(num.labels = 1 + (1:len) * 2, type.mf = type)
+    } else {
+      out <- data.frame(
+        type.mf = sample(type, size = len, replace = TRUE),
+        num.labels = sample(2:20, size = len, replace = TRUE)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    args <- list(
+      data.train = as.matrix(cbind(x, as.numeric(y))),
+      method.type = "FRBCS.CHI"
+    )
+
+    theDots <- list(...)
+    if (any(names(theDots) == "control")) {
+      theDots$control$num.labels <- param$num.labels
+      theDots$control$type.mf <- param$type.mf
+    } else {
+      theDots$control <- list(
+        num.labels = param$num.labels,
+        type.mf = param$type.mf,
+        type.tnorm = "MIN",
+        type.snorm = "MAX",
+        type.implication.func = "ZADEH",
+        num.class = length(unique(y)),
+        name = "sim-0"
+      )
+    }
+    if (!(any(names(theDots) == "range.data"))) {
+      args$range.data <- apply(args$data.train, 2, extendrange)
+    }
+    do.call(frbs::frbs.learn, c(args, theDots))
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    modelFit$obsLevels[predict(modelFit, newdata)[, 1]]
+  },
+  prob = NULL,
+  predictors = function(x, ...) {
+    x$colnames.var[x$colnames.var %in% as.vector(x$rule)]
+  },
+  tags = c("Rule-Based Model"),
+  levels = NULL,
+  sort = function(x) x[order(x$num.labels), ]
+)

--- a/inst/model_sources/files/FRBCS.W.R
+++ b/inst/model_sources/files/FRBCS.W.R
@@ -1,49 +1,59 @@
-modelInfo <- list(label = "Fuzzy Rules with Weight Factor",
-                  library = "frbs",
-                  type = "Classification",
-                  parameters = data.frame(parameter = c('num.labels', 'type.mf'),
-                                          class = c("numeric", "character"),
-                                          label = c('#Fuzzy Terms', 'Membership Function')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    type <- c("GAUSSIAN", "TRAPEZOID", "TRIANGLE")
-                    if(search == "grid") {
-                      out <- expand.grid(num.labels = 1+(1:len)*2,      
-                                         type.mf = type)
-                    } else {
-                      out <- data.frame(type.mf = sample(type, size = len, replace = TRUE),
-                                        num.labels = sample(2:20, size = len, replace = TRUE))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    args <- list(data.train = as.matrix(cbind(x, as.numeric(y))),
-                                 method.type = "FRBCS.W")
-                    
-                    theDots <- list(...)
-                    if(any(names(theDots) == "control")) {
-                      theDots$control$num.labels <- param$num.labels                  
-                      theDots$control$type.mf <- param$type.mf
-                    } else theDots$control <- list(num.labels  = param$num.labels,                  
-                                                   type.mf     = param$type.mf,
-                                                   type.tnorm = "MIN", 
-                                                   type.snorm = "MAX",
-                                                   type.implication.func = "ZADEH",
-                                                   num.class = length(unique(y)),
-                                                   name="sim-0")     
-                    if(!(any(names(theDots) == "range.data"))) {
-                      args$range.data <- apply(args$data.train, 2, extendrange)
-                    }
-                    do.call(frbs::frbs.learn, c(args, theDots))
-                    
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    modelFit$obsLevels[predict(modelFit, newdata)[,1]]
-                  },
-                  prob = NULL,
-                  predictors = function(x, ...){
-                    x$colnames.var[x$colnames.var %in% as.vector(x$rule)]
-                  },
-                  tags = c("Rule-Based Model"),
-                  levels = NULL,
-                  sort = function(x) x[order(x$num.labels),])
+modelInfo <- list(
+  label = "Fuzzy Rules with Weight Factor",
+  library = "frbs",
+  type = "Classification",
+  parameters = data.frame(
+    parameter = c('num.labels', 'type.mf'),
+    class = c("numeric", "character"),
+    label = c('#Fuzzy Terms', 'Membership Function')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    type <- c("GAUSSIAN", "TRAPEZOID", "TRIANGLE")
+    if (search == "grid") {
+      out <- expand.grid(num.labels = 1 + (1:len) * 2, type.mf = type)
+    } else {
+      out <- data.frame(
+        type.mf = sample(type, size = len, replace = TRUE),
+        num.labels = sample(2:20, size = len, replace = TRUE)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    args <- list(
+      data.train = as.matrix(cbind(x, as.numeric(y))),
+      method.type = "FRBCS.W"
+    )
+
+    theDots <- list(...)
+    if (any(names(theDots) == "control")) {
+      theDots$control$num.labels <- param$num.labels
+      theDots$control$type.mf <- param$type.mf
+    } else {
+      theDots$control <- list(
+        num.labels = param$num.labels,
+        type.mf = param$type.mf,
+        type.tnorm = "MIN",
+        type.snorm = "MAX",
+        type.implication.func = "ZADEH",
+        num.class = length(unique(y)),
+        name = "sim-0"
+      )
+    }
+    if (!(any(names(theDots) == "range.data"))) {
+      args$range.data <- apply(args$data.train, 2, extendrange)
+    }
+    do.call(frbs::frbs.learn, c(args, theDots))
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    modelFit$obsLevels[predict(modelFit, newdata)[, 1]]
+  },
+  prob = NULL,
+  predictors = function(x, ...) {
+    x$colnames.var[x$colnames.var %in% as.vector(x$rule)]
+  },
+  tags = c("Rule-Based Model"),
+  levels = NULL,
+  sort = function(x) x[order(x$num.labels), ]
+)

--- a/inst/model_sources/files/FS.HGD.R
+++ b/inst/model_sources/files/FS.HGD.R
@@ -1,50 +1,57 @@
-modelInfo <- list(label = "Simplified TSK Fuzzy Rules",
-                  library = "frbs",
-                  type = "Regression",
-                  parameters = data.frame(parameter = c('num.labels', 'max.iter'),
-                                          class = c("numeric", "numeric"),
-                                          label = c('#Fuzzy Terms', 'Max. Iterations')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(num.labels = 1+(1:len)*2,      
-                                         max.iter = 100)
-                    } else {
-                      out <- data.frame(max.iter = sample(1:20, replace = TRUE, size = len),
-                                        num.labels = sample(2:20, size = len, replace = TRUE))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    args <- list(data.train = as.matrix(cbind(x, y)),
-                                 method.type = "FS.HGD")
-                    
-                    theDots <- list(...)
-                    if(any(names(theDots) == "control")) {
-                      theDots$control$num.labels <- param$num.labels                  
-                      theDots$control$max.iter <- param$max.iter
-                    } else theDots$control <- list(num.labels = param$num.labels,                  
-                                                   max.iter = param$max.iter,
-                                                   step.size = 0.01, 
-                                                   alpha.heuristic = 1,
-                                                   type.tnorm = "MIN", 
-                                                   type.snorm = "MAX",
-                                                   type.implication.func = "ZADEH",
-                                                   name="sim-0")   
-                    if(!(any(names(theDots) == "range.data"))) {
-                      args$range.data <- apply(args$data.train, 2, extendrange)
-                    }
-                    
-                    do.call(frbs::frbs.learn, c(args, theDots))
-                    
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    predict(modelFit, newdata)[, 1]
-                  },
-                  prob = NULL,
-                  predictors = function(x, ...){
-                    x$colnames.var[x$colnames.var %in% as.vector(x$rule)]
-                  },
-                  tags = c("Rule-Based Model"),
-                  levels = NULL,
-                  sort = function(x) x[order(x$num.labels),])
+modelInfo <- list(
+  label = "Simplified TSK Fuzzy Rules",
+  library = "frbs",
+  type = "Regression",
+  parameters = data.frame(
+    parameter = c('num.labels', 'max.iter'),
+    class = c("numeric", "numeric"),
+    label = c('#Fuzzy Terms', 'Max. Iterations')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(num.labels = 1 + (1:len) * 2, max.iter = 100)
+    } else {
+      out <- data.frame(
+        max.iter = sample(1:20, replace = TRUE, size = len),
+        num.labels = sample(2:20, size = len, replace = TRUE)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    args <- list(data.train = as.matrix(cbind(x, y)), method.type = "FS.HGD")
+
+    theDots <- list(...)
+    if (any(names(theDots) == "control")) {
+      theDots$control$num.labels <- param$num.labels
+      theDots$control$max.iter <- param$max.iter
+    } else {
+      theDots$control <- list(
+        num.labels = param$num.labels,
+        max.iter = param$max.iter,
+        step.size = 0.01,
+        alpha.heuristic = 1,
+        type.tnorm = "MIN",
+        type.snorm = "MAX",
+        type.implication.func = "ZADEH",
+        name = "sim-0"
+      )
+    }
+    if (!(any(names(theDots) == "range.data"))) {
+      args$range.data <- apply(args$data.train, 2, extendrange)
+    }
+
+    do.call(frbs::frbs.learn, c(args, theDots))
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)[, 1]
+  },
+  prob = NULL,
+  predictors = function(x, ...) {
+    x$colnames.var[x$colnames.var %in% as.vector(x$rule)]
+  },
+  tags = c("Rule-Based Model"),
+  levels = NULL,
+  sort = function(x) x[order(x$num.labels), ]
+)

--- a/inst/model_sources/files/GFS.FR.MOGUL.R
+++ b/inst/model_sources/files/GFS.FR.MOGUL.R
@@ -1,52 +1,64 @@
-modelInfo <- list(label = "Fuzzy Rules via MOGUL",
-                  library = "frbs",
-                  type = "Regression",
-                  parameters = data.frame(parameter = c('max.gen', 'max.iter', 'max.tune'),
-                                          class = rep("numeric", 3),
-                                          label = c('Max. Generations', 'Max. Iterations',
-                                                    'Max. Tuning Iterations')),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- expand.grid(max.gen = 10*(1:len),      
-                                         max.iter = 10,
-                                         max.tune = 10*(1:len))
-                    } else {
-                      out <- data.frame(max.gen = sample(1:20, size = len, replace = TRUE),
-                                        max.iter = sample(1:20, replace = TRUE, size = len),
-                                        max.tune = sample(1:20, size = len, replace = TRUE))
-                    }
-                    out
-                  }, 
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    args <- list(data.train = as.matrix(cbind(x, y)),
-                                 method.type = "GFS.FR.MOGUL")
-                    
-                    theDots <- list(...)
-                    if(any(names(theDots) == "control")) {
-                      theDots$control$max.gen <- param$max.gen                  
-                      theDots$control$max.iter <- param$max.iter
-                      theDots$control$max.tune <- param$max.tune 
-                    } else theDots$control <- list(max.gen = param$max.gen,                  
-                                                   max.iter = param$max.iter,
-                                                   max.tune = param$max.tune,
-                                                   persen_cross = 0.6,
-                                                   persen_mutant = 0.3,
-                                                   epsilon = 0.4,
-                                                   name="sim-0")   
-                    if(!(any(names(theDots) == "range.data"))) {
-                      args$range.data <- apply(args$data.train, 2, extendrange)
-                    }
-                    do.call(frbs::frbs.learn, c(args, theDots))
-                    
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    predict(modelFit, newdata)[, 1]
-                  },
-                  prob = NULL,
-                  predictors = function(x, ...){
-                    x$colnames.var[x$colnames.var %in% as.vector(x$rule)]
-                  },
-                  tags = c("Rule-Based Model"),
-                  levels = NULL,
-                  sort = function(x) x[order(x$max.iter),])
+modelInfo <- list(
+  label = "Fuzzy Rules via MOGUL",
+  library = "frbs",
+  type = "Regression",
+  parameters = data.frame(
+    parameter = c('max.gen', 'max.iter', 'max.tune'),
+    class = rep("numeric", 3),
+    label = c('Max. Generations', 'Max. Iterations', 'Max. Tuning Iterations')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        max.gen = 10 * (1:len),
+        max.iter = 10,
+        max.tune = 10 * (1:len)
+      )
+    } else {
+      out <- data.frame(
+        max.gen = sample(1:20, size = len, replace = TRUE),
+        max.iter = sample(1:20, replace = TRUE, size = len),
+        max.tune = sample(1:20, size = len, replace = TRUE)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    args <- list(
+      data.train = as.matrix(cbind(x, y)),
+      method.type = "GFS.FR.MOGUL"
+    )
+
+    theDots <- list(...)
+    if (any(names(theDots) == "control")) {
+      theDots$control$max.gen <- param$max.gen
+      theDots$control$max.iter <- param$max.iter
+      theDots$control$max.tune <- param$max.tune
+    } else {
+      theDots$control <- list(
+        max.gen = param$max.gen,
+        max.iter = param$max.iter,
+        max.tune = param$max.tune,
+        persen_cross = 0.6,
+        persen_mutant = 0.3,
+        epsilon = 0.4,
+        name = "sim-0"
+      )
+    }
+    if (!(any(names(theDots) == "range.data"))) {
+      args$range.data <- apply(args$data.train, 2, extendrange)
+    }
+    do.call(frbs::frbs.learn, c(args, theDots))
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)[, 1]
+  },
+  prob = NULL,
+  predictors = function(x, ...) {
+    x$colnames.var[x$colnames.var %in% as.vector(x$rule)]
+  },
+  tags = c("Rule-Based Model"),
+  levels = NULL,
+  sort = function(x) x[order(x$max.iter), ]
+)

--- a/inst/model_sources/files/GFS.LT.RS.R
+++ b/inst/model_sources/files/GFS.LT.RS.R
@@ -1,60 +1,66 @@
-modelInfo <- list(label = "Genetic Lateral Tuning and Rule Selection of Linguistic Fuzzy Systems",
-                  library = "frbs",
-                  type = "Regression",
-                  parameters = data.frame(parameter = c('popu.size', 
-                                                        'num.labels', 
-                                                        'max.gen'),
-                                          class = rep("numeric", 3),
-                                          label = c('Population Size',
-                                                    '# Fuzzy Labels',
-                                                    'Max. Generations')),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- expand.grid(popu.size = 10*(1:len),      
-                                         num.labels = 1+(1:len)*2,
-                                         max.gen = 10)
-                    } else {
-                      out <- data.frame(max.gen = sample(1:20, size = len, replace = TRUE),
-                                        popu.size = sample(seq(10, 50, by = 2), size = len, replace = TRUE),
-                                        num.labels = sample(2:20, size = len, replace = TRUE))
-                    }
-                    out
-                  }, 
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    args <- list(data.train = as.matrix(cbind(x, y)),
-                                 method.type = "GFS.LT.RS")
-                    
-                    theDots <- list(...)
-                    if(any(names(theDots) == "control")) {
-                      theDots$control$popu.size <- param$popu.size                  
-                      theDots$control$num.labels <- param$num.labels
-                      theDots$control$max.gen <- param$max.gen 
-                    } else theDots$control <- list(popu.size  = param$popu.size,                  
-                                                   num.labels = param$num.labels,
-                                                   max.gen    = param$max.gen,
-                                                   persen_cross = 0.6,
-                                                   persen_mutant = 0.3,
-                                                   mode.tuning = "GLOBAL", 
-                                                   type.tnorm = "MIN",
-                                                   type.snorm = "MAX", 
-                                                   type.implication.func = "ZADEH",
-                                                   type.defuz = "WAM", 
-                                                   rule.selection = FALSE,
-                                                   name="sim-0")  
-                    if(!(any(names(theDots) == "range.data"))) {
-                      args$range.data <- apply(args$data.train, 2, extendrange)
-                    }
-                    do.call(frbs::frbs.learn, c(args, theDots))
-                    
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    predict(modelFit, newdata)[, 1]
-                  },
-                  prob = NULL,
-                  predictors = function(x, ...){
-                    x$colnames.var[x$colnames.var %in% as.vector(x$rule)]
-                  },
-                  tags = c("Rule-Based Model"),
-                  levels = NULL,
-                  sort = function(x) x[order(x$num.labels),])
+modelInfo <- list(
+  label = "Genetic Lateral Tuning and Rule Selection of Linguistic Fuzzy Systems",
+  library = "frbs",
+  type = "Regression",
+  parameters = data.frame(
+    parameter = c('popu.size', 'num.labels', 'max.gen'),
+    class = rep("numeric", 3),
+    label = c('Population Size', '# Fuzzy Labels', 'Max. Generations')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        popu.size = 10 * (1:len),
+        num.labels = 1 + (1:len) * 2,
+        max.gen = 10
+      )
+    } else {
+      out <- data.frame(
+        max.gen = sample(1:20, size = len, replace = TRUE),
+        popu.size = sample(seq(10, 50, by = 2), size = len, replace = TRUE),
+        num.labels = sample(2:20, size = len, replace = TRUE)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    args <- list(data.train = as.matrix(cbind(x, y)), method.type = "GFS.LT.RS")
+
+    theDots <- list(...)
+    if (any(names(theDots) == "control")) {
+      theDots$control$popu.size <- param$popu.size
+      theDots$control$num.labels <- param$num.labels
+      theDots$control$max.gen <- param$max.gen
+    } else {
+      theDots$control <- list(
+        popu.size = param$popu.size,
+        num.labels = param$num.labels,
+        max.gen = param$max.gen,
+        persen_cross = 0.6,
+        persen_mutant = 0.3,
+        mode.tuning = "GLOBAL",
+        type.tnorm = "MIN",
+        type.snorm = "MAX",
+        type.implication.func = "ZADEH",
+        type.defuz = "WAM",
+        rule.selection = FALSE,
+        name = "sim-0"
+      )
+    }
+    if (!(any(names(theDots) == "range.data"))) {
+      args$range.data <- apply(args$data.train, 2, extendrange)
+    }
+    do.call(frbs::frbs.learn, c(args, theDots))
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)[, 1]
+  },
+  prob = NULL,
+  predictors = function(x, ...) {
+    x$colnames.var[x$colnames.var %in% as.vector(x$rule)]
+  },
+  tags = c("Rule-Based Model"),
+  levels = NULL,
+  sort = function(x) x[order(x$num.labels), ]
+)

--- a/inst/model_sources/files/GFS.THRIFT.R
+++ b/inst/model_sources/files/GFS.THRIFT.R
@@ -1,59 +1,68 @@
-modelInfo <- list(label = "Fuzzy Rules via Thrift",
-                  library = "frbs",
-                  type = "Regression",
-                  parameters = data.frame(parameter = c('popu.size', 
-                                                        'num.labels', 
-                                                        'max.gen'),
-                                          class = rep("numeric", 3),
-                                          label = c('Population Size',
-                                                    '# Fuzzy Labels',
-                                                    'Max. Generations')),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- expand.grid(popu.size = 10*(1:len),      
-                                         num.labels = 1+(1:len)*2,
-                                         max.gen = 10)
-                    } else {
-                      out <- data.frame(max.gen = sample(1:20, size = len, replace = TRUE),
-                                        popu.size = sample(seq(2, 20, by = 2), size = len, replace = TRUE),
-                                        num.labels = sample(2:20, size = len, replace = TRUE))
-                    }
-                    out
-                  }, 
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    args <- list(data.train = as.matrix(cbind(x, y)),
-                                 method.type = "GFS.THRIFT")
-                    
-                    theDots <- list(...)
-                    if(any(names(theDots) == "control")) {
-                      theDots$control$popu.size <- param$popu.size                  
-                      theDots$control$num.labels <- param$num.labels
-                      theDots$control$max.gen <- param$max.gen 
-                    } else theDots$control <- list(popu.size  = param$popu.size,                  
-                                                   num.labels = param$num.labels,
-                                                   max.gen    = param$max.gen,
-                                                   persen_cross = 0.6,
-                                                   persen_mutant = 0.3,
-                                                   type.defuz = "WAM", 
-                                                   type.tnorm = "MIN",
-                                                   type.snorm = "MAX", 
-                                                   type.mf = "TRIANGLE",
-                                                   type.implication.func = "ZADEH",
-                                                   name="sim-0")    
-                    if(!(any(names(theDots) == "range.data"))) {
-                      args$range.data <- apply(args$data.train, 2, extendrange)
-                    }
-                    do.call(frbs::frbs.learn, c(args, theDots))
-                    
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    predict(modelFit, newdata)[, 1]
-                  },
-                  prob = NULL,
-                  predictors = function(x, ...){
-                    x$colnames.var[x$colnames.var %in% as.vector(x$rule)]
-                  },
-                  tags = c("Rule-Based Model"),
-                  levels = NULL,
-                  sort = function(x) x[order(x$num.labels),])
+modelInfo <- list(
+  label = "Fuzzy Rules via Thrift",
+  library = "frbs",
+  type = "Regression",
+  parameters = data.frame(
+    parameter = c('popu.size', 'num.labels', 'max.gen'),
+    class = rep("numeric", 3),
+    label = c('Population Size', '# Fuzzy Labels', 'Max. Generations')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        popu.size = 10 * (1:len),
+        num.labels = 1 + (1:len) * 2,
+        max.gen = 10
+      )
+    } else {
+      out <- data.frame(
+        max.gen = sample(1:20, size = len, replace = TRUE),
+        popu.size = sample(seq(2, 20, by = 2), size = len, replace = TRUE),
+        num.labels = sample(2:20, size = len, replace = TRUE)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    args <- list(
+      data.train = as.matrix(cbind(x, y)),
+      method.type = "GFS.THRIFT"
+    )
+
+    theDots <- list(...)
+    if (any(names(theDots) == "control")) {
+      theDots$control$popu.size <- param$popu.size
+      theDots$control$num.labels <- param$num.labels
+      theDots$control$max.gen <- param$max.gen
+    } else {
+      theDots$control <- list(
+        popu.size = param$popu.size,
+        num.labels = param$num.labels,
+        max.gen = param$max.gen,
+        persen_cross = 0.6,
+        persen_mutant = 0.3,
+        type.defuz = "WAM",
+        type.tnorm = "MIN",
+        type.snorm = "MAX",
+        type.mf = "TRIANGLE",
+        type.implication.func = "ZADEH",
+        name = "sim-0"
+      )
+    }
+    if (!(any(names(theDots) == "range.data"))) {
+      args$range.data <- apply(args$data.train, 2, extendrange)
+    }
+    do.call(frbs::frbs.learn, c(args, theDots))
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)[, 1]
+  },
+  prob = NULL,
+  predictors = function(x, ...) {
+    x$colnames.var[x$colnames.var %in% as.vector(x$rule)]
+  },
+  tags = c("Rule-Based Model"),
+  levels = NULL,
+  sort = function(x) x[order(x$num.labels), ]
+)

--- a/inst/model_sources/files/HYFIS.R
+++ b/inst/model_sources/files/HYFIS.R
@@ -1,49 +1,56 @@
-modelInfo <- list(label = "Hybrid Neural Fuzzy Inference System",
-                  library = "frbs",
-                  type = "Regression",
-                  parameters = data.frame(parameter = c('num.labels', 'max.iter'),
-                                          class = c("numeric", "numeric"),
-                                          label = c('#Fuzzy Terms', 'Max. Iterations')),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- expand.grid(num.labels = 1+(1:len)*2,      
-                                         max.iter = 10)
-                    } else {
-                      out <- data.frame(num.labels = sample(2:20, size = len, replace = TRUE),
-                                        max.iter = sample(1:20, replace = TRUE, size = len))
-                    }
-                    out
-                  }, 
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    args <- list(data.train = as.matrix(cbind(x, y)),
-                                 method.type = "HYFIS")
-                    
-                    theDots <- list(...)
-                    if(any(names(theDots) == "control")) {
-                      theDots$control$num.labels <- param$num.labels                  
-                      theDots$control$max.iter <- param$max.iter
-                    } else theDots$control <- list(num.labels = param$num.labels,                  
-                                                   max.iter = param$max.iter,
-                                                   step.size = 0.01, 
-                                                   type.tnorm = "MIN",
-                                                   type.snorm = "MAX", 
-                                                   type.defuz = "COG",
-                                                   type.implication.func = "ZADEH",
-                                                   name="sim-0")    
-                    if(!(any(names(theDots) == "range.data"))) {
-                      args$range.data <- apply(args$data.train, 2, extendrange)
-                    }
-                    do.call(frbs::frbs.learn, c(args, theDots))
-                    
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    predict(modelFit, newdata)[,1]
-                  },
-                  prob = NULL,
-                  predictors = function(x, ...){
-                    x$colnames.var[x$colnames.var %in% as.vector(x$rule)]
-                  },
-                  tags = c("Rule-Based Model"),
-                  levels = NULL,
-                  sort = function(x) x[order(x$num.labels),])
+modelInfo <- list(
+  label = "Hybrid Neural Fuzzy Inference System",
+  library = "frbs",
+  type = "Regression",
+  parameters = data.frame(
+    parameter = c('num.labels', 'max.iter'),
+    class = c("numeric", "numeric"),
+    label = c('#Fuzzy Terms', 'Max. Iterations')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(num.labels = 1 + (1:len) * 2, max.iter = 10)
+    } else {
+      out <- data.frame(
+        num.labels = sample(2:20, size = len, replace = TRUE),
+        max.iter = sample(1:20, replace = TRUE, size = len)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    args <- list(data.train = as.matrix(cbind(x, y)), method.type = "HYFIS")
+
+    theDots <- list(...)
+    if (any(names(theDots) == "control")) {
+      theDots$control$num.labels <- param$num.labels
+      theDots$control$max.iter <- param$max.iter
+    } else {
+      theDots$control <- list(
+        num.labels = param$num.labels,
+        max.iter = param$max.iter,
+        step.size = 0.01,
+        type.tnorm = "MIN",
+        type.snorm = "MAX",
+        type.defuz = "COG",
+        type.implication.func = "ZADEH",
+        name = "sim-0"
+      )
+    }
+    if (!(any(names(theDots) == "range.data"))) {
+      args$range.data <- apply(args$data.train, 2, extendrange)
+    }
+    do.call(frbs::frbs.learn, c(args, theDots))
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)[, 1]
+  },
+  prob = NULL,
+  predictors = function(x, ...) {
+    x$colnames.var[x$colnames.var %in% as.vector(x$rule)]
+  },
+  tags = c("Rule-Based Model"),
+  levels = NULL,
+  sort = function(x) x[order(x$num.labels), ]
+)

--- a/inst/model_sources/files/J48.R
+++ b/inst/model_sources/files/J48.R
@@ -27,10 +27,10 @@ modelInfo <- list(
     return(out)
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     theDots <- list(...)

--- a/inst/model_sources/files/J48.R
+++ b/inst/model_sources/files/J48.R
@@ -1,53 +1,71 @@
-modelInfo <- list(label = "C4.5-like Trees",
-                  library = "RWeka",
-                  loop = NULL,
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = c("C", "M"),
-                                          class = c("numeric", "numeric"),
-                                          label = c("Confidence Threshold", "Minimum Instances Per Leaf")),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    upperBound <- min(max(1, floor(nrow(x) / 2)), 50)
-                    if(search == "grid"){
-                      out <- expand.grid(C = seq(0.01, 0.5, length.out = len),
-                                         M = 1:min(upperBound, len))
-                      if(len == 1){
-                        out <- data.frame(C = 0.25, M = 2)
-                      }
-                    } else {
-                      out <- data.frame(C = runif(len , 0.0, 0.5),
-                                        M = round(exp(runif(len, 0, log(upperBound)))))
-                    }
-                    return(out)
-                  } ,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    theDots <- list(...)
-                    
-                    if(any(names(theDots) == "control")) {
-                      theDots$control$C <- param$C 
-                      theDots$control$M <- param$M
-                      ctl <- theDots$control
-                      theDots$control <- NULL
-                    } else ctl <- RWeka::Weka_control(C = param$C, M = param$M) 
-                    
-                    modelArgs <- c(list(formula = as.formula(".outcome ~ ."),
-                                        data = dat,
-                                        control = ctl),
-                                   theDots)
-                    
-                    out <- do.call(RWeka::J48, modelArgs) 
-                    out      
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata)
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata, type = "probability")
-                  },
-                  levels = function(x) x$obsLevels,
-                  predictors = function(x, ...) predictors(x$terms),
-                  tags = c("Tree-Based Model", "Implicit Feature Selection"),
-                  sort = function(x) x[order(x$C, x$M),])
+modelInfo <- list(
+  label = "C4.5-like Trees",
+  library = "RWeka",
+  loop = NULL,
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = c("C", "M"),
+    class = c("numeric", "numeric"),
+    label = c("Confidence Threshold", "Minimum Instances Per Leaf")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    upperBound <- min(max(1, floor(nrow(x) / 2)), 50)
+    if (search == "grid") {
+      out <- expand.grid(
+        C = seq(0.01, 0.5, length.out = len),
+        M = 1:min(upperBound, len)
+      )
+      if (len == 1) {
+        out <- data.frame(C = 0.25, M = 2)
+      }
+    } else {
+      out <- data.frame(
+        C = runif(len, 0.0, 0.5),
+        M = round(exp(runif(len, 0, log(upperBound))))
+      )
+    }
+    return(out)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    theDots <- list(...)
+
+    if (any(names(theDots) == "control")) {
+      theDots$control$C <- param$C
+      theDots$control$M <- param$M
+      ctl <- theDots$control
+      theDots$control <- NULL
+    } else {
+      ctl <- RWeka::Weka_control(C = param$C, M = param$M)
+    }
+
+    modelArgs <- c(
+      list(formula = as.formula(".outcome ~ ."), data = dat, control = ctl),
+      theDots
+    )
+
+    out <- do.call(RWeka::J48, modelArgs)
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata, type = "probability")
+  },
+  levels = function(x) x$obsLevels,
+  predictors = function(x, ...) predictors(x$terms),
+  tags = c("Tree-Based Model", "Implicit Feature Selection"),
+  sort = function(x) x[order(x$C, x$M), ]
+)

--- a/inst/model_sources/files/JRip.R
+++ b/inst/model_sources/files/JRip.R
@@ -31,10 +31,10 @@ modelInfo <- list(
     return(out)
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     theDots <- list(...)

--- a/inst/model_sources/files/JRip.R
+++ b/inst/model_sources/files/JRip.R
@@ -1,62 +1,88 @@
-modelInfo <- list(label = "Rule-Based Classifier",
-                  library = "RWeka",
-                  loop = NULL,
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = c("NumOpt", "NumFolds", "MinWeights"),
-                                          class = c("numeric", "numeric", "numeric"),
-                                          label = c("# Optimizations", "# Folds", "Min Weights")),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    upperBound <- min(max(1, floor(nrow(x) / 2)), 50)
-                    if(search == "grid"){
-                      out <- expand.grid(NumOpt = 1:min(len, sqrt(upperBound)), NumFolds = 2:min(len + 1, upperBound), MinWeights = 1:min(len, sqrt(upperBound)))
-                      if(len == 1){
-                        out <- data.frame(NumOpt = 2, NumFolds = 3, MinWeights = 2)
-                      }
-                    } else {
-                      out <- data.frame(NumOpt = round(exp(runif(5 * len, 0, log(len)))),
-                                        NumFolds = round(exp(runif(5 * len, 0, log(upperBound)))),
-                                        MinWeights = round(exp(runif(5 * len, 0, log(upperBound)))))
-                      out <- unique(out)
-                      out <- out[1:min(nrow(out), len), ]
-                    }
-                    return(out)
-                  } ,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    theDots <- list(...)
-                    
-                    if(any(names(theDots) == "control")) {
-                      theDots$control$O <- param$NumOpt
-                      theDots$control$F <- param$NumFolds
-                      theDots$control$N <- param$MinWeights
-                      ctl <- theDots$control
-                      theDots$control <- NULL
-                    } else ctl <- RWeka::Weka_control(O = param$NumOpt, F = param$NumFolds, N = param$MinWeights) 
-                    
-                    modelArgs <- c(list(formula = as.formula(".outcome ~ ."),
-                                        data = dat,
-                                        control = ctl),
-                                   theDots)
-                    
-                    out <- do.call(RWeka::JRip, modelArgs) 
-                    out      
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata)
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata, type = "probability")
-                  },
-                  levels = function(x) x$obsLevels,
-                  predictors = function(x, ...) predictors(x$terms),
-                  tags = c("Rule-Based Model", "Implicit Feature Selection"),
-                  varImp = function(object, ...) {
-                    dat <- caret:::ripperRuleSummary(object)
-                    out <- dat$varUsage[,"Overall", drop = FALSE]
-                    rownames(out) <- dat$varUsage$Var
-                    out
-                  },
-                  sort = function(x) x[order(x$NumOpt, x$NumFolds, x$MinWeights, decreasing = TRUE),])
+modelInfo <- list(
+  label = "Rule-Based Classifier",
+  library = "RWeka",
+  loop = NULL,
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = c("NumOpt", "NumFolds", "MinWeights"),
+    class = c("numeric", "numeric", "numeric"),
+    label = c("# Optimizations", "# Folds", "Min Weights")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    upperBound <- min(max(1, floor(nrow(x) / 2)), 50)
+    if (search == "grid") {
+      out <- expand.grid(
+        NumOpt = 1:min(len, sqrt(upperBound)),
+        NumFolds = 2:min(len + 1, upperBound),
+        MinWeights = 1:min(len, sqrt(upperBound))
+      )
+      if (len == 1) {
+        out <- data.frame(NumOpt = 2, NumFolds = 3, MinWeights = 2)
+      }
+    } else {
+      out <- data.frame(
+        NumOpt = round(exp(runif(5 * len, 0, log(len)))),
+        NumFolds = round(exp(runif(5 * len, 0, log(upperBound)))),
+        MinWeights = round(exp(runif(5 * len, 0, log(upperBound))))
+      )
+      out <- unique(out)
+      out <- out[1:min(nrow(out), len), ]
+    }
+    return(out)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    theDots <- list(...)
+
+    if (any(names(theDots) == "control")) {
+      theDots$control$O <- param$NumOpt
+      theDots$control$F <- param$NumFolds
+      theDots$control$N <- param$MinWeights
+      ctl <- theDots$control
+      theDots$control <- NULL
+    } else {
+      ctl <- RWeka::Weka_control(
+        O = param$NumOpt,
+        F = param$NumFolds,
+        N = param$MinWeights
+      )
+    }
+
+    modelArgs <- c(
+      list(formula = as.formula(".outcome ~ ."), data = dat, control = ctl),
+      theDots
+    )
+
+    out <- do.call(RWeka::JRip, modelArgs)
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata, type = "probability")
+  },
+  levels = function(x) x$obsLevels,
+  predictors = function(x, ...) predictors(x$terms),
+  tags = c("Rule-Based Model", "Implicit Feature Selection"),
+  varImp = function(object, ...) {
+    dat <- caret:::ripperRuleSummary(object)
+    out <- dat$varUsage[, "Overall", drop = FALSE]
+    rownames(out) <- dat$varUsage$Var
+    out
+  },
+  sort = function(x) {
+    x[order(x$NumOpt, x$NumFolds, x$MinWeights, decreasing = TRUE), ]
+  }
+)

--- a/inst/model_sources/files/LMT.R
+++ b/inst/model_sources/files/LMT.R
@@ -1,46 +1,67 @@
-modelInfo <- list(label = "Logistic Model Trees",
-                  library = "RWeka",
-                  loop = NULL,
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = "iter",
-                                          class = "numeric",
-                                          label = "# Iteratons"),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <-  data.frame(iter = 1+(0:(len-1)) * 20)
-                    } else {
-                      out <- data.frame(iter = unique(sample(1:100, size = len, replace = TRUE)))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    theDots <- list(...)
-                    
-                    if(any(names(theDots) == "control")) {
-                      theDots$control$I <- param$iter 
-                      ctl <- theDots$control
-                      theDots$control <- NULL
-                    } else ctl <- RWeka::Weka_control(I = param$iter) 
-                    
-                    modelArgs <- c(list(formula = as.formula(".outcome ~ ."),
-                                        data = dat,
-                                        control = ctl),
-                                   theDots)
-                    
-                    out <- do.call(RWeka::LMT, modelArgs) 
-                    out      
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata)
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata, type = "probability")
-                  },
-                  levels = function(x) x$obsLevels,
-                  predictors = function(x, ...) predictors(x$terms),
-                  tags = c("Model Tree", "Implicit Feature Selection", "Logistic Regression", "Linear Classifier"),
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Logistic Model Trees",
+  library = "RWeka",
+  loop = NULL,
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = "iter",
+    class = "numeric",
+    label = "# Iteratons"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(iter = 1 + (0:(len - 1)) * 20)
+    } else {
+      out <- data.frame(
+        iter = unique(sample(1:100, size = len, replace = TRUE))
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    theDots <- list(...)
+
+    if (any(names(theDots) == "control")) {
+      theDots$control$I <- param$iter
+      ctl <- theDots$control
+      theDots$control <- NULL
+    } else {
+      ctl <- RWeka::Weka_control(I = param$iter)
+    }
+
+    modelArgs <- c(
+      list(formula = as.formula(".outcome ~ ."), data = dat, control = ctl),
+      theDots
+    )
+
+    out <- do.call(RWeka::LMT, modelArgs)
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata, type = "probability")
+  },
+  levels = function(x) x$obsLevels,
+  predictors = function(x, ...) predictors(x$terms),
+  tags = c(
+    "Model Tree",
+    "Implicit Feature Selection",
+    "Logistic Regression",
+    "Linear Classifier"
+  ),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/LMT.R
+++ b/inst/model_sources/files/LMT.R
@@ -19,10 +19,10 @@ modelInfo <- list(
     out
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     theDots <- list(...)

--- a/inst/model_sources/files/Linda.R
+++ b/inst/model_sources/files/Linda.R
@@ -1,21 +1,28 @@
-modelInfo <- list(label = "Robust Linear Discriminant Analysis",
-                  library = "rrcov",
-                  loop = NULL,
-                  type = c('Classification'),
-                  parameters = data.frame(parameter = c('parameter'),
-                                          class = c('character'),
-                                          label = c('none')),
-                  grid = function(x, y, len = NULL, search = "grid") 
-                    data.frame(parameter = "none"),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) 
-                    rrcov:::Linda(x, y, ...) ,
-                  predict = function(modelFit, newdata, submodels = NULL) 
-                    rrcov:::predict(modelFit, newdata)@classification,
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    probs <- rrcov:::predict(modelFit, newdata)@posterior
-                    colnames(probs) <- names(modelFit@prior)
-                    probs
-                  },
-                  tags = c("Discriminant Analysis", "Linear Classifier", "Robust Model"),
-                  levels = function(x) names(x@prior),
-                  sort = function(x) x)
+modelInfo <- list(
+  label = "Robust Linear Discriminant Analysis",
+  library = "rrcov",
+  loop = NULL,
+  type = c('Classification'),
+  parameters = data.frame(
+    parameter = c('parameter'),
+    class = c('character'),
+    label = c('none')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(parameter = "none")
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    rrcov:::Linda(x, y, ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    rrcov:::predict(modelFit, newdata)@classification
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    probs <- rrcov:::predict(modelFit, newdata)@posterior
+    colnames(probs) <- names(modelFit@prior)
+    probs
+  },
+  tags = c("Discriminant Analysis", "Linear Classifier", "Robust Model"),
+  levels = function(x) names(x@prior),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/LogitBoost.R
+++ b/inst/model_sources/files/LogitBoost.R
@@ -1,86 +1,101 @@
-modelInfo <- list(label = "Boosted Logistic Regression",
-                  library = "caTools",
-                  loop = function(grid) {            
-                    ## Get the largest value of ncomp to fit the "full" model
-                    loop <- grid[which.max(grid$nIter),,drop = FALSE]
-                    
-                    submodels <- grid[-which.max(grid$nIter),,drop = FALSE]
-                    
-                    ## This needs to be excased in a list in case there are more
-                    ## than one tuning parameter
-                    submodels <- list(submodels)  
-                    list(loop = loop, submodels = submodels)
-                  },
-                  type = "Classification",
-                  parameters = data.frame(parameter = 'nIter',
-                                          class = 'numeric',
-                                          label = '# Boosting Iterations'),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- data.frame(nIter = 1 + ((1:len)*10))
-                    } else {
-                      out <- data.frame(nIter = unique(sample(1:100, size = len, replace = TRUE)))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    ## There is another package with a function called `LogitBoost`
-                    ## so we call using the namespace
-                    caTools::LogitBoost(as.matrix(x), y, nIter = param$nIter)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    ## This model was fit with the maximum value of nIter
-                    out <- caTools::predict.LogitBoost(modelFit, newdata, type="class")
-                    ## submodels contains one of the elements of 'submodels'. In this 
-                    ## case, 'submodels' is a data frame with the other values of
-                    ## nIter. We loop over these to get the other predictions.
-                    if(!is.null(submodels))
-                    {                   
-                      ## Save _all_ the predictions in a list
-                      tmp <- out
-                      out <- vector(mode = "list", length = nrow(submodels) + 1)
-                      out[[1]] <- tmp
-                      
-                      for(j in seq(along = submodels$nIter))
-                      {
-                        out[[j+1]] <- caTools::predict.LogitBoost(modelFit,
-                                                                  newdata,
-                                                                  nIter = submodels$nIter[j])
-                      }
-                    }
-                    out                   
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- caTools::predict.LogitBoost(modelFit, newdata, type = "raw")
-                    ## I've seen them not be on [0, 1]
-                    out <- t(apply(out, 1, function(x) x/sum(x)))
-                    if(!is.null(submodels))
-                    {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
-                      
-                      for(j in seq(along = submodels$nIter))
-                      {                           
-                        tmpProb <- caTools::predict.LogitBoost(modelFit,
-                                                               newdata,
-                                                               type = "raw",
-                                                               nIter = submodels$nIter[j])
-                        tmpProb <- out <- t(apply(tmpProb, 1, function(x) x/sum(x)))
-                        tmp[[j+1]] <- as.data.frame(tmpProb[, modelFit$obsLevels, drop = FALSE], stringsAsFactors = TRUE)           
-                      }
-                      out <- tmp
-                    }                       
-                    out
-                  },
-                  predictors = function(x, ...) {                    
-                    if(!is.null(x$xNames))
-                    {
-                      out <- unique(x$xNames[x$Stump[, "feature"]])
-                    } else out <- NA
-                    
-                    out
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("Ensemble Model", "Boosting", "Implicit Feature Selection",
-                           "Tree-Based Model", "Logistic Regression"),
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Boosted Logistic Regression",
+  library = "caTools",
+  loop = function(grid) {
+    ## Get the largest value of ncomp to fit the "full" model
+    loop <- grid[which.max(grid$nIter), , drop = FALSE]
+
+    submodels <- grid[-which.max(grid$nIter), , drop = FALSE]
+
+    ## This needs to be excased in a list in case there are more
+    ## than one tuning parameter
+    submodels <- list(submodels)
+    list(loop = loop, submodels = submodels)
+  },
+  type = "Classification",
+  parameters = data.frame(
+    parameter = 'nIter',
+    class = 'numeric',
+    label = '# Boosting Iterations'
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(nIter = 1 + ((1:len) * 10))
+    } else {
+      out <- data.frame(
+        nIter = unique(sample(1:100, size = len, replace = TRUE))
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    ## There is another package with a function called `LogitBoost`
+    ## so we call using the namespace
+    caTools::LogitBoost(as.matrix(x), y, nIter = param$nIter)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    ## This model was fit with the maximum value of nIter
+    out <- caTools::predict.LogitBoost(modelFit, newdata, type = "class")
+    ## submodels contains one of the elements of 'submodels'. In this
+    ## case, 'submodels' is a data frame with the other values of
+    ## nIter. We loop over these to get the other predictions.
+    if (!is.null(submodels)) {
+      ## Save _all_ the predictions in a list
+      tmp <- out
+      out <- vector(mode = "list", length = nrow(submodels) + 1)
+      out[[1]] <- tmp
+
+      for (j in seq(along = submodels$nIter)) {
+        out[[j + 1]] <- caTools::predict.LogitBoost(
+          modelFit,
+          newdata,
+          nIter = submodels$nIter[j]
+        )
+      }
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- caTools::predict.LogitBoost(modelFit, newdata, type = "raw")
+    ## I've seen them not be on [0, 1]
+    out <- t(apply(out, 1, function(x) x / sum(x)))
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
+
+      for (j in seq(along = submodels$nIter)) {
+        tmpProb <- caTools::predict.LogitBoost(
+          modelFit,
+          newdata,
+          type = "raw",
+          nIter = submodels$nIter[j]
+        )
+        tmpProb <- out <- t(apply(tmpProb, 1, function(x) x / sum(x)))
+        tmp[[j + 1]] <- as.data.frame(
+          tmpProb[, modelFit$obsLevels, drop = FALSE],
+          stringsAsFactors = TRUE
+        )
+      }
+      out <- tmp
+    }
+    out
+  },
+  predictors = function(x, ...) {
+    if (!is.null(x$xNames)) {
+      out <- unique(x$xNames[x$Stump[, "feature"]])
+    } else {
+      out <- NA
+    }
+
+    out
+  },
+  levels = function(x) x$obsLevels,
+  tags = c(
+    "Ensemble Model",
+    "Boosting",
+    "Implicit Feature Selection",
+    "Tree-Based Model",
+    "Logistic Regression"
+  ),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/M5.R
+++ b/inst/model_sources/files/M5.R
@@ -1,46 +1,71 @@
-modelInfo <- list(label = "Model Tree",
-                  library = "RWeka",
-                  loop = NULL,
-                  type = "Regression",
-                  parameters = data.frame(parameter = c('pruned', 'smoothed', 'rules'),
-                                          class = rep("character", 3),
-                                          label = c('Pruned', 'Smoothed', 'Rules')),
-                  grid = function(x, y, len = NULL, search = "grid") expand.grid(pruned = c("Yes", "No"), 
-                                                                smoothed = c("Yes", "No"), 
-                                                                rules = c("Yes", "No")),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    theDots <- list(...)
-                    
-                    if(any(names(theDots) == "control"))
-                    {
-                      theDots$control$N <- ifelse(param$pruned == "No", TRUE, FALSE)
-                      theDots$control$U <- ifelse(param$smoothed == "No", TRUE, FALSE)
-                      ctl <- theDots$control
-                      theDots$control <- NULL
-                      
-                    } else ctl <- RWeka::Weka_control(N = ifelse(param$pruned == "No", TRUE, FALSE),
-                                               U = ifelse(param$smoothed == "No", TRUE, FALSE)) 
-                    
-                    modelArgs <- c(list(formula = as.formula(".outcome ~ ."),
-                                        control = ctl),
-                                   theDots)
-                    modelArgs$data <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    modelArgs$data$.outcome <- y
-                    
-                    out <- do.call(if(param$rules == "Yes") RWeka::M5Rules else RWeka::M5P, modelArgs) 
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata)
-                  },
-                  prob = NULL,
-                  predictors = function(x, ...) predictors(x$terms),
-                  tags = c("Rule-Based Model", "Tree-Based Model", "Linear Regression", "Implicit Feature Selection",
-                           "Model Tree"),
-                  sort = function(x) {
-                    x$pruned <- factor(as.character(x$pruned), levels = c("Yes", "No"))
-                    x$smoothed <- factor(as.character(x$smoothed), levels = c("Yes", "No"))
-                    x$rules <- factor(as.character(x$rules), levels = c("Yes", "No"))
-                    x[order(x$pruned, x$smoothed, x$rules),]
-                  })
+modelInfo <- list(
+  label = "Model Tree",
+  library = "RWeka",
+  loop = NULL,
+  type = "Regression",
+  parameters = data.frame(
+    parameter = c('pruned', 'smoothed', 'rules'),
+    class = rep("character", 3),
+    label = c('Pruned', 'Smoothed', 'Rules')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    expand.grid(
+      pruned = c("Yes", "No"),
+      smoothed = c("Yes", "No"),
+      rules = c("Yes", "No")
+    )
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    theDots <- list(...)
+
+    if (any(names(theDots) == "control")) {
+      theDots$control$N <- ifelse(param$pruned == "No", TRUE, FALSE)
+      theDots$control$U <- ifelse(param$smoothed == "No", TRUE, FALSE)
+      ctl <- theDots$control
+      theDots$control <- NULL
+    } else {
+      ctl <- RWeka::Weka_control(
+        N = ifelse(param$pruned == "No", TRUE, FALSE),
+        U = ifelse(param$smoothed == "No", TRUE, FALSE)
+      )
+    }
+
+    modelArgs <- c(
+      list(formula = as.formula(".outcome ~ ."), control = ctl),
+      theDots
+    )
+    modelArgs$data <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    modelArgs$data$.outcome <- y
+
+    out <- do.call(
+      if (param$rules == "Yes") RWeka::M5Rules else RWeka::M5P,
+      modelArgs
+    )
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata)
+  },
+  prob = NULL,
+  predictors = function(x, ...) predictors(x$terms),
+  tags = c(
+    "Rule-Based Model",
+    "Tree-Based Model",
+    "Linear Regression",
+    "Implicit Feature Selection",
+    "Model Tree"
+  ),
+  sort = function(x) {
+    x$pruned <- factor(as.character(x$pruned), levels = c("Yes", "No"))
+    x$smoothed <- factor(as.character(x$smoothed), levels = c("Yes", "No"))
+    x$rules <- factor(as.character(x$rules), levels = c("Yes", "No"))
+    x[order(x$pruned, x$smoothed, x$rules), ]
+  }
+)

--- a/inst/model_sources/files/M5.R
+++ b/inst/model_sources/files/M5.R
@@ -34,10 +34,10 @@ modelInfo <- list(
       list(formula = as.formula(".outcome ~ ."), control = ctl),
       theDots
     )
-    modelArgs$data <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      modelArgs$data <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      modelArgs$data <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     modelArgs$data$.outcome <- y
 

--- a/inst/model_sources/files/M5Rules.R
+++ b/inst/model_sources/files/M5Rules.R
@@ -1,44 +1,62 @@
-modelInfo <- list(label = "Model Rules",
-                  library = "RWeka",
-                  loop = NULL,
-                  type = "Regression",
-                  parameters = data.frame(parameter = c('pruned', 'smoothed'),
-                                          class = rep("character", 2),
-                                          label = c('Pruned', 'Smoothed')),
-                  grid = function(x, y, len = NULL, search = "grid") expand.grid(pruned = c("Yes", "No"), 
-                                                                smoothed = c("Yes", "No")),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    theDots <- list(...)
-                    
-                    if(any(names(theDots) == "control"))
-                    {
-                      theDots$control$N <- ifelse(param$pruned == "No", TRUE, FALSE)
-                      theDots$control$U <- ifelse(param$smoothed == "No", TRUE, FALSE)
-                      ctl <- theDots$control
-                      theDots$control <- NULL
-                      
-                    } else ctl <- RWeka::Weka_control(N = ifelse(param$pruned == "No", TRUE, FALSE),
-                                               U = ifelse(param$smoothed == "No", TRUE, FALSE)) 
-                    
-                    modelArgs <- c(list(formula = as.formula(".outcome ~ ."),
-                                        control = ctl),
-                                   theDots)
-                    modelArgs$data <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    modelArgs$data$.outcome <- y
-                    
-                    out <- do.call(RWeka::M5Rules, modelArgs) 
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata)
-                  },
-                  predictors = function(x, ...) predictors(x$terms),
-                  prob = NULL,
-                  tags = c("Rule-Based Model", "Linear Regression", "Implicit Feature Selection",
-                           "Model Tree"),
-                  sort = function(x) {
-                    x$pruned <- factor(as.character(x$pruned), levels = c("Yes", "No"))
-                    x$smoothed <- factor(as.character(x$smoothed), levels = c("Yes", "No"))
-                    x[order(x$pruned, x$smoothed),]
-                  })
+modelInfo <- list(
+  label = "Model Rules",
+  library = "RWeka",
+  loop = NULL,
+  type = "Regression",
+  parameters = data.frame(
+    parameter = c('pruned', 'smoothed'),
+    class = rep("character", 2),
+    label = c('Pruned', 'Smoothed')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    expand.grid(pruned = c("Yes", "No"), smoothed = c("Yes", "No"))
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    theDots <- list(...)
+
+    if (any(names(theDots) == "control")) {
+      theDots$control$N <- ifelse(param$pruned == "No", TRUE, FALSE)
+      theDots$control$U <- ifelse(param$smoothed == "No", TRUE, FALSE)
+      ctl <- theDots$control
+      theDots$control <- NULL
+    } else {
+      ctl <- RWeka::Weka_control(
+        N = ifelse(param$pruned == "No", TRUE, FALSE),
+        U = ifelse(param$smoothed == "No", TRUE, FALSE)
+      )
+    }
+
+    modelArgs <- c(
+      list(formula = as.formula(".outcome ~ ."), control = ctl),
+      theDots
+    )
+    modelArgs$data <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    modelArgs$data$.outcome <- y
+
+    out <- do.call(RWeka::M5Rules, modelArgs)
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata)
+  },
+  predictors = function(x, ...) predictors(x$terms),
+  prob = NULL,
+  tags = c(
+    "Rule-Based Model",
+    "Linear Regression",
+    "Implicit Feature Selection",
+    "Model Tree"
+  ),
+  sort = function(x) {
+    x$pruned <- factor(as.character(x$pruned), levels = c("Yes", "No"))
+    x$smoothed <- factor(as.character(x$smoothed), levels = c("Yes", "No"))
+    x[order(x$pruned, x$smoothed), ]
+  }
+)

--- a/inst/model_sources/files/M5Rules.R
+++ b/inst/model_sources/files/M5Rules.R
@@ -30,10 +30,10 @@ modelInfo <- list(
       list(formula = as.formula(".outcome ~ ."), control = ctl),
       theDots
     )
-    modelArgs$data <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      modelArgs$data <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      modelArgs$data <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     modelArgs$data$.outcome <- y
 

--- a/inst/model_sources/files/Mlda.R
+++ b/inst/model_sources/files/Mlda.R
@@ -1,20 +1,26 @@
-modelInfo <- list(label = "Maximum Uncertainty Linear Discriminant Analysis",
-                  library = "HiDimDA",
-                  loop = NULL,
-                  type = c('Classification'),
-                  parameters = data.frame(parameter = c('parameter'),
-                                          class = c("character"),
-                                          label = c('parameter')),
-                  grid = function(x, y, len = NULL, search = "grid") 
-                    data.frame(parameter = "none"),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) 
-                    HiDimDA::Mlda(x, y, q = param$.q, maxq = param$.q, ...),
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata)$class
-                    out <- modelFit$obsLevels[as.numeric(out)]
-                    out
-                  },
-                  levels = function(x) x$obsLevels,
-                  prob = NULL,
-                  tags = c("Discriminant Analysis", "Linear Classifier"),
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Maximum Uncertainty Linear Discriminant Analysis",
+  library = "HiDimDA",
+  loop = NULL,
+  type = c('Classification'),
+  parameters = data.frame(
+    parameter = c('parameter'),
+    class = c("character"),
+    label = c('parameter')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(parameter = "none")
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    HiDimDA::Mlda(x, y, q = param$.q, maxq = param$.q, ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata)$class
+    out <- modelFit$obsLevels[as.numeric(out)]
+    out
+  },
+  levels = function(x) x$obsLevels,
+  prob = NULL,
+  tags = c("Discriminant Analysis", "Linear Classifier"),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/ORFlog.R
+++ b/inst/model_sources/files/ORFlog.R
@@ -1,33 +1,51 @@
-modelInfo <- list(label = "Oblique Random Forest",
-                  library = "obliqueRF",
-                  loop = NULL,
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = "mtry",
-                                          class = "numeric",
-                                          label = "#Randomly Selected Predictors"),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- data.frame(mtry = caret::var_seq(p = ncol(x), 
-                                                              classification = is.factor(y), 
-                                                              len = len))
-                    } else {
-                      out <- data.frame(mtry = unique(sample(1:ncol(x), size = len, replace = TRUE)))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    require(obliqueRF)
-                    obliqueRF::obliqueRF(as.matrix(x), y, training_method = "log", ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL)
-                    predict(modelFit, newdata),
-                  prob = function(modelFit, newdata, submodels = NULL)
-                    predict(modelFit, newdata, type = "prob"),
-                  levels = function(x) x$obsLevels,
-                  notes = paste(
-                    "Unlike other packages used by `train`, the `obliqueRF`",
-                    "package is fully loaded when this model is used."
-                  ),
-                  tags = c("Random Forest", "Oblique Tree", "Logistic Regression", 
-                           "Implicit Feature Selection", "Ensemble Model", "Two Class Only"),
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Oblique Random Forest",
+  library = "obliqueRF",
+  loop = NULL,
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = "mtry",
+    class = "numeric",
+    label = "#Randomly Selected Predictors"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(
+        mtry = caret::var_seq(
+          p = ncol(x),
+          classification = is.factor(y),
+          len = len
+        )
+      )
+    } else {
+      out <- data.frame(
+        mtry = unique(sample(1:ncol(x), size = len, replace = TRUE))
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    require(obliqueRF)
+    obliqueRF::obliqueRF(as.matrix(x), y, training_method = "log", ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata, type = "prob")
+  },
+  levels = function(x) x$obsLevels,
+  notes = paste(
+    "Unlike other packages used by `train`, the `obliqueRF`",
+    "package is fully loaded when this model is used."
+  ),
+  tags = c(
+    "Random Forest",
+    "Oblique Tree",
+    "Logistic Regression",
+    "Implicit Feature Selection",
+    "Ensemble Model",
+    "Two Class Only"
+  ),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/ORFpls.R
+++ b/inst/model_sources/files/ORFpls.R
@@ -1,33 +1,51 @@
-modelInfo <- list(label = "Oblique Random Forest",
-                  library = "obliqueRF",
-                  loop = NULL,
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = "mtry",
-                                          class = "numeric",
-                                          label = "#Randomly Selected Predictors"),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- data.frame(mtry = caret::var_seq(p = ncol(x), 
-                                                              classification = is.factor(y), 
-                                                              len = len))
-                    } else {
-                      out <- data.frame(mtry = unique(sample(1:ncol(x), size = len, replace = TRUE)))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    require(obliqueRF)
-                    obliqueRF::obliqueRF(as.matrix(x), y, training_method = "pls", ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL)
-                    predict(modelFit, newdata),
-                  prob = function(modelFit, newdata, submodels = NULL)
-                    predict(modelFit, newdata, type = "prob"),
-                  levels = function(x) x$obsLevels,
-                  notes = paste(
-                    "Unlike other packages used by `train`, the `obliqueRF`",
-                    "package is fully loaded when this model is used."
-                  ),
-                  tags = c("Random Forest", "Oblique Tree", "Partial Least Squares", 
-                           "Implicit Feature Selection", "Ensemble Model", "Two Class Only"),
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Oblique Random Forest",
+  library = "obliqueRF",
+  loop = NULL,
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = "mtry",
+    class = "numeric",
+    label = "#Randomly Selected Predictors"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(
+        mtry = caret::var_seq(
+          p = ncol(x),
+          classification = is.factor(y),
+          len = len
+        )
+      )
+    } else {
+      out <- data.frame(
+        mtry = unique(sample(1:ncol(x), size = len, replace = TRUE))
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    require(obliqueRF)
+    obliqueRF::obliqueRF(as.matrix(x), y, training_method = "pls", ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata, type = "prob")
+  },
+  levels = function(x) x$obsLevels,
+  notes = paste(
+    "Unlike other packages used by `train`, the `obliqueRF`",
+    "package is fully loaded when this model is used."
+  ),
+  tags = c(
+    "Random Forest",
+    "Oblique Tree",
+    "Partial Least Squares",
+    "Implicit Feature Selection",
+    "Ensemble Model",
+    "Two Class Only"
+  ),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/ORFridge.R
+++ b/inst/model_sources/files/ORFridge.R
@@ -1,34 +1,52 @@
-modelInfo <- list(label = "Oblique Random Forest",
-                  library = "obliqueRF",
-                  loop = NULL,
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = "mtry",
-                                          class = "numeric",
-                                          label = "#Randomly Selected Predictors"),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- data.frame(mtry = caret::var_seq(p = ncol(x), 
-                                                              classification = is.factor(y), 
-                                                              len = len))
-                    } else {
-                      out <- data.frame(mtry = unique(sample(1:ncol(x), size = len, replace = TRUE)))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    require(obliqueRF)
-                    obliqueRF::obliqueRF(as.matrix(x), y, training_method = "ridge", ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL)
-                    predict(modelFit, newdata),
-                  prob = function(modelFit, newdata, submodels = NULL)
-                    predict(modelFit, newdata, type = "prob"),
-                  levels = function(x) x$obsLevels,
-                  notes = paste(
-                    "Unlike other packages used by `train`, the `obliqueRF`",
-                    "package is fully loaded when this model is used."
-                  ),
-                  tags = c("Random Forest", "Oblique Tree", "Ridge Regression", 
-                           "Implicit Feature Selection", "Ensemble Model", "Two Class Only",
-                           "L2 Regularization"),
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Oblique Random Forest",
+  library = "obliqueRF",
+  loop = NULL,
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = "mtry",
+    class = "numeric",
+    label = "#Randomly Selected Predictors"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(
+        mtry = caret::var_seq(
+          p = ncol(x),
+          classification = is.factor(y),
+          len = len
+        )
+      )
+    } else {
+      out <- data.frame(
+        mtry = unique(sample(1:ncol(x), size = len, replace = TRUE))
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    require(obliqueRF)
+    obliqueRF::obliqueRF(as.matrix(x), y, training_method = "ridge", ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata, type = "prob")
+  },
+  levels = function(x) x$obsLevels,
+  notes = paste(
+    "Unlike other packages used by `train`, the `obliqueRF`",
+    "package is fully loaded when this model is used."
+  ),
+  tags = c(
+    "Random Forest",
+    "Oblique Tree",
+    "Ridge Regression",
+    "Implicit Feature Selection",
+    "Ensemble Model",
+    "Two Class Only",
+    "L2 Regularization"
+  ),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/ORFsvm.R
+++ b/inst/model_sources/files/ORFsvm.R
@@ -1,33 +1,51 @@
-modelInfo <- list(label = "Oblique Random Forest",
-                  library = "obliqueRF",
-                  loop = NULL,
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = "mtry",
-                                          class = "numeric",
-                                          label = "#Randomly Selected Predictors"),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- data.frame(mtry = caret::var_seq(p = ncol(x), 
-                                                              classification = is.factor(y), 
-                                                              len = len))
-                    } else {
-                      out <- data.frame(mtry = unique(sample(1:ncol(x), size = len, replace = TRUE)))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    require(obliqueRF)
-                    obliqueRF::obliqueRF(as.matrix(x), y, training_method = "svm", ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL)
-                    predict(modelFit, newdata),
-                  prob = function(modelFit, newdata, submodels = NULL)
-                    predict(modelFit, newdata, type = "prob"),
-                  levels = function(x) x$obsLevels,
-                  notes = paste(
-                    "Unlike other packages used by `train`, the `obliqueRF`",
-                    "package is fully loaded when this model is used."
-                  ),
-                  tags = c("Random Forest", "Oblique Tree", "Kernel Method", 
-                           "Implicit Feature Selection", "Ensemble Model", "Two Class Only"),
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Oblique Random Forest",
+  library = "obliqueRF",
+  loop = NULL,
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = "mtry",
+    class = "numeric",
+    label = "#Randomly Selected Predictors"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(
+        mtry = caret::var_seq(
+          p = ncol(x),
+          classification = is.factor(y),
+          len = len
+        )
+      )
+    } else {
+      out <- data.frame(
+        mtry = unique(sample(1:ncol(x), size = len, replace = TRUE))
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    require(obliqueRF)
+    obliqueRF::obliqueRF(as.matrix(x), y, training_method = "svm", ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata, type = "prob")
+  },
+  levels = function(x) x$obsLevels,
+  notes = paste(
+    "Unlike other packages used by `train`, the `obliqueRF`",
+    "package is fully loaded when this model is used."
+  ),
+  tags = c(
+    "Random Forest",
+    "Oblique Tree",
+    "Kernel Method",
+    "Implicit Feature Selection",
+    "Ensemble Model",
+    "Two Class Only"
+  ),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/OneR.R
+++ b/inst/model_sources/files/OneR.R
@@ -1,33 +1,47 @@
-modelInfo <- list(label = "Single Rule Classification",
-                  library = "RWeka",
-                  loop = NULL,
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = c('parameter'),
-                                          class = c("character"),
-                                          label = "none"),
-                  grid = function(x, y, len = NULL, search = "grid") 
-                    data.frame(parameter = "none"),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    theDots <- list(...)
-                    
-                    modelArgs <- c(list(formula = as.formula(".outcome ~ ."),
-                                        data = dat),
-                                   theDots)
-                    
-                    out <- do.call(RWeka::OneR, modelArgs) 
-                    out      
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata)
-                    },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata, type = "probability")
-                    },
-                  levels = function(x) x$obsLevels,
-                  predictors = function(x, ...) predictors(x$terms),
-                  tags = c("Rule-Based Model", "Implicit Feature Selection"),
-                  sort = function(x) x)
+modelInfo <- list(
+  label = "Single Rule Classification",
+  library = "RWeka",
+  loop = NULL,
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = c('parameter'),
+    class = c("character"),
+    label = "none"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(parameter = "none")
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    theDots <- list(...)
+
+    modelArgs <- c(
+      list(formula = as.formula(".outcome ~ ."), data = dat),
+      theDots
+    )
+
+    out <- do.call(RWeka::OneR, modelArgs)
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata, type = "probability")
+  },
+  levels = function(x) x$obsLevels,
+  predictors = function(x, ...) predictors(x$terms),
+  tags = c("Rule-Based Model", "Implicit Feature Selection"),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/OneR.R
+++ b/inst/model_sources/files/OneR.R
@@ -12,10 +12,10 @@ modelInfo <- list(
     data.frame(parameter = "none")
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     theDots <- list(...)

--- a/inst/model_sources/files/PART.R
+++ b/inst/model_sources/files/PART.R
@@ -1,60 +1,79 @@
-modelInfo <- list(label = "Rule-Based Classifier",
-                  library = "RWeka",
-                  loop = NULL,
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = c('threshold', 'pruned'),
-                                          class = c("numeric", "character"),
-                                          label = c("Confidence Threshold", 'Pruning')),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid"){
-                      out <- expand.grid(threshold = seq(0.01, 0.5, length.out = len), pruned = c("yes", "no"))
-                      if(len == 1){
-                        out <- data.frame(threshold = 0.25, pruned = "yes")
-                      }
-                    } else{
-                      out <- data.frame(threshold = runif(len, 0.0, 0.5), pruned = sample(c("yes", "no"), len, replace = TRUE))
-                      }
-                    return(out)
-                  } 
-                    ,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    theDots <- list(...)
-                    
-                    if(any(names(theDots) == "control"))
-                    {
-                      theDots$control$U <- ifelse(tolower(param$pruned) == "no", TRUE, FALSE)
-                      theDots$control$C <- param$threshold
-                      ctl <- theDots$control
-                      theDots$control <- NULL
-                      
-                    } else ctl <- RWeka::Weka_control(U = ifelse(tolower(param$pruned) == "no", TRUE, FALSE),
-                                               C = param$threshold) 
-                    
-                    modelArgs <- c(list(formula = as.formula(".outcome ~ ."),
-                                        data = dat,
-                                        control = ctl),
-                                   theDots)
-                    
-                    out <- do.call(RWeka::PART, modelArgs) 
-                    out      
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata)
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata, type = "probability")
-                  },
-                  levels = function(x) x$obsLevels,
-                  predictors = function(x, ...) predictors(x$terms),
-                  tags = c("Rule-Based Model", "Implicit Feature Selection"),
-                  varImp = function(object, ...) {
-                    dat <- caret:::partRuleSummary(object)
-                    out <- dat$varUsage[,"Overall", drop = FALSE]
-                    rownames(out) <- dat$varUsage$Var
-                    out
-                  },
-                  sort = function(x) x[order(x$pruned, -x$threshold),])
+modelInfo <- list(
+  label = "Rule-Based Classifier",
+  library = "RWeka",
+  loop = NULL,
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = c('threshold', 'pruned'),
+    class = c("numeric", "character"),
+    label = c("Confidence Threshold", 'Pruning')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        threshold = seq(0.01, 0.5, length.out = len),
+        pruned = c("yes", "no")
+      )
+      if (len == 1) {
+        out <- data.frame(threshold = 0.25, pruned = "yes")
+      }
+    } else {
+      out <- data.frame(
+        threshold = runif(len, 0.0, 0.5),
+        pruned = sample(c("yes", "no"), len, replace = TRUE)
+      )
+    }
+    return(out)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    theDots <- list(...)
+
+    if (any(names(theDots) == "control")) {
+      theDots$control$U <- ifelse(tolower(param$pruned) == "no", TRUE, FALSE)
+      theDots$control$C <- param$threshold
+      ctl <- theDots$control
+      theDots$control <- NULL
+    } else {
+      ctl <- RWeka::Weka_control(
+        U = ifelse(tolower(param$pruned) == "no", TRUE, FALSE),
+        C = param$threshold
+      )
+    }
+
+    modelArgs <- c(
+      list(formula = as.formula(".outcome ~ ."), data = dat, control = ctl),
+      theDots
+    )
+
+    out <- do.call(RWeka::PART, modelArgs)
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata, type = "probability")
+  },
+  levels = function(x) x$obsLevels,
+  predictors = function(x, ...) predictors(x$terms),
+  tags = c("Rule-Based Model", "Implicit Feature Selection"),
+  varImp = function(object, ...) {
+    dat <- caret:::partRuleSummary(object)
+    out <- dat$varUsage[, "Overall", drop = FALSE]
+    rownames(out) <- dat$varUsage$Var
+    out
+  },
+  sort = function(x) x[order(x$pruned, -x$threshold), ]
+)

--- a/inst/model_sources/files/PART.R
+++ b/inst/model_sources/files/PART.R
@@ -26,10 +26,10 @@ modelInfo <- list(
     return(out)
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     theDots <- list(...)

--- a/inst/model_sources/files/PRIM.R
+++ b/inst/model_sources/files/PRIM.R
@@ -69,7 +69,13 @@ modelInfo <- list(
     names(out) <- modelFit$levels[1:2]
     return(out)
   },
-  predictors = function(x, ...) if (hasTerms(x)) predictors(x$terms) else NA,
+  predictors = function(x, ...) {
+    if (hasTerms(x)) {
+      predictors(x$terms)
+    } else {
+      NA
+    }
+  },
   tags = c("Rule-Based Model", "Patient Rule Induction Method"),
   levels = function(x) x$lev,
   sort = function(x) x[order(x$peel.alpha, x$paste.alpha, x$mass.min), ]

--- a/inst/model_sources/files/PRIM.R
+++ b/inst/model_sources/files/PRIM.R
@@ -1,76 +1,76 @@
-modelInfo <- list(label = "Patient Rule Induction Method",
-                  library = "supervisedPRIM",
-                  loop = NULL,
-                  type = "Classification",
-                  parameters = data.frame(parameter = c("peel.alpha", "paste.alpha", "mass.min"),
-                                          class = c("numeric", "numeric", "numeric"),
-                                          label = c("peeling quantile", 'pasting quantile', "minimum mass")),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    lowerlimit <- 1 / nrow(x)
-                    if(search == "grid") {
-                      out <- expand.grid(
-                        peel.alpha = seq(max(lowerlimit, 0.01),
-                                         0.25, length.out = len),
-                        paste.alpha = seq(max(lowerlimit, 0.01),
-                                          0.25, length.out = len),
-                        mass.min = seq(max(lowerlimit, 0.01),
-                                       0.25, length.out = len)
-                        )
-                      if(len == 1){
-                        out <- data.frame(
-                          peel.alpha = 0.05,
-                          paste.alpha = 0.01,
-                          mass.min = 0.05
-                          )
-                      }
-                    } else {
-                      out <- data.frame(
-                        peel.alpha = runif(len,
-                                           min = lowerlimit,
-                                           max = 0.25),
-                        paste.alpha = runif(len,
-                                            min = lowerlimit,
-                                            max = 0.25),
-                        mass.min = runif(len, min = lowerlimit,
-                                         max = 0.25)
-                        )
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    if(!is.data.frame(x) | inherits(x, "tbl_df")) 
-                      x <- as.data.frame(x, stringsAsFactors = TRUE)
-                    out <- supervisedPRIM::supervisedPRIM(
-                      x = x, y = y,
-                      peel.alpha = param$peel.alpha,
-                      paste.alpha = param$paste.alpha,
-                      mass.min = param$mass.min,
-                      ...
-                      )
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL){
-                    if(!is.data.frame(newdata) | inherits(newdata, "tbl_df")) 
-                      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    supervisedPRIM:::predict.supervisedPRIM(
-                      modelFit, 
-                      newdata = newdata, 
-                      classProb = FALSE
-                      )
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL){
-                    if(!is.data.frame(newdata) | inherits(newdata, "tbl_df")) 
-                      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    out <- supervisedPRIM:::predict.supervisedPRIM(
-                      modelFit, 
-                      newdata = newdata, 
-                      classProb = TRUE
-                    )
-                    out <- data.frame(out, 1 - out)
-                    names(out) <- modelFit$levels[1:2]
-                    return(out)
-                  },
-                  predictors = function(x, ...) if(hasTerms(x)) predictors(x$terms) else NA,
-                  tags = c("Rule-Based Model", "Patient Rule Induction Method"),
-                  levels = function(x) x$lev,
-                  sort = function(x) x[order(x$peel.alpha, x$paste.alpha, x$mass.min),])
+modelInfo <- list(
+  label = "Patient Rule Induction Method",
+  library = "supervisedPRIM",
+  loop = NULL,
+  type = "Classification",
+  parameters = data.frame(
+    parameter = c("peel.alpha", "paste.alpha", "mass.min"),
+    class = c("numeric", "numeric", "numeric"),
+    label = c("peeling quantile", 'pasting quantile', "minimum mass")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    lowerlimit <- 1 / nrow(x)
+    if (search == "grid") {
+      out <- expand.grid(
+        peel.alpha = seq(max(lowerlimit, 0.01), 0.25, length.out = len),
+        paste.alpha = seq(max(lowerlimit, 0.01), 0.25, length.out = len),
+        mass.min = seq(max(lowerlimit, 0.01), 0.25, length.out = len)
+      )
+      if (len == 1) {
+        out <- data.frame(
+          peel.alpha = 0.05,
+          paste.alpha = 0.01,
+          mass.min = 0.05
+        )
+      }
+    } else {
+      out <- data.frame(
+        peel.alpha = runif(len, min = lowerlimit, max = 0.25),
+        paste.alpha = runif(len, min = lowerlimit, max = 0.25),
+        mass.min = runif(len, min = lowerlimit, max = 0.25)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (!is.data.frame(x) | inherits(x, "tbl_df")) {
+      x <- as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    out <- supervisedPRIM::supervisedPRIM(
+      x = x,
+      y = y,
+      peel.alpha = param$peel.alpha,
+      paste.alpha = param$paste.alpha,
+      mass.min = param$mass.min,
+      ...
+    )
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata) | inherits(newdata, "tbl_df")) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    supervisedPRIM:::predict.supervisedPRIM(
+      modelFit,
+      newdata = newdata,
+      classProb = FALSE
+    )
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata) | inherits(newdata, "tbl_df")) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    out <- supervisedPRIM:::predict.supervisedPRIM(
+      modelFit,
+      newdata = newdata,
+      classProb = TRUE
+    )
+    out <- data.frame(out, 1 - out)
+    names(out) <- modelFit$levels[1:2]
+    return(out)
+  },
+  predictors = function(x, ...) if (hasTerms(x)) predictors(x$terms) else NA,
+  tags = c("Rule-Based Model", "Patient Rule Induction Method"),
+  levels = function(x) x$lev,
+  sort = function(x) x[order(x$peel.alpha, x$paste.alpha, x$mass.min), ]
+)

--- a/inst/model_sources/files/PenalizedLDA.R
+++ b/inst/model_sources/files/PenalizedLDA.R
@@ -1,51 +1,67 @@
-modelInfo <- list(label = "Penalized Linear Discriminant Analysis",
-                  library = c("penalizedLDA", "plyr"),
-                  loop = function(grid) {
-                    loop <- plyr::ddply(grid, .(lambda), function(x) c(K = max(x$K)))
-                    if(length(unique(loop$K)) == 1) return(list(loop = loop, submodels = NULL))
-                    submodels <- vector(mode = "list", length = nrow(loop))
-                    for(i in seq(along = loop$K))
-                    {
-                      index <- which(grid$lambda == loop$lambda[i])
-                      subK <- grid[index, "K"]
-                      otherK <- data.frame(K = subK[subK != loop$K[i]])
-                      if(nrow(otherK) > 0) submodels[[i]] <- otherK
-                    }    
-                    list(loop = loop, submodels = submodels)
-                  },
-                  type = c('Classification'),
-                  parameters = data.frame(parameter = c('lambda', 'K'),
-                                          class = c('numeric', 'numeric'),
-                                          label = c('L1 Penalty', '#Discriminant Functions')),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- data.frame(lambda = 10 ^ seq(-1, -4, length = len), 
-                                        K = length(levels(y)) - 1)
-                    } else {
-                      out <- data.frame(lambda = 10^runif(len, min = -5, 1), 
-                                        K = sample(1:(length(levels(y)) - 1), size = len, replace = TRUE))
-                    }
-                    out
-                  }, 
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) 
-                    penalizedLDA::PenalizedLDA(as.matrix(x), as.numeric(y),
-                                                lambda = param$lambda,
-                                                K = param$K,
-                                                ...),
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out0 <- predict(modelFit, newdata)$ypred
-                    out <- out0[,ncol(out0)]
-                    out <- modelFit$obsLevels[out]
-                    if(!is.null(submodels))
-                    {
-                      tmp <- out0[, submodels$K,drop = FALSE]
-                      tmp <- apply(tmp, 2, function(x, l) l[x], l = modelFit$obsLevels)
-                      out <- as.data.frame(cbind(out, tmp), stringsAsFactors = FALSE)                                 
-                    }
-                    out
-                  },
-                  levels = function(x) x$obsLevels,
-                  prob = NULL,
-                  tags = c("Discriminant Analysis", "L1 Regularization", 
-                           "Implicit Feature Selection", "Linear Classifier"),
-                  sort = function(x) x[order(x$lambda, x$K),])
+modelInfo <- list(
+  label = "Penalized Linear Discriminant Analysis",
+  library = c("penalizedLDA", "plyr"),
+  loop = function(grid) {
+    loop <- plyr::ddply(grid, .(lambda), function(x) c(K = max(x$K)))
+    if (length(unique(loop$K)) == 1) {
+      return(list(loop = loop, submodels = NULL))
+    }
+    submodels <- vector(mode = "list", length = nrow(loop))
+    for (i in seq(along = loop$K)) {
+      index <- which(grid$lambda == loop$lambda[i])
+      subK <- grid[index, "K"]
+      otherK <- data.frame(K = subK[subK != loop$K[i]])
+      if (nrow(otherK) > 0) submodels[[i]] <- otherK
+    }
+    list(loop = loop, submodels = submodels)
+  },
+  type = c('Classification'),
+  parameters = data.frame(
+    parameter = c('lambda', 'K'),
+    class = c('numeric', 'numeric'),
+    label = c('L1 Penalty', '#Discriminant Functions')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(
+        lambda = 10^seq(-1, -4, length = len),
+        K = length(levels(y)) - 1
+      )
+    } else {
+      out <- data.frame(
+        lambda = 10^runif(len, min = -5, 1),
+        K = sample(1:(length(levels(y)) - 1), size = len, replace = TRUE)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    penalizedLDA::PenalizedLDA(
+      as.matrix(x),
+      as.numeric(y),
+      lambda = param$lambda,
+      K = param$K,
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out0 <- predict(modelFit, newdata)$ypred
+    out <- out0[, ncol(out0)]
+    out <- modelFit$obsLevels[out]
+    if (!is.null(submodels)) {
+      tmp <- out0[, submodels$K, drop = FALSE]
+      tmp <- apply(tmp, 2, function(x, l) l[x], l = modelFit$obsLevels)
+      out <- as.data.frame(cbind(out, tmp), stringsAsFactors = FALSE)
+    }
+    out
+  },
+  levels = function(x) x$obsLevels,
+  prob = NULL,
+  tags = c(
+    "Discriminant Analysis",
+    "L1 Regularization",
+    "Implicit Feature Selection",
+    "Linear Classifier"
+  ),
+  sort = function(x) x[order(x$lambda, x$K), ]
+)

--- a/inst/model_sources/files/PenalizedLDA.R
+++ b/inst/model_sources/files/PenalizedLDA.R
@@ -11,7 +11,9 @@ modelInfo <- list(
       index <- which(grid$lambda == loop$lambda[i])
       subK <- grid[index, "K"]
       otherK <- data.frame(K = subK[subK != loop$K[i]])
-      if (nrow(otherK) > 0) submodels[[i]] <- otherK
+      if (nrow(otherK) > 0) {
+        submodels[[i]] <- otherK
+      }
     }
     list(loop = loop, submodels = submodels)
   },

--- a/inst/model_sources/files/QdaCov.R
+++ b/inst/model_sources/files/QdaCov.R
@@ -1,20 +1,28 @@
-modelInfo <- list(label = "Robust Quadratic Discriminant Analysis",
-                  library = "rrcov",
-                  loop = NULL,
-                  type = "Classification",
-                  parameters = data.frame(parameter = "parameter",
-                                          class = "character",
-                                          label = "parameter"),
-                  grid = function(x, y, len = NULL, search = "grid") data.frame(parameter = "none"),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) 
-                    rrcov:::QdaCov(x, y, ...),
-                  predict = function(modelFit, newdata, submodels = NULL) 
-                    rrcov::predict(modelFit, newdata)@classification,
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    probs <- rrcov::predict(modelFit, newdata)@posterior
-                    colnames(probs) <- names(modelFit@prior)
-                    probs
-                  },
-                  tags = c("Discriminant Analysis", "Polynomial Model"),
-                  levels = function(x) names(x@prior),
-                  sort = function(x) x)
+modelInfo <- list(
+  label = "Robust Quadratic Discriminant Analysis",
+  library = "rrcov",
+  loop = NULL,
+  type = "Classification",
+  parameters = data.frame(
+    parameter = "parameter",
+    class = "character",
+    label = "parameter"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(parameter = "none")
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    rrcov:::QdaCov(x, y, ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    rrcov::predict(modelFit, newdata)@classification
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    probs <- rrcov::predict(modelFit, newdata)@posterior
+    colnames(probs) <- names(modelFit@prior)
+    probs
+  },
+  tags = c("Discriminant Analysis", "Polynomial Model"),
+  levels = function(x) names(x@prior),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/RFlda.R
+++ b/inst/model_sources/files/RFlda.R
@@ -1,26 +1,31 @@
-modelInfo <- list(label = "Factor-Based Linear Discriminant Analysis",
-                  library = "HiDimDA",
-                  loop = NULL,
-                  type = c('Classification'),
-                  parameters = data.frame(parameter = c('q'),
-                                          class = c('numeric'),
-                                          label = c('# Factors')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- data.frame(q = 1:len)
-                    } else {
-                      out <- data.frame(q = unique(sample(1:10, size = len, replace = TRUE)))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) 
-                    HiDimDA::RFlda(x, y, q = param$q, maxq = param$q, ...),
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata)$class
-                    out <- modelFit$obsLevels[as.numeric(out)]
-                    out
-                  },
-                  levels = function(x) x$obsLevels,
-                  prob = NULL,
-                  tags = c("Discriminant Analysis", "Linear Classifier"),
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Factor-Based Linear Discriminant Analysis",
+  library = "HiDimDA",
+  loop = NULL,
+  type = c('Classification'),
+  parameters = data.frame(
+    parameter = c('q'),
+    class = c('numeric'),
+    label = c('# Factors')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(q = 1:len)
+    } else {
+      out <- data.frame(q = unique(sample(1:10, size = len, replace = TRUE)))
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    HiDimDA::RFlda(x, y, q = param$q, maxq = param$q, ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata)$class
+    out <- modelFit$obsLevels[as.numeric(out)]
+    out
+  },
+  levels = function(x) x$obsLevels,
+  prob = NULL,
+  tags = c("Discriminant Analysis", "Linear Classifier"),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/RRF.R
+++ b/inst/model_sources/files/RRF.R
@@ -1,65 +1,87 @@
-modelInfo <- list(label = "Regularized Random Forest",
-                  library = c("randomForest", "RRF"),
-                  loop = NULL,
-                  type = c('Regression', 'Classification'),
-                  parameters = data.frame(parameter = c('mtry', 'coefReg', 'coefImp'),
-                                          class = c('numeric', 'numeric', 'numeric'),
-                                          label = c('#Randomly Selected Predictors', 'Regularization Value', 
-                                                    'Importance Coefficient')),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- expand.grid(mtry = caret::var_seq(p = ncol(x), 
-                                                               classification = is.factor(y), 
-                                                               len = len),
-                                         coefReg = seq(0.01, 1, length = len),
-                                         coefImp = seq(0, 1, length = len))
-                    } else {
-                      out <- data.frame(mtry = sample(1:ncol(x), size = len, replace = TRUE),
-                                        coefReg = runif(len, min = 0, max = 1),
-                                        coefImp = runif(len, min = 0, max = 1))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    theDots <- list(...)
-                    theDots$importance <- TRUE
-                    args <- list(x = x, y = y, mtry = min(param$mtry, ncol(x)))
-                    args <- c(args, theDots)                       
-                    firstFit <- do.call(randomForest::randomForest, args)
-                    firstImp <- randomForest:::importance(firstFit)
-                    if(is.factor(y))
-                    {
-                      firstImp <- firstImp[,"MeanDecreaseGini"]/max(firstImp[,"MeanDecreaseGini"])
-                    } else firstImp <- firstImp[,"%IncMSE"]/max(firstImp[,"%IncMSE"])
-                    firstImp <- ((1 - param$coefImp) * param$coefReg) + (param$coefImp * firstImp)
-                    
-                    RRF::RRF(x, y, mtry = min(param$mtry, ncol(x)), coefReg = firstImp, ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) 
-                    predict(modelFit, newdata),
-                  prob = function(modelFit, newdata, submodels = NULL)
-                    predict(modelFit, newdata, type = "prob"),
-                  varImp = function(object, ...) {
-                    varImp <- RRF::importance(object, ...)
-                    if(object$type == "regression")
-                      varImp <- data.frame(Overall = varImp[,"%IncMSE"])
-                    else {
-                      retainNames <- levels(object$y)
-                      if(all(retainNames %in% colnames(varImp))) {
-                        varImp <- varImp[, retainNames]
-                      } else {
-                        varImp <- data.frame(Overall = varImp[,1])
-                      }
-                    } 
-                    out <- as.data.frame(varImp, stringsAsFactors = TRUE)
-                    if(dim(out)[2] == 2) {
-                      tmp <- apply(out, 1, mean)
-                      out[,1] <- out[,2] <- tmp  
-                    }
-                    out
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("Random Forest", "Ensemble Model", 
-                           "Bagging", "Implicit Feature Selection", 
-                           "Regularization"),
-                  sort = function(x) x[order(x$coefReg),])
+modelInfo <- list(
+  label = "Regularized Random Forest",
+  library = c("randomForest", "RRF"),
+  loop = NULL,
+  type = c('Regression', 'Classification'),
+  parameters = data.frame(
+    parameter = c('mtry', 'coefReg', 'coefImp'),
+    class = c('numeric', 'numeric', 'numeric'),
+    label = c(
+      '#Randomly Selected Predictors',
+      'Regularization Value',
+      'Importance Coefficient'
+    )
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        mtry = caret::var_seq(
+          p = ncol(x),
+          classification = is.factor(y),
+          len = len
+        ),
+        coefReg = seq(0.01, 1, length = len),
+        coefImp = seq(0, 1, length = len)
+      )
+    } else {
+      out <- data.frame(
+        mtry = sample(1:ncol(x), size = len, replace = TRUE),
+        coefReg = runif(len, min = 0, max = 1),
+        coefImp = runif(len, min = 0, max = 1)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    theDots <- list(...)
+    theDots$importance <- TRUE
+    args <- list(x = x, y = y, mtry = min(param$mtry, ncol(x)))
+    args <- c(args, theDots)
+    firstFit <- do.call(randomForest::randomForest, args)
+    firstImp <- randomForest:::importance(firstFit)
+    if (is.factor(y)) {
+      firstImp <- firstImp[, "MeanDecreaseGini"] /
+        max(firstImp[, "MeanDecreaseGini"])
+    } else {
+      firstImp <- firstImp[, "%IncMSE"] / max(firstImp[, "%IncMSE"])
+    }
+    firstImp <- ((1 - param$coefImp) * param$coefReg) +
+      (param$coefImp * firstImp)
+
+    RRF::RRF(x, y, mtry = min(param$mtry, ncol(x)), coefReg = firstImp, ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata, type = "prob")
+  },
+  varImp = function(object, ...) {
+    varImp <- RRF::importance(object, ...)
+    if (object$type == "regression") {
+      varImp <- data.frame(Overall = varImp[, "%IncMSE"])
+    } else {
+      retainNames <- levels(object$y)
+      if (all(retainNames %in% colnames(varImp))) {
+        varImp <- varImp[, retainNames]
+      } else {
+        varImp <- data.frame(Overall = varImp[, 1])
+      }
+    }
+    out <- as.data.frame(varImp, stringsAsFactors = TRUE)
+    if (dim(out)[2] == 2) {
+      tmp <- apply(out, 1, mean)
+      out[, 1] <- out[, 2] <- tmp
+    }
+    out
+  },
+  levels = function(x) x$obsLevels,
+  tags = c(
+    "Random Forest",
+    "Ensemble Model",
+    "Bagging",
+    "Implicit Feature Selection",
+    "Regularization"
+  ),
+  sort = function(x) x[order(x$coefReg), ]
+)

--- a/inst/model_sources/files/RRFglobal.R
+++ b/inst/model_sources/files/RRFglobal.R
@@ -1,48 +1,66 @@
-modelInfo <- list(label = "Regularized Random Forest",
-                  library = "RRF",
-                  loop = NULL,
-                  type = c('Regression', 'Classification'),
-                  parameters = data.frame(parameter = c('mtry', 'coefReg'),
-                                          class = c('numeric', 'numeric'),
-                                          label = c('#Randomly Selected Predictors', 'Regularization Value')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(mtry = caret::var_seq(p = ncol(x), 
-                                                               classification = is.factor(y), 
-                                                               len = len),
-                                         coefReg = seq(0.01, 1, length = len))
-                    } else {
-                      out <- data.frame(mtry = sample(1:ncol(x), size = len, replace = TRUE),
-                                        coefReg = runif(len, min = 0, max = 1))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    RRF::RRF(x, y, mtry = param$mtry, coefReg = param$coefReg, ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) 
-                    predict(modelFit, newdata),
-                  prob = function(modelFit, newdata, submodels = NULL)
-                    predict(modelFit, newdata, type = "prob"),
-                  varImp = function(object, ...) {
-                    varImp <- RRF::importance(object, ...)
-                    if(object$type == "regression")
-                      varImp <- data.frame(Overall = varImp[,"%IncMSE"])
-                    else {
-                      retainNames <- levels(object$y)
-                      if(all(retainNames %in% colnames(varImp))) {
-                        varImp <- varImp[, retainNames]
-                      } else {
-                        varImp <- data.frame(Overall = varImp[,1])
-                      }
-                    }  
-                    out <- as.data.frame(varImp, stringsAsFactors = TRUE)
-                    if(dim(out)[2] == 2) {
-                      tmp <- apply(out, 1, mean)
-                      out[,1] <- out[,2] <- tmp  
-                    }
-                    out
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("Random Forest", "Ensemble Model", "Bagging", "Implicit Feature Selection", "Regularization"),
-                  sort = function(x) x[order(x$coefReg),])
+modelInfo <- list(
+  label = "Regularized Random Forest",
+  library = "RRF",
+  loop = NULL,
+  type = c('Regression', 'Classification'),
+  parameters = data.frame(
+    parameter = c('mtry', 'coefReg'),
+    class = c('numeric', 'numeric'),
+    label = c('#Randomly Selected Predictors', 'Regularization Value')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        mtry = caret::var_seq(
+          p = ncol(x),
+          classification = is.factor(y),
+          len = len
+        ),
+        coefReg = seq(0.01, 1, length = len)
+      )
+    } else {
+      out <- data.frame(
+        mtry = sample(1:ncol(x), size = len, replace = TRUE),
+        coefReg = runif(len, min = 0, max = 1)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    RRF::RRF(x, y, mtry = param$mtry, coefReg = param$coefReg, ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata, type = "prob")
+  },
+  varImp = function(object, ...) {
+    varImp <- RRF::importance(object, ...)
+    if (object$type == "regression") {
+      varImp <- data.frame(Overall = varImp[, "%IncMSE"])
+    } else {
+      retainNames <- levels(object$y)
+      if (all(retainNames %in% colnames(varImp))) {
+        varImp <- varImp[, retainNames]
+      } else {
+        varImp <- data.frame(Overall = varImp[, 1])
+      }
+    }
+    out <- as.data.frame(varImp, stringsAsFactors = TRUE)
+    if (dim(out)[2] == 2) {
+      tmp <- apply(out, 1, mean)
+      out[, 1] <- out[, 2] <- tmp
+    }
+    out
+  },
+  levels = function(x) x$obsLevels,
+  tags = c(
+    "Random Forest",
+    "Ensemble Model",
+    "Bagging",
+    "Implicit Feature Selection",
+    "Regularization"
+  ),
+  sort = function(x) x[order(x$coefReg), ]
+)

--- a/inst/model_sources/files/RSimca.R
+++ b/inst/model_sources/files/RSimca.R
@@ -1,24 +1,29 @@
-modelInfo <- list(label = "Robust SIMCA",
-                  library = "rrcovHD",
-                  loop = NULL,
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = 'parameter',
-                                          class = "character",
-                                          label = 'parameter'),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    data.frame(parameter = "none")
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    require(rrcovHD)
-                    rrcovHD::RSimca(x, y, ...)
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) 
-                    predict(modelFit, newdata)@classification,
-                  prob = NULL,
-                  notes = paste(
-                    "Unlike other packages used by `train`, the `rrcovHD`",
-                    "package is fully loaded when this model is used."
-                  ),
-                  tags = c('Robust Model', "Linear Classifier"),
-                  levels = function(x) names(x@prior),
-                  sort = function(x) x)
+modelInfo <- list(
+  label = "Robust SIMCA",
+  library = "rrcovHD",
+  loop = NULL,
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = 'parameter',
+    class = "character",
+    label = 'parameter'
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(parameter = "none")
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    require(rrcovHD)
+    rrcovHD::RSimca(x, y, ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)@classification
+  },
+  prob = NULL,
+  notes = paste(
+    "Unlike other packages used by `train`, the `rrcovHD`",
+    "package is fully loaded when this model is used."
+  ),
+  tags = c('Robust Model', "Linear Classifier"),
+  levels = function(x) names(x@prior),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/Rborist.R
+++ b/inst/model_sources/files/Rborist.R
@@ -1,48 +1,79 @@
-modelInfo <- list(label = "Random Forest",
-                  library = "Rborist",
-                  loop = NULL,
-                  type = c("Classification", "Regression"),
-                  parameters = data.frame(parameter = c("predFixed","minNode"),
-                                          class = c("numeric","numeric"),
-                                          label = c("#Randomly Selected Predictors","Minimal Node Size")),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- data.frame(predFixed = caret::var_seq(p = ncol(x),
-                                                                   classification = is.factor(y),
-                                                                   len = len),
-                                        minNode = ifelse(is.factor(y), 2, 3))
-                    } else {
-                      out <- data.frame(predFixed = sample(1:ncol(x), size = len, replace = TRUE), #removed unique
-                                        minNode = sample(1:(min(20,nrow(x))), size = len, replace = TRUE)) # might cause warning for very small samples < 20
-                    }
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...){
-                    Rborist::Rborist(x, y, predFixed = param$predFixed, minNode = param$minNode, ...)
-                  } ,
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata)$yPred
-                    if(modelFit$problemType == "Classification") out <- modelFit$obsLevels[out]
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL){
-                    out <- predict(modelFit, newdata)$census
-                    out <- t(apply(out, 1, function(x) x/sum(x)))
-                    out
-                  },
-                  predictors = function(x, ...) x$xNames[x$training$info != 0],
-                  varImp = function(object, ...){
-                    out <- data.frame(Overall = object$training$info)
-                    rownames(out) <- object$xNames
-                    out
-                  },
-                  levels = function(x) colnames(x$validation$confusion),
-                  tags = c("Random Forest", "Ensemble Model", "Bagging", "Implicit Feature Selection"),
-                  sort = function(x) x[order(x[,1]),],
-                  oob = function(x) {
-                    out <- switch(x$problemType ,
-                                  Regression =   c(sqrt(x$validation$mse), x$validation$rsq),
-                                  Classification =  c(sum(diag(x$validation$confusion))/sum(x$validation$confusion),
-                                                      e1071::classAgreement(x$validation$confusion)[["kappa"]]))
-                    names(out) <- if(x$problemType == "Regression") c("RMSE", "Rsquared") else c("Accuracy", "Kappa")
-                    out
-                  })
+modelInfo <- list(
+  label = "Random Forest",
+  library = "Rborist",
+  loop = NULL,
+  type = c("Classification", "Regression"),
+  parameters = data.frame(
+    parameter = c("predFixed", "minNode"),
+    class = c("numeric", "numeric"),
+    label = c("#Randomly Selected Predictors", "Minimal Node Size")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(
+        predFixed = caret::var_seq(
+          p = ncol(x),
+          classification = is.factor(y),
+          len = len
+        ),
+        minNode = ifelse(is.factor(y), 2, 3)
+      )
+    } else {
+      out <- data.frame(
+        predFixed = sample(1:ncol(x), size = len, replace = TRUE), #removed unique
+        minNode = sample(1:(min(20, nrow(x))), size = len, replace = TRUE)
+      ) # might cause warning for very small samples < 20
+    }
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    Rborist::Rborist(
+      x,
+      y,
+      predFixed = param$predFixed,
+      minNode = param$minNode,
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata)$yPred
+    if (modelFit$problemType == "Classification") {
+      out <- modelFit$obsLevels[out]
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata)$census
+    out <- t(apply(out, 1, function(x) x / sum(x)))
+    out
+  },
+  predictors = function(x, ...) x$xNames[x$training$info != 0],
+  varImp = function(object, ...) {
+    out <- data.frame(Overall = object$training$info)
+    rownames(out) <- object$xNames
+    out
+  },
+  levels = function(x) colnames(x$validation$confusion),
+  tags = c(
+    "Random Forest",
+    "Ensemble Model",
+    "Bagging",
+    "Implicit Feature Selection"
+  ),
+  sort = function(x) x[order(x[, 1]), ],
+  oob = function(x) {
+    out <- switch(
+      x$problemType,
+      Regression = c(sqrt(x$validation$mse), x$validation$rsq),
+      Classification = c(
+        sum(diag(x$validation$confusion)) / sum(x$validation$confusion),
+        e1071::classAgreement(x$validation$confusion)[["kappa"]]
+      )
+    )
+    names(out) <- if (x$problemType == "Regression") {
+      c("RMSE", "Rsquared")
+    } else {
+      c("Accuracy", "Kappa")
+    }
+    out
+  }
+)

--- a/inst/model_sources/files/Rborist.R
+++ b/inst/model_sources/files/Rborist.R
@@ -69,10 +69,10 @@ modelInfo <- list(
         e1071::classAgreement(x$validation$confusion)[["kappa"]]
       )
     )
-    names(out) <- if (x$problemType == "Regression") {
-      c("RMSE", "Rsquared")
+    if (x$problemType == "Regression") {
+      names(out) <- c("RMSE", "Rsquared")
     } else {
-      c("Accuracy", "Kappa")
+      names(out) <- c("Accuracy", "Kappa")
     }
     out
   }

--- a/inst/model_sources/files/SBC.R
+++ b/inst/model_sources/files/SBC.R
@@ -1,43 +1,55 @@
-modelInfo <- list(label = "Subtractive Clustering and Fuzzy c-Means Rules",
-                  library = "frbs",
-                  type = "Regression",
-                  parameters = data.frame(parameter = c('r.a', 'eps.high', 'eps.low'),
-                                          class = rep("numeric", 3),
-                                          label = c('Radius', 'Upper Threshold', 'Lower Threshold')),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- expand.grid(r.a = seq(0, 1, length = len),
-                                         eps.high = seq(0, 1, length = len),
-                                         eps.low = seq(0, 1, length = len))
-                    } else {
-                      out <- data.frame(r.a = sample(1:20, size = len*10, replace = TRUE),
-                                        eps.high = runif(len*10, min = 0, max = 1),
-                                        eps.low = runif(len*10, min = 0, max = 1))
-                    }
-                    out <- subset(out, eps.high > eps.low)
-                    out[1:min(nrow(out), len),]
-                  }, 
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    args <- list(data.train = as.matrix(cbind(x, y)),
-                                 method.type = "SBC",
-                                 control = list(r.a  = param$r.a,                  
-                                                eps.high = param$eps.high,
-                                                eps.low = param$eps.low))
-                    
-                    theDots <- list(...)
-                    if(!(any(names(theDots) == "range.data"))) {
-                      args$range.data <- apply(args$data.train, 2, extendrange)
-                    }
-                    do.call(frbs::frbs.learn, c(args, theDots))
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    predict(modelFit, newdata)[, 1]
-                  },
-                  prob = NULL,
-                  predictors = function(x, ...){
-                    x$colnames.var[x$colnames.var %in% as.vector(x$rule)]
-                  },
-                  tags = c("Rule-Based Model"),
-                  levels = NULL,
-                  sort = function(x) x[order(x$r.a),])
+modelInfo <- list(
+  label = "Subtractive Clustering and Fuzzy c-Means Rules",
+  library = "frbs",
+  type = "Regression",
+  parameters = data.frame(
+    parameter = c('r.a', 'eps.high', 'eps.low'),
+    class = rep("numeric", 3),
+    label = c('Radius', 'Upper Threshold', 'Lower Threshold')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        r.a = seq(0, 1, length = len),
+        eps.high = seq(0, 1, length = len),
+        eps.low = seq(0, 1, length = len)
+      )
+    } else {
+      out <- data.frame(
+        r.a = sample(1:20, size = len * 10, replace = TRUE),
+        eps.high = runif(len * 10, min = 0, max = 1),
+        eps.low = runif(len * 10, min = 0, max = 1)
+      )
+    }
+    out <- subset(out, eps.high > eps.low)
+    out[1:min(nrow(out), len), ]
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    args <- list(
+      data.train = as.matrix(cbind(x, y)),
+      method.type = "SBC",
+      control = list(
+        r.a = param$r.a,
+        eps.high = param$eps.high,
+        eps.low = param$eps.low
+      )
+    )
+
+    theDots <- list(...)
+    if (!(any(names(theDots) == "range.data"))) {
+      args$range.data <- apply(args$data.train, 2, extendrange)
+    }
+    do.call(frbs::frbs.learn, c(args, theDots))
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)[, 1]
+  },
+  prob = NULL,
+  predictors = function(x, ...) {
+    x$colnames.var[x$colnames.var %in% as.vector(x$rule)]
+  },
+  tags = c("Rule-Based Model"),
+  levels = NULL,
+  sort = function(x) x[order(x$r.a), ]
+)

--- a/inst/model_sources/files/SLAVE.R
+++ b/inst/model_sources/files/SLAVE.R
@@ -1,54 +1,67 @@
-modelInfo <- list(label = "Fuzzy Rules Using the Structural Learning Algorithm on Vague Environment",
-                  library = "frbs",
-                  type = "Classification",
-                  parameters = data.frame(parameter = c('num.labels', 'max.iter', 'max.gen'),
-                                          class = rep("numeric", 3),
-                                          label = c('#Fuzzy Terms', 'Max. Iterations',
-                                                    'Max. Generations')),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- expand.grid(num.labels = 1+(1:len)*2,      
-                                         max.iter = 10,
-                                         max.gen = 10)
-                    } else {
-                      out <- data.frame(num.labels = sample(2:20, size = len, replace = TRUE),
-                                        max.iter = sample(1:20, replace = TRUE, size = len),
-                                        max.gen = sample(1:20, size = len, replace = TRUE))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    args <- list(data.train = as.matrix(cbind(x, as.numeric(y))),
-                                 method.type = "SLAVE")
-                    theDots <- list(...)
-                    if(any(names(theDots) == "control")) {
-                      theDots$control$num.labels <- param$num.labels                  
-                      theDots$control$max.iter <- param$max.iter
-                      theDots$control$max.gen <- param$max.gen
-		      theDots$control$num.class <- length(unique(y))
-                    } else theDots$control <- list(num.labels = param$num.labels,                  
-                                                   max.iter  = param$max.iter,
-                                                   max.gen    = param$max.gen,
-                                                   persen_cross = 0.6,
-                                                   persen_mutant = 0.3,
-                                                   k.lower = 0.25,
-                                                   k.upper = 0.75, 
-                                                   epsilon = 0.1,
-                                                   num.class = length(unique(y)),
-                                                   name="sim-0") 
-                    if(!(any(names(theDots) == "range.data"))) {
-                      args$range.data <- apply(args$data.train, 2, extendrange)
-                    }
-                    do.call(frbs::frbs.learn, c(args, theDots))
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    modelFit$obsLevels[predict(modelFit, newdata)[,1]]
-                  },
-                  prob = NULL,
-                  predictors = function(x, ...){
-                    x$colnames.var[x$colnames.var %in% as.vector(x$rule)]
-                  },
-                  tags = c("Rule-Based Model"),
-                  levels = NULL,
-                  sort = function(x) x[order(x$num.labels),])
+modelInfo <- list(
+  label = "Fuzzy Rules Using the Structural Learning Algorithm on Vague Environment",
+  library = "frbs",
+  type = "Classification",
+  parameters = data.frame(
+    parameter = c('num.labels', 'max.iter', 'max.gen'),
+    class = rep("numeric", 3),
+    label = c('#Fuzzy Terms', 'Max. Iterations', 'Max. Generations')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        num.labels = 1 + (1:len) * 2,
+        max.iter = 10,
+        max.gen = 10
+      )
+    } else {
+      out <- data.frame(
+        num.labels = sample(2:20, size = len, replace = TRUE),
+        max.iter = sample(1:20, replace = TRUE, size = len),
+        max.gen = sample(1:20, size = len, replace = TRUE)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    args <- list(
+      data.train = as.matrix(cbind(x, as.numeric(y))),
+      method.type = "SLAVE"
+    )
+    theDots <- list(...)
+    if (any(names(theDots) == "control")) {
+      theDots$control$num.labels <- param$num.labels
+      theDots$control$max.iter <- param$max.iter
+      theDots$control$max.gen <- param$max.gen
+      theDots$control$num.class <- length(unique(y))
+    } else {
+      theDots$control <- list(
+        num.labels = param$num.labels,
+        max.iter = param$max.iter,
+        max.gen = param$max.gen,
+        persen_cross = 0.6,
+        persen_mutant = 0.3,
+        k.lower = 0.25,
+        k.upper = 0.75,
+        epsilon = 0.1,
+        num.class = length(unique(y)),
+        name = "sim-0"
+      )
+    }
+    if (!(any(names(theDots) == "range.data"))) {
+      args$range.data <- apply(args$data.train, 2, extendrange)
+    }
+    do.call(frbs::frbs.learn, c(args, theDots))
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    modelFit$obsLevels[predict(modelFit, newdata)[, 1]]
+  },
+  prob = NULL,
+  predictors = function(x, ...) {
+    x$colnames.var[x$colnames.var %in% as.vector(x$rule)]
+  },
+  tags = c("Rule-Based Model"),
+  levels = NULL,
+  sort = function(x) x[order(x$num.labels), ]
+)

--- a/inst/model_sources/files/WM.R
+++ b/inst/model_sources/files/WM.R
@@ -1,47 +1,62 @@
-modelInfo <- list(label = "Wang and Mendel Fuzzy Rules",
-                  library = "frbs",
-                  type = "Regression",
-                  parameters = data.frame(parameter = c('num.labels', 'type.mf'),
-                                          class = c("numeric", "character"),
-                                          label = c('#Fuzzy Terms', 'Membership Function')),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- expand.grid(num.labels = 1+(1:len)*2,      
-                                         type.mf = c("GAUSSIAN", "TRAPEZOID", "TRIANGLE"))
-                    } else {
-                      out <- data.frame(num.labels = sample(2:20, size = len, replace = TRUE),
-                                        type.mf = sample(c("GAUSSIAN", "TRAPEZOID", "TRIANGLE"), size = len, replace = TRUE))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    args <- list(data.train = as.matrix(cbind(x, y)))
-                    
-                    theDots <- list(...)
-                    if(any(names(theDots) == "control")) {
-                      theDots$control$num.labels <- param$num.labels                  
-                      theDots$control$type.mf <- param$type.mf
-                    } else theDots$control <- list(num.labels = param$num.labels,                  
-                                                   type.mf = param$type.mf,            
-                                                   type.defuz = "WAM", 
-                                                   type.tnorm = "MIN", 
-                                                   type.snorm = "MAX", 
-                                                   type.implication.func = "ZADEH",
-                                                   name="sim-0")    
-                    if(!(any(names(theDots) == "range.data"))) {
-                      args$range.data <- apply(args$data.train, 2, extendrange)
-                    }
-                    do.call(frbs::frbs.learn, c(args, theDots))
-                    
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    predict(modelFit, newdata)[,1]
-                  },
-                  prob = NULL,
-                  predictors = function(x, ...){
-                    x$colnames.var[x$colnames.var %in% as.vector(x$rule)]
-                  },
-                  tags = c("Rule-Based Model"),
-                  levels = NULL,
-                  sort = function(x) x[order(x$num.labels),])
+modelInfo <- list(
+  label = "Wang and Mendel Fuzzy Rules",
+  library = "frbs",
+  type = "Regression",
+  parameters = data.frame(
+    parameter = c('num.labels', 'type.mf'),
+    class = c("numeric", "character"),
+    label = c('#Fuzzy Terms', 'Membership Function')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        num.labels = 1 + (1:len) * 2,
+        type.mf = c("GAUSSIAN", "TRAPEZOID", "TRIANGLE")
+      )
+    } else {
+      out <- data.frame(
+        num.labels = sample(2:20, size = len, replace = TRUE),
+        type.mf = sample(
+          c("GAUSSIAN", "TRAPEZOID", "TRIANGLE"),
+          size = len,
+          replace = TRUE
+        )
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    args <- list(data.train = as.matrix(cbind(x, y)))
+
+    theDots <- list(...)
+    if (any(names(theDots) == "control")) {
+      theDots$control$num.labels <- param$num.labels
+      theDots$control$type.mf <- param$type.mf
+    } else {
+      theDots$control <- list(
+        num.labels = param$num.labels,
+        type.mf = param$type.mf,
+        type.defuz = "WAM",
+        type.tnorm = "MIN",
+        type.snorm = "MAX",
+        type.implication.func = "ZADEH",
+        name = "sim-0"
+      )
+    }
+    if (!(any(names(theDots) == "range.data"))) {
+      args$range.data <- apply(args$data.train, 2, extendrange)
+    }
+    do.call(frbs::frbs.learn, c(args, theDots))
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)[, 1]
+  },
+  prob = NULL,
+  predictors = function(x, ...) {
+    x$colnames.var[x$colnames.var %in% as.vector(x$rule)]
+  },
+  tags = c("Rule-Based Model"),
+  levels = NULL,
+  sort = function(x) x[order(x$num.labels), ]
+)

--- a/inst/model_sources/files/ada.R
+++ b/inst/model_sources/files/ada.R
@@ -1,89 +1,118 @@
-modelInfo <- list(label = "Boosted Classification Trees",
-                  library = c("ada", "plyr"),
-                  loop = function(grid) {
-                    loop <- plyr::ddply(grid, c("nu", "maxdepth"),
-                                  function(x) c(iter = max(x$iter)))
-                    submodels <- vector(mode = "list", length = nrow(loop))
-                    for(i in seq(along = loop$iter)) {
-                      index <- which(grid$maxdepth == loop$maxdepth[i] &
-                                       grid$nu == loop$nu[i])
-                      trees <- grid[index, "iter"]
-                      submodels[[i]] <- data.frame(iter = trees[trees != loop$iter[i]])
-                    }
-                    list(loop = loop, submodels = submodels)
-                  },
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = c('iter', 'maxdepth', 'nu'),
-                                          class = rep("numeric", 3),
-                                          label = c('#Trees', 'Max Tree Depth', 'Learning Rate')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out  = expand.grid(iter = floor((1:len) * 50),
-                                         maxdepth = seq(1, len),
-                                         nu = .1)
-                    } else {
-                      out <- data.frame(iter =  sample(1:1000, replace = TRUE, size = len),
-                                        maxdepth = sample(1:10, replace = TRUE, size = len),
-                                        nu = runif(len, min = .001, max = .5))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    theDots <- list(...)
+modelInfo <- list(
+  label = "Boosted Classification Trees",
+  library = c("ada", "plyr"),
+  loop = function(grid) {
+    loop <- plyr::ddply(grid, c("nu", "maxdepth"), function(x) {
+      c(iter = max(x$iter))
+    })
+    submodels <- vector(mode = "list", length = nrow(loop))
+    for (i in seq(along = loop$iter)) {
+      index <- which(
+        grid$maxdepth == loop$maxdepth[i] &
+          grid$nu == loop$nu[i]
+      )
+      trees <- grid[index, "iter"]
+      submodels[[i]] <- data.frame(iter = trees[trees != loop$iter[i]])
+    }
+    list(loop = loop, submodels = submodels)
+  },
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = c('iter', 'maxdepth', 'nu'),
+    class = rep("numeric", 3),
+    label = c('#Trees', 'Max Tree Depth', 'Learning Rate')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out = expand.grid(
+        iter = floor((1:len) * 50),
+        maxdepth = seq(1, len),
+        nu = .1
+      )
+    } else {
+      out <- data.frame(
+        iter = sample(1:1000, replace = TRUE, size = len),
+        maxdepth = sample(1:10, replace = TRUE, size = len),
+        nu = runif(len, min = .001, max = .5)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    theDots <- list(...)
 
-                    if(any(names(theDots) == "control")) {
-                      theDots$control$maxdepth <- param$maxdepth
-                      ctl <- theDots$control
-                      theDots$control <- NULL
+    if (any(names(theDots) == "control")) {
+      theDots$control$maxdepth <- param$maxdepth
+      ctl <- theDots$control
+      theDots$control <- NULL
+    } else {
+      ctl <- rpart::rpart.control(
+        maxdepth = param$maxdepth,
+        cp = -1,
+        minsplit = 0,
+        xval = 0
+      )
+    }
 
-                    } else ctl <- rpart::rpart.control(maxdepth = param$maxdepth,
-                                                cp=-1,minsplit=0,xval=0)
+    modelArgs <- c(
+      list(x = x, y = y, iter = param$iter, nu = param$nu, control = ctl),
+      theDots
+    )
+    out <- do.call(ada::ada, modelArgs)
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    out <- predict(modelFit, newdata, n.iter = modelFit$tuneValue$iter)
 
-                    modelArgs <- c(list(x = x,
-                                        y = y,
-                                        iter = param$iter,
-                                        nu = param$nu,
-                                        control = ctl),
-                                   theDots)
-                    out <- do.call(ada::ada, modelArgs)
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = length(submodels$iter) + 1)
+      tmp[[1]] <- out
+      for (i in seq(along = submodels$iter)) {
+        tmp[[i + 1]] <- predict(modelFit, newdata, n.iter = submodels$iter[[i]])
+      }
+      out <- lapply(tmp, as.character)
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    out <- predict(
+      modelFit,
+      newdata,
+      type = "prob",
+      n.iter = modelFit$tuneValue$iter
+    )
+    colnames(out) <- modelFit$obsLevels
 
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    out <- predict(modelFit, newdata, n.iter = modelFit$tuneValue$iter)
-
-                    if(!is.null(submodels)) {
-                      tmp <- vector(mode = "list", length = length(submodels$iter)+1)
-                      tmp[[1]] <- out
-                      for(i in seq(along = submodels$iter)) {
-                        tmp[[i+1]] <- predict(modelFit, newdata, n.iter = submodels$iter[[i]])
-                      }
-                      out <- lapply(tmp, as.character)
-                    }
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL){
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    out <- predict(modelFit, newdata, type = "prob",
-                                   n.iter = modelFit$tuneValue$iter)
-                    colnames(out) <- modelFit$obsLevels
-
-                    if(!is.null(submodels)) {
-                      tmp <- vector(mode = "list", length = length(submodels$iter)+1)
-                      tmp[[1]] <- out
-                      for(i in seq(along = submodels$iter)) {
-                        tmp[[i+1]] <- predict(modelFit, newdata, type = "prob",
-                                              n.iter = submodels$iter[[i]])
-                        colnames(tmp[[i+1]]) <- modelFit$obsLevels
-                      }
-                      out <- lapply(tmp, as.data.frame)
-                    }
-                    out
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("Tree-Based Model", "Ensemble Model", "Boosting",
-                           "Implicit Feature Selection", "Two Class Only", "Handle Missing Predictor Data"),
-                  sort = function(x) x[order(x$iter, x$maxdepth, x$nu),])
-
-
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = length(submodels$iter) + 1)
+      tmp[[1]] <- out
+      for (i in seq(along = submodels$iter)) {
+        tmp[[i + 1]] <- predict(
+          modelFit,
+          newdata,
+          type = "prob",
+          n.iter = submodels$iter[[i]]
+        )
+        colnames(tmp[[i + 1]]) <- modelFit$obsLevels
+      }
+      out <- lapply(tmp, as.data.frame)
+    }
+    out
+  },
+  levels = function(x) x$obsLevels,
+  tags = c(
+    "Tree-Based Model",
+    "Ensemble Model",
+    "Boosting",
+    "Implicit Feature Selection",
+    "Two Class Only",
+    "Handle Missing Predictor Data"
+  ),
+  sort = function(x) x[order(x$iter, x$maxdepth, x$nu), ]
+)

--- a/inst/model_sources/files/adaboost.R
+++ b/inst/model_sources/files/adaboost.R
@@ -27,17 +27,21 @@ modelInfo <- list(
     out
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <-
-      if (!is.data.frame(x) | inherits(x, "tbl_df")) {
-        as.data.frame(x, stringsAsFactors = TRUE)
-      } else {
-        x
-      }
-    dat$.outcome <- y
-    out <- if (param$method == "Adaboost.M1") {
-      fastAdaboost::adaboost(.outcome ~ ., data = dat, nIter = param$nIter, ...)
+    if (!is.data.frame(x) | inherits(x, "tbl_df")) {
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     } else {
-      fastAdaboost::real_adaboost(
+      dat <- x
+    }
+    dat$.outcome <- y
+    if (param$method == "Adaboost.M1") {
+      out <- fastAdaboost::adaboost(
+        .outcome ~ .,
+        data = dat,
+        nIter = param$nIter,
+        ...
+      )
+    } else {
+      out <- fastAdaboost::real_adaboost(
         .outcome ~ .,
         data = dat,
         nIter = param$nIter,

--- a/inst/model_sources/files/adaboost.R
+++ b/inst/model_sources/files/adaboost.R
@@ -1,51 +1,76 @@
-modelInfo <- list(label = "AdaBoost Classification Trees",
-                  library = c("fastAdaboost"),
-                  loop = NULL,
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = c('nIter', 'method'),
-                                          class = c("numeric", "character"),
-                                          label = c('#Trees', 'Method')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out  = expand.grid(nIter = floor((1:len) * 50),
-                                         method = c("Adaboost.M1", "Real adaboost"))
-                    } else {
-                      out <- data.frame(nIter =  sample(1:1000, replace = TRUE, size = len),
-                                        method = sample(c("Adaboost.M1", "Real adaboost"), replace = TRUE, size = len))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    dat <-
-                      if (!is.data.frame(x) | inherits(x, "tbl_df"))
-                        as.data.frame(x, stringsAsFactors = TRUE)
-                    else
-                      x
-                    dat$.outcome <- y
-                    out <- if(param$method == "Adaboost.M1") 
-                      fastAdaboost::adaboost(.outcome ~ ., data = dat, nIter = param$nIter, ...) else 
-                      fastAdaboost::real_adaboost(.outcome ~ ., data = dat, nIter = param$nIter, ...) 
-                    out     
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata) | inherits(newdata, "tbl_df")) 
-                      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata)$class
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL){
-                    if(!is.data.frame(newdata) | inherits(newdata, "tbl_df")) 
-                      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    out <- predict(modelFit, newdata)$prob
-                    out <- t(apply(out, 1, function(x) ifelse(x == Inf, 1, x)))
-                    out <- t(apply(out, 1, function(x) ifelse(x == -Inf, 0, x))) 
-                    out <- as.data.frame(out, stringsAsFactors = TRUE)
-                    colnames(out) <- as.vector(modelFit$classnames)
-                    out 
-                  },
-                  levels = function(x) as.vector(x$classnames),
-                  predictors = function(x, ...) unique(unlist(lapply(x$trees, predictors))),
-                  tags = c("Tree-Based Model", "Ensemble Model", "Boosting", 
-                           "Implicit Feature Selection", "Two Class Only"),
-                  sort = function(x) x[order(x$nIter),])
-
-
+modelInfo <- list(
+  label = "AdaBoost Classification Trees",
+  library = c("fastAdaboost"),
+  loop = NULL,
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = c('nIter', 'method'),
+    class = c("numeric", "character"),
+    label = c('#Trees', 'Method')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out = expand.grid(
+        nIter = floor((1:len) * 50),
+        method = c("Adaboost.M1", "Real adaboost")
+      )
+    } else {
+      out <- data.frame(
+        nIter = sample(1:1000, replace = TRUE, size = len),
+        method = sample(
+          c("Adaboost.M1", "Real adaboost"),
+          replace = TRUE,
+          size = len
+        )
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <-
+      if (!is.data.frame(x) | inherits(x, "tbl_df")) {
+        as.data.frame(x, stringsAsFactors = TRUE)
+      } else {
+        x
+      }
+    dat$.outcome <- y
+    out <- if (param$method == "Adaboost.M1") {
+      fastAdaboost::adaboost(.outcome ~ ., data = dat, nIter = param$nIter, ...)
+    } else {
+      fastAdaboost::real_adaboost(
+        .outcome ~ .,
+        data = dat,
+        nIter = param$nIter,
+        ...
+      )
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata) | inherits(newdata, "tbl_df")) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata)$class
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata) | inherits(newdata, "tbl_df")) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    out <- predict(modelFit, newdata)$prob
+    out <- t(apply(out, 1, function(x) ifelse(x == Inf, 1, x)))
+    out <- t(apply(out, 1, function(x) ifelse(x == -Inf, 0, x)))
+    out <- as.data.frame(out, stringsAsFactors = TRUE)
+    colnames(out) <- as.vector(modelFit$classnames)
+    out
+  },
+  levels = function(x) as.vector(x$classnames),
+  predictors = function(x, ...) unique(unlist(lapply(x$trees, predictors))),
+  tags = c(
+    "Tree-Based Model",
+    "Ensemble Model",
+    "Boosting",
+    "Implicit Feature Selection",
+    "Two Class Only"
+  ),
+  sort = function(x) x[order(x$nIter), ]
+)

--- a/inst/model_sources/files/amdai.R
+++ b/inst/model_sources/files/amdai.R
@@ -1,29 +1,37 @@
-modelInfo <- list(label = "Adaptive Mixture Discriminant Analysis",
-                  library = "adaptDA",
-                  loop = NULL,
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = "model",
-                                          class = "character",
-                                          label = "Model Type"),
-                  grid = function(x, y, len = NULL, search = "grid") data.frame(model = "lda"),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    mod <- adaptDA::amdai(x, as.numeric(y), 
-                                 model = as.character(param$model), ...)
-                    mod$levels <- levels(y)
-                    mod
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata, K = length(modelFit$levels))$cls
-                    factor(modelFit$levels[out], levels = modelFit$levels)
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL){
-                    out <- predict(modelFit, newdata, K = length(modelFit$levels))$P
-                    factor(modelFit$levels[out], levels = modelFit$levels)
-                    colnames(out)<-  modelFit$obsLevels
-                    out
-                  },
-                  varImp = NULL,
-                  predictors = function(x, ...) predictors(x$terms),
-                  levels = function(x) if(any(names(x) == "obsLevels")) x$obsLevels else NULL,
-                  tags = c("Discriminant Analysis", "Mixture Model"),
-                  sort = function(x) x)
+modelInfo <- list(
+  label = "Adaptive Mixture Discriminant Analysis",
+  library = "adaptDA",
+  loop = NULL,
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = "model",
+    class = "character",
+    label = "Model Type"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") data.frame(model = "lda"),
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    mod <- adaptDA::amdai(
+      x,
+      as.numeric(y),
+      model = as.character(param$model),
+      ...
+    )
+    mod$levels <- levels(y)
+    mod
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata, K = length(modelFit$levels))$cls
+    factor(modelFit$levels[out], levels = modelFit$levels)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata, K = length(modelFit$levels))$P
+    factor(modelFit$levels[out], levels = modelFit$levels)
+    colnames(out) <- modelFit$obsLevels
+    out
+  },
+  varImp = NULL,
+  predictors = function(x, ...) predictors(x$terms),
+  levels = function(x) if (any(names(x) == "obsLevels")) x$obsLevels else NULL,
+  tags = c("Discriminant Analysis", "Mixture Model"),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/amdai.R
+++ b/inst/model_sources/files/amdai.R
@@ -31,7 +31,13 @@ modelInfo <- list(
   },
   varImp = NULL,
   predictors = function(x, ...) predictors(x$terms),
-  levels = function(x) if (any(names(x) == "obsLevels")) x$obsLevels else NULL,
+  levels = function(x) {
+    if (any(names(x) == "obsLevels")) {
+      x$obsLevels
+    } else {
+      NULL
+    }
+  },
   tags = c("Discriminant Analysis", "Mixture Model"),
   sort = function(x) x
 )

--- a/inst/model_sources/files/avNNet.R
+++ b/inst/model_sources/files/avNNet.R
@@ -1,61 +1,82 @@
-modelInfo <- list(label = "Model Averaged Neural Network", 
-                  library = "nnet",
-                  loop = NULL,
-                  type = c("Classification", "Regression"),
-                  parameters = data.frame(parameter = c('size', 'decay', 'bag'),
-                                          class = c(rep("numeric", 2), "logical"),
-                                          label = c('#Hidden Units', 'Weight Decay', 'Bagging')),
-                  grid =  function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- expand.grid(size = ((1:len) * 2) - 1, 
-                                         decay = c(0, 10 ^ seq(-1, -4, length = len - 1)),
-                                         bag = FALSE)
-                    } else {
-                      out <- data.frame(size = sample(1:20, size = len, replace = TRUE), 
-                                        decay = 10^runif(len, min = -5, 1),
-                                        bag = sample(c(TRUE, FALSE), size = len, replace = TRUE))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    if(!is.null(wts)) {
-                      out <- caret::avNNet(.outcome ~ .,
-                                    data = dat,
-                                    weights = wts,                                       
-                                    size = param$size,
-                                    decay = param$decay,
-                                    bag = param$bag,
-                                    ...)
-                    } else out <- caret::avNNet(.outcome ~ .,
-                                         data = dat,
-                                         size = param$size,
-                                         decay = param$decay,
-                                         bag = param$bag,
-                                         ...)
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL)
-                  {
-                    if(modelFit$problemType == "Classification")
-                    {
-                      out <- predict(modelFit, newdata, type="class")
-                    } else {
-                      out  <- predict(modelFit, newdata, type="raw")
-                    }
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL){
-                    out <- predict(modelFit, newdata, type = "prob")
-                    if(ncol(as.data.frame(out, stringsAsFactors = TRUE)) == 1)
-                    {
-                      out <- cbind(out, 1-out)
-                      dimnames(out)[[2]] <-  rev(modelFit$obsLevels)
-                    }
-                    out
-                  },
-                  predictors = function(x, ...) x$names,
-                  levels = function(x) x$model[[1]]$lev,
-                  tags = c("Neural Network", "Ensemble Model", "Bagging", "L2 Regularization", "Accepts Case Weights"),
-                  sort = function(x) x[order(x$size, -x$decay),])
+modelInfo <- list(
+  label = "Model Averaged Neural Network",
+  library = "nnet",
+  loop = NULL,
+  type = c("Classification", "Regression"),
+  parameters = data.frame(
+    parameter = c('size', 'decay', 'bag'),
+    class = c(rep("numeric", 2), "logical"),
+    label = c('#Hidden Units', 'Weight Decay', 'Bagging')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        size = ((1:len) * 2) - 1,
+        decay = c(0, 10^seq(-1, -4, length = len - 1)),
+        bag = FALSE
+      )
+    } else {
+      out <- data.frame(
+        size = sample(1:20, size = len, replace = TRUE),
+        decay = 10^runif(len, min = -5, 1),
+        bag = sample(c(TRUE, FALSE), size = len, replace = TRUE)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    if (!is.null(wts)) {
+      out <- caret::avNNet(
+        .outcome ~ .,
+        data = dat,
+        weights = wts,
+        size = param$size,
+        decay = param$decay,
+        bag = param$bag,
+        ...
+      )
+    } else {
+      out <- caret::avNNet(
+        .outcome ~ .,
+        data = dat,
+        size = param$size,
+        decay = param$decay,
+        bag = param$bag,
+        ...
+      )
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (modelFit$problemType == "Classification") {
+      out <- predict(modelFit, newdata, type = "class")
+    } else {
+      out <- predict(modelFit, newdata, type = "raw")
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata, type = "prob")
+    if (ncol(as.data.frame(out, stringsAsFactors = TRUE)) == 1) {
+      out <- cbind(out, 1 - out)
+      dimnames(out)[[2]] <- rev(modelFit$obsLevels)
+    }
+    out
+  },
+  predictors = function(x, ...) x$names,
+  levels = function(x) x$model[[1]]$lev,
+  tags = c(
+    "Neural Network",
+    "Ensemble Model",
+    "Bagging",
+    "L2 Regularization",
+    "Accepts Case Weights"
+  ),
+  sort = function(x) x[order(x$size, -x$decay), ]
+)

--- a/inst/model_sources/files/avNNet.R
+++ b/inst/model_sources/files/avNNet.R
@@ -25,10 +25,10 @@ modelInfo <- list(
     out
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     if (!is.null(wts)) {

--- a/inst/model_sources/files/awnb.R
+++ b/inst/model_sources/files/awnb.R
@@ -17,10 +17,10 @@ modelInfo <- list(
   },
   loop = NULL,
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     struct <- bnclassify::nb(class = '.outcome', dataset = dat)

--- a/inst/model_sources/files/awnb.R
+++ b/inst/model_sources/files/awnb.R
@@ -1,43 +1,55 @@
-modelInfo <- list(label = "Naive Bayes Classifier with Attribute Weighting",
-                  library = "bnclassify",
-                  type = "Classification",
-                  parameters = data.frame(parameter = c("smooth"),
-                                          class = c("numeric"),
-                                          label = c("Smoothing Parameter")),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") { 
-                      out <- data.frame(smooth = 0:(len-1))
-                    } else {
-                      out <- data.frame(smooth= runif(len, min = 0, max = 10))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    struct <- bnclassify::nb(class = '.outcome', dataset = dat)
-                    args <- list(
-                      x = bnclassify::nb(
-                        '.outcome',
-                        dataset = dat
-                      ),
-                      dataset = dat,
-                      smooth = param$smooth
-                    )
-                    dots <- list(...)
-                    args <- c(args, dots)
-                    do.call(bnclassify::lp, args)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata)       
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata, prob = TRUE) 
-                  },
-                  levels = function(x) x$obsLevels,
-                  predictors = function(x, s = NULL, ...) x$xNames,
-                  tags = c("Bayesian Model", "Categorical Predictors Only"),
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Naive Bayes Classifier with Attribute Weighting",
+  library = "bnclassify",
+  type = "Classification",
+  parameters = data.frame(
+    parameter = c("smooth"),
+    class = c("numeric"),
+    label = c("Smoothing Parameter")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(smooth = 0:(len - 1))
+    } else {
+      out <- data.frame(smooth = runif(len, min = 0, max = 10))
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    struct <- bnclassify::nb(class = '.outcome', dataset = dat)
+    args <- list(
+      x = bnclassify::nb(
+        '.outcome',
+        dataset = dat
+      ),
+      dataset = dat,
+      smooth = param$smooth
+    )
+    dots <- list(...)
+    args <- c(args, dots)
+    do.call(bnclassify::lp, args)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata, prob = TRUE)
+  },
+  levels = function(x) x$obsLevels,
+  predictors = function(x, s = NULL, ...) x$xNames,
+  tags = c("Bayesian Model", "Categorical Predictors Only"),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/awtan.R
+++ b/inst/model_sources/files/awtan.R
@@ -2,16 +2,21 @@ modelInfo <- list(
   label = "Tree Augmented Naive Bayes Classifier with Attribute Weighting",
   library = "bnclassify",
   type = "Classification",
-  parameters = data.frame(parameter = c('score', "smooth"),
-                          class = c("character", "numeric"),
-                          label = c('Score Function', "Smoothing Parameter")),
+  parameters = data.frame(
+    parameter = c('score', "smooth"),
+    class = c("character", "numeric"),
+    label = c('Score Function', "Smoothing Parameter")
+  ),
   grid = function(x, y, len = NULL, search = "grid") {
-    out <- expand.grid(score = c('loglik', 'bic', 'aic'),
-                        smooth = 1:2)
+    out <- expand.grid(score = c('loglik', 'bic', 'aic'), smooth = 1:2)
   },
   loop = NULL,
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
     dat$.outcome <- y
     args <- list(
       x = bnclassify::tan_cl(
@@ -23,32 +28,43 @@ modelInfo <- list(
       smooth = param$smooth
     )
     dots <- list(...)
-    if (!any(names(dots) == "awnb_trees"))
+    if (!any(names(dots) == "awnb_trees")) {
       dots$awnb_trees <- 10
-    if (!any(names(dots) == "awnb_bootstrap"))
+    }
+    if (!any(names(dots) == "awnb_bootstrap")) {
       dots$awnb_bootstrap <- 10
-    
+    }
+
     args <- c(args, dots)
     do.call(bnclassify::lp, args)
   },
   predict = function(modelFit, newdata, submodels = NULL) {
-    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-    predict(modelFit, newdata)       
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata)
   },
   prob = function(modelFit, newdata, submodels = NULL) {
-    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-    predict(modelFit, newdata, prob = TRUE) 
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata, prob = TRUE)
   },
   levels = function(x) x$obsLevels,
   predictors = function(x, s = NULL, ...) x$xNames,
   tags = c("Bayesian Model", "Categorical Predictors Only"),
-  sort = function(x) x[order(x[,1]),],
+  sort = function(x) x[order(x[, 1]), ],
   check = function(pkg) {
     requireNamespace("kohonen")
     current <- packageDescription("bnclassify")$Version
     expected <- "0.3.3"
-    if(compareVersion(current, expected) < 0)
-      stop("This modeling workflow requires bnclassify version ",
-           expected, "or greater.", call. = FALSE)
+    if (compareVersion(current, expected) < 0) {
+      stop(
+        "This modeling workflow requires bnclassify version ",
+        expected,
+        "or greater.",
+        call. = FALSE
+      )
+    }
   }
 )

--- a/inst/model_sources/files/awtan.R
+++ b/inst/model_sources/files/awtan.R
@@ -12,10 +12,10 @@ modelInfo <- list(
   },
   loop = NULL,
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     args <- list(

--- a/inst/model_sources/files/bag.R
+++ b/inst/model_sources/files/bag.R
@@ -1,24 +1,32 @@
-modelInfo <- list(label = "Bagged Model",
-                  library = "caret",
-                  loop = NULL,
-                  type = c('Regression', 'Classification'),
-                  parameters = data.frame(parameter = c('vars'),
-                                          class = c('numeric'),
-                                          label = c('#Randomly Selected Predictors')),
-                  grid = function(x, y, len = NULL, search = "grid") 
-                    data.frame(vars = ncol(x)),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    out <- caret::bag(x, y, vars = param$vars, ...)
-                    out$xNames <- colnames(x)
-                    out
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) 
-                    predict(modelFit, newdata),
-                  prob = function(modelFit, newdata, submodels = NULL)
-                    predict(modelFit, newdata, type= "prob"),
-                  predictors = function(x, ...)
-                    x$xNames,
-                  levels = function(x) x$obsLevels,
-                  varImp = NULL,
-                  tags = c("Bagging", "Ensemble Model"),
-                  sort = function(x) x)
+modelInfo <- list(
+  label = "Bagged Model",
+  library = "caret",
+  loop = NULL,
+  type = c('Regression', 'Classification'),
+  parameters = data.frame(
+    parameter = c('vars'),
+    class = c('numeric'),
+    label = c('#Randomly Selected Predictors')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(vars = ncol(x))
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    out <- caret::bag(x, y, vars = param$vars, ...)
+    out$xNames <- colnames(x)
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata, type = "prob")
+  },
+  predictors = function(x, ...) {
+    x$xNames
+  },
+  levels = function(x) x$obsLevels,
+  varImp = NULL,
+  tags = c("Bagging", "Ensemble Model"),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/bagEarth.R
+++ b/inst/model_sources/files/bagEarth.R
@@ -8,10 +8,10 @@ modelInfo <- list(
     label = c('#Terms', 'Product Degree')
   ),
   grid = function(x, y, len = NULL, search = "grid") {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
 
@@ -79,7 +79,11 @@ modelInfo <- list(
 
     if (!is.null(submodels)) {
       tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-      tmp[[1]] <- if (is.matrix(out)) out[, 1] else out
+      if (is.matrix(out)) {
+        tmp[[1]] <- out[, 1]
+      } else {
+        tmp[[1]] <- out
+      }
 
       for (j in seq(along = submodels$nprune)) {
         prunedFit <- update(modelFit, nprune = submodels$nprune[j])
@@ -113,7 +117,11 @@ modelInfo <- list(
     predEarth <- function(x) {
       vi <- varImp(x)
       notZero <- sort(unique(unlist(lapply(vi, function(x) which(x > 0)))))
-      if (length(notZero) > 0) rownames(vi)[notZero] else NULL
+      if (length(notZero) > 0) {
+        rownames(vi)[notZero]
+      } else {
+        NULL
+      }
     }
     eachFit <- lapply(x$fit, predEarth)
     unique(unlist(eachFit))

--- a/inst/model_sources/files/bagEarth.R
+++ b/inst/model_sources/files/bagEarth.R
@@ -1,132 +1,154 @@
-modelInfo <- list(label = "Bagged MARS",
-                  library = "earth",
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('nprune', 'degree'),
-                                          class = c("numeric", "numeric"),
-                                          label = c('#Terms', 'Product Degree')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    dat <- if (is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
+modelInfo <- list(
+  label = "Bagged MARS",
+  library = "earth",
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c('nprune', 'degree'),
+    class = c("numeric", "numeric"),
+    label = c('#Terms', 'Product Degree')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
 
-                    mod <- earth::earth( .outcome~., data = dat, pmethod = "none")
-                    maxTerms <- nrow(mod$dirs)
+    mod <- earth::earth(.outcome ~ ., data = dat, pmethod = "none")
+    maxTerms <- nrow(mod$dirs)
 
-                    maxTerms <- min(200, floor(maxTerms * .75) + 2)
-                    if (search == "grid") {
-                      out <- data.frame(nprune = unique(floor(seq(2, to = maxTerms, length = len))),
-                                        degree = 1)
-                    } else {
-                      out <- data.frame(nprune = sample(2:maxTerms, size = len, replace = TRUE),
-                                        degree = sample(1:2, size = len, replace = TRUE))
-                    }
-                  },
-                  loop = function(grid) {
-                    deg <- unique(grid$degree)
+    maxTerms <- min(200, floor(maxTerms * .75) + 2)
+    if (search == "grid") {
+      out <- data.frame(
+        nprune = unique(floor(seq(2, to = maxTerms, length = len))),
+        degree = 1
+      )
+    } else {
+      out <- data.frame(
+        nprune = sample(2:maxTerms, size = len, replace = TRUE),
+        degree = sample(1:2, size = len, replace = TRUE)
+      )
+    }
+  },
+  loop = function(grid) {
+    deg <- unique(grid$degree)
 
-                    loop <- data.frame(degree = deg)
-                    loop$nprune <- NA
+    loop <- data.frame(degree = deg)
+    loop$nprune <- NA
 
-                    submodels <- vector(mode = "list", length = length(deg))
-                    for (i in seq(along = deg)) {
-                      np <- grid[grid$degree == deg[i],"nprune"]
-                      loop$nprune[loop$degree == deg[i]] <- np[which.max(np)]
-                      submodels[[i]] <- data.frame(nprune = np[-which.max(np)])
-                    }
-                    list(loop = loop, submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    require(earth)
-                    theDots <- list(...)
-                    theDots$keepxy <- TRUE
+    submodels <- vector(mode = "list", length = length(deg))
+    for (i in seq(along = deg)) {
+      np <- grid[grid$degree == deg[i], "nprune"]
+      loop$nprune[loop$degree == deg[i]] <- np[which.max(np)]
+      submodels[[i]] <- data.frame(nprune = np[-which.max(np)])
+    }
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    require(earth)
+    theDots <- list(...)
+    theDots$keepxy <- TRUE
 
-                    ## pass in any model weights
-                    if (!is.null(wts))
-                      theDots$weights <- wts
+    ## pass in any model weights
+    if (!is.null(wts)) {
+      theDots$weights <- wts
+    }
 
-                    modelArgs <- c(list(x = x, y = y,
-                                        degree = param$degree,
-                                        nprune = param$nprune),
-                                   theDots)
+    modelArgs <- c(
+      list(x = x, y = y, degree = param$degree, nprune = param$nprune),
+      theDots
+    )
 
-                    if (is.factor(y) & !any(names(theDots) == "glm")) {
-                      modelArgs$glm <- list(family = binomial, maxit = 100)
-                    }
+    if (is.factor(y) & !any(names(theDots) == "glm")) {
+      modelArgs$glm <- list(family = binomial, maxit = 100)
+    }
 
-                    tmp <- do.call(getFromNamespace("bagEarth.default", "caret"), modelArgs)
+    tmp <- do.call(getFromNamespace("bagEarth.default", "caret"), modelArgs)
 
-                    tmp$call["nprune"] <-  param$nprune
-                    tmp$call["degree"] <-  param$degree
-                    tmp
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if (modelFit$problemType == "Classification") {
-                      out <- predict(modelFit, newdata,  type = "class")
-                    } else {
-                      out <- predict(modelFit, newdata)
-                    }
+    tmp$call["nprune"] <- param$nprune
+    tmp$call["degree"] <- param$degree
+    tmp
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (modelFit$problemType == "Classification") {
+      out <- predict(modelFit, newdata, type = "class")
+    } else {
+      out <- predict(modelFit, newdata)
+    }
 
-                    if (!is.null(submodels)) {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- if (is.matrix(out)) out[,1] else out
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- if (is.matrix(out)) out[, 1] else out
 
-                      for (j in seq(along = submodels$nprune)) {
-                        prunedFit <- update(modelFit, nprune = submodels$nprune[j])
-                        if (modelFit$problemType == "Classification") {
-                          tmp[[j+1]]  <-  predict(prunedFit, newdata,  type = "class")
-                        } else {
-                          tmp[[j+1]]  <-  predict(prunedFit, newdata)
-                        }
-                      }
+      for (j in seq(along = submodels$nprune)) {
+        prunedFit <- update(modelFit, nprune = submodels$nprune[j])
+        if (modelFit$problemType == "Classification") {
+          tmp[[j + 1]] <- predict(prunedFit, newdata, type = "class")
+        } else {
+          tmp[[j + 1]] <- predict(prunedFit, newdata)
+        }
+      }
 
-                      out <- tmp
-                    }
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata, type= "prob")
-                    if (!is.null(submodels))  {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
+      out <- tmp
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata, type = "prob")
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
 
-                      for(j in seq(along = submodels$nprune))  {
-                        prunedFit <- update(modelFit, nprune = submodels$nprune[j])
-                        tmp2 <- predict(prunedFit, newdata, type= "prob")
-                        tmp[[j+1]] <- tmp2
-                      }
-                      out <- tmp
-                    }
-                    out
-                  },
-                  predictors = function(x, ...) {
-                    predEarth <- function(x) {
-                      vi <- varImp(x)
-                      notZero <- sort(unique(unlist(lapply(vi, function(x) which(x > 0)))))
-                      if (length(notZero) > 0) rownames(vi)[notZero] else NULL
-                    }
-                    eachFit <- lapply(x$fit, predEarth)
-                    unique(unlist(eachFit))
-                  },
-                  varImp = function(object, ...) {
-                    allImp <- lapply(object$fit, varImp, ...)
-                    allImp <- lapply(allImp,
-                                     function (x) {
-                                       x$var <- rownames(x)
-                                       x
-                                     },
-                                     ...)
-                    allImp <- do.call("rbind", allImp)
+      for (j in seq(along = submodels$nprune)) {
+        prunedFit <- update(modelFit, nprune = submodels$nprune[j])
+        tmp2 <- predict(prunedFit, newdata, type = "prob")
+        tmp[[j + 1]] <- tmp2
+      }
+      out <- tmp
+    }
+    out
+  },
+  predictors = function(x, ...) {
+    predEarth <- function(x) {
+      vi <- varImp(x)
+      notZero <- sort(unique(unlist(lapply(vi, function(x) which(x > 0)))))
+      if (length(notZero) > 0) rownames(vi)[notZero] else NULL
+    }
+    eachFit <- lapply(x$fit, predEarth)
+    unique(unlist(eachFit))
+  },
+  varImp = function(object, ...) {
+    allImp <- lapply(object$fit, varImp, ...)
+    allImp <- lapply(
+      allImp,
+      function(x) {
+        x$var <- rownames(x)
+        x
+      },
+      ...
+    )
+    allImp <- do.call("rbind", allImp)
 
-                    impDF <- plyr::ddply(allImp, .(var), function(x) c(Overall = mean(x$Overall, rm.na = TRUE)))
-                    out <- data.frame(Overall = impDF$Overall)
-                    rownames(out) <- impDF$var
-                    out
-                  },
-                  levels = function(x) x$levels,
-                  tags = c("Multivariate Adaptive Regression Splines", "Ensemble Model",
-                           "Implicit Feature Selection", "Bagging", "Accepts Case Weights"),
-                  notes = paste(
-                    "Unlike other packages used by `train`, the `earth`",
-                    "package is fully loaded when this model is used."
-                  ),
-                  sort = function(x) x[order(x$degree, x$nprune),],
-                  oob = function(x) apply(x$oob, 2, function(x) quantile(x, probs = .5)))
+    impDF <- plyr::ddply(allImp, .(var), function(x) {
+      c(Overall = mean(x$Overall, rm.na = TRUE))
+    })
+    out <- data.frame(Overall = impDF$Overall)
+    rownames(out) <- impDF$var
+    out
+  },
+  levels = function(x) x$levels,
+  tags = c(
+    "Multivariate Adaptive Regression Splines",
+    "Ensemble Model",
+    "Implicit Feature Selection",
+    "Bagging",
+    "Accepts Case Weights"
+  ),
+  notes = paste(
+    "Unlike other packages used by `train`, the `earth`",
+    "package is fully loaded when this model is used."
+  ),
+  sort = function(x) x[order(x$degree, x$nprune), ],
+  oob = function(x) apply(x$oob, 2, function(x) quantile(x, probs = .5))
+)

--- a/inst/model_sources/files/bagEarthGCV.R
+++ b/inst/model_sources/files/bagEarthGCV.R
@@ -1,72 +1,86 @@
-modelInfo <- list(label = "Bagged MARS using gCV Pruning",
-                  library = "earth",
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('degree'),
-                                          class = c("numeric"),
-                                          label = c('Product Degree')),
-                  grid = function(x, y, len = NULL, search = "grid")  data.frame(degree = 1),
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                  	require(earth)
-                    theDots <- list(...)
-                    theDots$keepxy <- TRUE
+modelInfo <- list(
+  label = "Bagged MARS using gCV Pruning",
+  library = "earth",
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c('degree'),
+    class = c("numeric"),
+    label = c('Product Degree')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") data.frame(degree = 1),
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    require(earth)
+    theDots <- list(...)
+    theDots$keepxy <- TRUE
 
-                    ## pass in any model weights
-                    if (!is.null(wts))
-                      theDots$weights <- wts
+    ## pass in any model weights
+    if (!is.null(wts)) {
+      theDots$weights <- wts
+    }
 
-                    modelArgs <- c(list(x = x, y = y, degree = param$degree), theDots)
+    modelArgs <- c(list(x = x, y = y, degree = param$degree), theDots)
 
-                    if (is.factor(y) & !any(names(theDots) == "glm")) {
-                      modelArgs$glm <- list(family = binomial, maxit = 100)
-                    }
+    if (is.factor(y) & !any(names(theDots) == "glm")) {
+      modelArgs$glm <- list(family = binomial, maxit = 100)
+    }
 
-                    tmp <- do.call(getFromNamespace("bagEarth.default", "caret"), modelArgs)
+    tmp <- do.call(getFromNamespace("bagEarth.default", "caret"), modelArgs)
 
-                    tmp$call["degree"] <-  param$degree
-                    tmp
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if (modelFit$problemType == "Classification") {
-                      out <- predict(modelFit, newdata,  type = "class")
-                    } else {
-                      out <- predict(modelFit, newdata)
-                    }
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    predict(modelFit, newdata, type= "prob")
-                  },
-                  predictors = function(x, ...) {
-                    predEarth <- function(x) {
-                      vi <- varImp(x)
-                      notZero <- sort(unique(unlist(lapply(vi, function(x) which(x > 0)))))
-                      if(length(notZero) > 0) rownames(vi)[notZero] else NULL
-                    }
-                    eachFit <- lapply(x$fit, predEarth)
-                    unique(unlist(eachFit))
-                  },
-                  varImp = function(object, ...) {
-                    allImp <- lapply(object$fit, varImp, ...)
-                    allImp <- lapply(allImp,
-                                     function (x) {
-                                       x$var <- rownames(x)
-                                       x
-                                     },
-                                     ...)
-                    allImp <- do.call("rbind", allImp)
+    tmp$call["degree"] <- param$degree
+    tmp
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (modelFit$problemType == "Classification") {
+      out <- predict(modelFit, newdata, type = "class")
+    } else {
+      out <- predict(modelFit, newdata)
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata, type = "prob")
+  },
+  predictors = function(x, ...) {
+    predEarth <- function(x) {
+      vi <- varImp(x)
+      notZero <- sort(unique(unlist(lapply(vi, function(x) which(x > 0)))))
+      if (length(notZero) > 0) rownames(vi)[notZero] else NULL
+    }
+    eachFit <- lapply(x$fit, predEarth)
+    unique(unlist(eachFit))
+  },
+  varImp = function(object, ...) {
+    allImp <- lapply(object$fit, varImp, ...)
+    allImp <- lapply(
+      allImp,
+      function(x) {
+        x$var <- rownames(x)
+        x
+      },
+      ...
+    )
+    allImp <- do.call("rbind", allImp)
 
-                    impDF <- plyr::ddply(allImp, .(var), function(x) c(Overall = mean(x$Overall, rm.na = TRUE)))
-                    out <- data.frame(Overall = impDF$Overall)
-                    rownames(out) <- impDF$var
-                    out
-                  },
-                  levels = function(x) x$levels,
-                  tags = c("Multivariate Adaptive Regression Splines", "Ensemble Model",
-                           "Implicit Feature Selection", "Bagging", "Accepts Case Weights"),
-                  notes = paste(
-                    "Unlike other packages used by `train`, the `earth`",
-                    "package is fully loaded when this model is used."
-                  ),
-                  sort = function(x) x[order(x$degree),],
-                  oob = function(x) apply(x$oob, 2, function(x) quantile(x, probs = .5)))
+    impDF <- plyr::ddply(allImp, .(var), function(x) {
+      c(Overall = mean(x$Overall, rm.na = TRUE))
+    })
+    out <- data.frame(Overall = impDF$Overall)
+    rownames(out) <- impDF$var
+    out
+  },
+  levels = function(x) x$levels,
+  tags = c(
+    "Multivariate Adaptive Regression Splines",
+    "Ensemble Model",
+    "Implicit Feature Selection",
+    "Bagging",
+    "Accepts Case Weights"
+  ),
+  notes = paste(
+    "Unlike other packages used by `train`, the `earth`",
+    "package is fully loaded when this model is used."
+  ),
+  sort = function(x) x[order(x$degree), ],
+  oob = function(x) apply(x$oob, 2, function(x) quantile(x, probs = .5))
+)

--- a/inst/model_sources/files/bagEarthGCV.R
+++ b/inst/model_sources/files/bagEarthGCV.R
@@ -45,7 +45,11 @@ modelInfo <- list(
     predEarth <- function(x) {
       vi <- varImp(x)
       notZero <- sort(unique(unlist(lapply(vi, function(x) which(x > 0)))))
-      if (length(notZero) > 0) rownames(vi)[notZero] else NULL
+      if (length(notZero) > 0) {
+        rownames(vi)[notZero]
+      } else {
+        NULL
+      }
     }
     eachFit <- lapply(x$fit, predEarth)
     unique(unlist(eachFit))

--- a/inst/model_sources/files/bagFDA.R
+++ b/inst/model_sources/files/bagFDA.R
@@ -9,10 +9,10 @@ modelInfo <- list(
     label = c('Product Degree', '#Terms')
   ),
   grid = function(x, y, len = NULL, search = "grid") {
-    dat <- if (!is.data.frame(x)) {
-      as.data.frame(x, stringsAsFactors = TRUE)
+    if (!is.data.frame(x)) {
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     } else {
-      x
+      dat <- x
     }
     dat$.outcome <- y
 
@@ -40,10 +40,10 @@ modelInfo <- list(
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
     require(earth)
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     bagFDA(
@@ -72,7 +72,11 @@ modelInfo <- list(
     fdaPreds <- function(x) {
       code <- getModelInfo("earth", regex = FALSE)[[1]]$predictors
       tmp <- predictors(x$terms)
-      out <- if (class(x$fit) == "earth") code(x$fit) else tmp
+      if (class(x$fit) == "earth") {
+        out <- code(x$fit)
+      } else {
+        out <- tmp
+      }
       out
     }
     eachFit <- lapply(x$fit, fdaPreds)

--- a/inst/model_sources/files/bagFDA.R
+++ b/inst/model_sources/files/bagFDA.R
@@ -1,73 +1,107 @@
-modelInfo <- list(label = "Bagged Flexible Discriminant Analysis",
-                  library = c("earth", "mda"),
-                  loop = NULL,
-                  type = "Classification",
-                  parameters = data.frame(parameter = c("degree", "nprune"),
-                                          class = c("numeric", "numeric"),
-                                          label = c('Product Degree', '#Terms')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    dat <- if(!is.data.frame(x)) as.data.frame(x, stringsAsFactors = TRUE) else x
-                    dat$.outcome <- y
+modelInfo <- list(
+  label = "Bagged Flexible Discriminant Analysis",
+  library = c("earth", "mda"),
+  loop = NULL,
+  type = "Classification",
+  parameters = data.frame(
+    parameter = c("degree", "nprune"),
+    class = c("numeric", "numeric"),
+    label = c('Product Degree', '#Terms')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    dat <- if (!is.data.frame(x)) {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    } else {
+      x
+    }
+    dat$.outcome <- y
 
-                    mod <- mda::fda( .outcome~., data = dat, method = earth::earth, pmethod = "none")
-                    maxTerms <- nrow(mod$fit$dirs) - 1
+    mod <- mda::fda(
+      .outcome ~ .,
+      data = dat,
+      method = earth::earth,
+      pmethod = "none"
+    )
+    maxTerms <- nrow(mod$fit$dirs) - 1
 
-                    maxTerms <- min(200, floor(maxTerms * .75) + 2)
-                    if(search == "grid") {
-                      out <- data.frame(nprune = unique(floor(seq(2, to = maxTerms, length = len))),
-                                        degree = 1)
-                    } else {
-                      out <- data.frame(nprune = sample(2:maxTerms, size = len, replace = TRUE),
-                                        degree = sample(1:2, size = len, replace = TRUE))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                  	require(earth)
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    bagFDA(.outcome ~ .,
-                           data = dat,
-                           degree = param$degree,
-                           nprune = param$nprune,
-                           weights = wts,
-                           ...)
-                  },
-                  tags = c("Multivariate Adaptive Regression Splines", "Ensemble Model",
-                           "Implicit Feature Selection", "Bagging", "Accepts Case Weights"),
-                  predict = function(modelFit, newdata, submodels = NULL)
-                    predict(modelFit , newdata),
-                  prob = function(modelFit, newdata, submodels = NULL)
-                    predict(modelFit, newdata, type= "probs"),
-                  predictors = function(x, ...) {
-                    fdaPreds <- function(x) {
-                      code <- getModelInfo("earth", regex = FALSE)[[1]]$predictors
-                      tmp <- predictors(x$terms)
-                      out <- if(class(x$fit) == "earth") code(x$fit) else tmp
-                      out
-                    }
-                    eachFit <- lapply(x$fit, fdaPreds)
-                    unique(unlist(eachFit))
-                  },
-                  varImp = function(object, ...) {
-                    allImp <- lapply(object$fit, varImp, ...)
-                    allImp <- lapply(allImp,
-                                     function (x) {
-                                       x$var <- rownames(x)
-                                       x
-                                     },
-                                     ...)
-                    allImp <- do.call("rbind", allImp)
+    maxTerms <- min(200, floor(maxTerms * .75) + 2)
+    if (search == "grid") {
+      out <- data.frame(
+        nprune = unique(floor(seq(2, to = maxTerms, length = len))),
+        degree = 1
+      )
+    } else {
+      out <- data.frame(
+        nprune = sample(2:maxTerms, size = len, replace = TRUE),
+        degree = sample(1:2, size = len, replace = TRUE)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    require(earth)
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    bagFDA(
+      .outcome ~ .,
+      data = dat,
+      degree = param$degree,
+      nprune = param$nprune,
+      weights = wts,
+      ...
+    )
+  },
+  tags = c(
+    "Multivariate Adaptive Regression Splines",
+    "Ensemble Model",
+    "Implicit Feature Selection",
+    "Bagging",
+    "Accepts Case Weights"
+  ),
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata, type = "probs")
+  },
+  predictors = function(x, ...) {
+    fdaPreds <- function(x) {
+      code <- getModelInfo("earth", regex = FALSE)[[1]]$predictors
+      tmp <- predictors(x$terms)
+      out <- if (class(x$fit) == "earth") code(x$fit) else tmp
+      out
+    }
+    eachFit <- lapply(x$fit, fdaPreds)
+    unique(unlist(eachFit))
+  },
+  varImp = function(object, ...) {
+    allImp <- lapply(object$fit, varImp, ...)
+    allImp <- lapply(
+      allImp,
+      function(x) {
+        x$var <- rownames(x)
+        x
+      },
+      ...
+    )
+    allImp <- do.call("rbind", allImp)
 
-                    impDF <- plyr::ddply(allImp, .(var), function(x) c(Overall = mean(x$Overall, rm.na = TRUE)))
-                    out <- data.frame(Overall = impDF$Overall)
-                    rownames(out) <- impDF$var
-                    out
-                  },
-                  notes = paste(
-                    "Unlike other packages used by `train`, the `earth`",
-                    "package is fully loaded when this model is used."
-                  ),
-                  levels = function(x) x$levels,
-                  sort = function(x) x[order(x$degree, x$nprune),],
-                  oob = function(x) apply(x$oob, 2, function(x) quantile(x, probs = .5)))
+    impDF <- plyr::ddply(allImp, .(var), function(x) {
+      c(Overall = mean(x$Overall, rm.na = TRUE))
+    })
+    out <- data.frame(Overall = impDF$Overall)
+    rownames(out) <- impDF$var
+    out
+  },
+  notes = paste(
+    "Unlike other packages used by `train`, the `earth`",
+    "package is fully loaded when this model is used."
+  ),
+  levels = function(x) x$levels,
+  sort = function(x) x[order(x$degree, x$nprune), ],
+  oob = function(x) apply(x$oob, 2, function(x) quantile(x, probs = .5))
+)

--- a/inst/model_sources/files/bagFDAGCV.R
+++ b/inst/model_sources/files/bagFDAGCV.R
@@ -11,10 +11,10 @@ modelInfo <- list(
   loop = NULL,
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
     require(earth)
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     caret::bagFDA(
@@ -41,7 +41,11 @@ modelInfo <- list(
     fdaPreds <- function(x) {
       code <- getModelInfo("earth", regex = FALSE)[[1]]$predictors
       tmp <- predictors(x$terms)
-      out <- if (class(x$fit) == "earth") code(x$fit) else tmp
+      if (class(x$fit) == "earth") {
+        out <- code(x$fit)
+      } else {
+        out <- tmp
+      }
       out
     }
     eachFit <- lapply(x$fit, fdaPreds)

--- a/inst/model_sources/files/bagFDAGCV.R
+++ b/inst/model_sources/files/bagFDAGCV.R
@@ -1,58 +1,83 @@
-modelInfo <- list(label = "Bagged FDA using gCV Pruning",
-                  library = "earth",
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = c('degree'),
-                                          class = c("numeric"),
-                                          label = c('Product Degree')),
-                  grid = function(x, y, len = NULL, search = "grid")  data.frame(degree = 1),
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                  	require(earth)
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    caret::bagFDA(.outcome ~ .,
-                                  data = dat,
-                                  degree = param$degree,
-                                  weights = wts,
-                                  ...)
-                  },
-                  tags = c("Multivariate Adaptive Regression Splines", "Ensemble Model",
-                           "Implicit Feature Selection", "Bagging"),
-                  predict = function(modelFit, newdata, submodels = NULL)
-                    predict(modelFit , newdata),
-                  prob = function(modelFit, newdata, submodels = NULL)
-                    predict(modelFit, newdata, type= "probs"),
-                  predictors = function(x, ...) {
-                    fdaPreds <- function(x) {
-                      code <- getModelInfo("earth", regex = FALSE)[[1]]$predictors
-                      tmp <- predictors(x$terms)
-                      out <- if(class(x$fit) == "earth") code(x$fit) else tmp
-                      out
-                    }
-                    eachFit <- lapply(x$fit, fdaPreds)
-                    unique(unlist(eachFit))
-                  },
-                  varImp = function(object, ...) {
-                    allImp <- lapply(object$fit, varImp, ...)
-                    allImp <- lapply(allImp,
-                                     function (x) {
-                                       x$var <- rownames(x)
-                                       x
-                                     },
-                                     ...)
-                    allImp <- do.call("rbind", allImp)
+modelInfo <- list(
+  label = "Bagged FDA using gCV Pruning",
+  library = "earth",
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = c('degree'),
+    class = c("numeric"),
+    label = c('Product Degree')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") data.frame(degree = 1),
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    require(earth)
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    caret::bagFDA(
+      .outcome ~ .,
+      data = dat,
+      degree = param$degree,
+      weights = wts,
+      ...
+    )
+  },
+  tags = c(
+    "Multivariate Adaptive Regression Splines",
+    "Ensemble Model",
+    "Implicit Feature Selection",
+    "Bagging"
+  ),
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata, type = "probs")
+  },
+  predictors = function(x, ...) {
+    fdaPreds <- function(x) {
+      code <- getModelInfo("earth", regex = FALSE)[[1]]$predictors
+      tmp <- predictors(x$terms)
+      out <- if (class(x$fit) == "earth") code(x$fit) else tmp
+      out
+    }
+    eachFit <- lapply(x$fit, fdaPreds)
+    unique(unlist(eachFit))
+  },
+  varImp = function(object, ...) {
+    allImp <- lapply(object$fit, varImp, ...)
+    allImp <- lapply(
+      allImp,
+      function(x) {
+        x$var <- rownames(x)
+        x
+      },
+      ...
+    )
+    allImp <- do.call("rbind", allImp)
 
-                    impDF <- plyr::ddply(allImp, .(var), function(x) c(Overall = mean(x$Overall, rm.na = TRUE)))
-                    out <- data.frame(Overall = impDF$Overall)
-                    rownames(out) <- impDF$var
-                    out
-                  },
-                  levels = function(x) x$levels,
-                  tags = c("Multivariate Adaptive Regression Splines", "Ensemble Model",
-                           "Implicit Feature Selection", "Bagging", "Accepts Case Weights"),
-                  notes = paste(
-                    "Unlike other packages used by `train`, the `earth`",
-                    "package is fully loaded when this model is used."
-                  ),
-                  sort = function(x) x[order(x$degree),],
-                  oob = function(x) apply(x$oob, 2, function(x) quantile(x, probs = .5)))
+    impDF <- plyr::ddply(allImp, .(var), function(x) {
+      c(Overall = mean(x$Overall, rm.na = TRUE))
+    })
+    out <- data.frame(Overall = impDF$Overall)
+    rownames(out) <- impDF$var
+    out
+  },
+  levels = function(x) x$levels,
+  tags = c(
+    "Multivariate Adaptive Regression Splines",
+    "Ensemble Model",
+    "Implicit Feature Selection",
+    "Bagging",
+    "Accepts Case Weights"
+  ),
+  notes = paste(
+    "Unlike other packages used by `train`, the `earth`",
+    "package is fully loaded when this model is used."
+  ),
+  sort = function(x) x[order(x$degree), ],
+  oob = function(x) apply(x$oob, 2, function(x) quantile(x, probs = .5))
+)

--- a/inst/model_sources/files/bam.R
+++ b/inst/model_sources/files/bam.R
@@ -1,98 +1,111 @@
-modelInfo <- list(label = "Generalized Additive Model using Splines",
-                  library = "mgcv",
-                  loop = NULL,
-                  type = c('Regression', 'Classification'),
-                  parameters = data.frame(parameter = c('select', 'method'),
-                                          class = c('logical', 'character'),
-                                          label = c('Feature Selection', 'Method')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(select = c(TRUE, FALSE), method = "GCV.Cp")
-                    } else {
-                      out <- data.frame(select = sample(c(TRUE, FALSE), size = len, replace = TRUE),
-                                        method = sample(c("GCV.Cp", "ML", "REML"),
-                                                        size = len, replace = TRUE))
-                    }
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    require(mgcv)
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    modForm <- caret:::smootherFormula(x)
-                    if(is.factor(y)) {
-                      dat$.outcome <- ifelse(y == lev[1], 0, 1)
-                      dist <- binomial()
-                    } else {
-                      dat$.outcome <- y
-                      dist <- gaussian()
-                    }
-                    modelArgs <- list(formula = modForm,
-                                      data = dat,
-                                      select = param$select,
-                                      method = as.character(param$method))
-                    ## Intercept family if passed in
-                    theDots <- list(...)
-                    if(!any(names(theDots) == "family")) modelArgs$family <- dist
-                    modelArgs <- c(modelArgs, theDots)
+modelInfo <- list(
+  label = "Generalized Additive Model using Splines",
+  library = "mgcv",
+  loop = NULL,
+  type = c('Regression', 'Classification'),
+  parameters = data.frame(
+    parameter = c('select', 'method'),
+    class = c('logical', 'character'),
+    label = c('Feature Selection', 'Method')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(select = c(TRUE, FALSE), method = "GCV.Cp")
+    } else {
+      out <- data.frame(
+        select = sample(c(TRUE, FALSE), size = len, replace = TRUE),
+        method = sample(c("GCV.Cp", "ML", "REML"), size = len, replace = TRUE)
+      )
+    }
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    require(mgcv)
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    modForm <- caret:::smootherFormula(x)
+    if (is.factor(y)) {
+      dat$.outcome <- ifelse(y == lev[1], 0, 1)
+      dist <- binomial()
+    } else {
+      dat$.outcome <- y
+      dist <- gaussian()
+    }
+    modelArgs <- list(
+      formula = modForm,
+      data = dat,
+      select = param$select,
+      method = as.character(param$method)
+    )
+    ## Intercept family if passed in
+    theDots <- list(...)
+    if (!any(names(theDots) == "family")) {
+      modelArgs$family <- dist
+    }
+    modelArgs <- c(modelArgs, theDots)
 
-                    out <- do.call(mgcv::bam, modelArgs)
-                    out
-
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    if(modelFit$problemType == "Classification") {
-                      probs <-  predict(modelFit, newdata, type = "response")
-                      out <- ifelse(probs < .5,
-                                    modelFit$obsLevel[1],
-                                    modelFit$obsLevel[2])
-                    } else {
-                      out <- predict(modelFit, newdata, type = "response")
-                    }
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL){
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    out <- predict(modelFit, newdata, type = "response")
-                    out <- cbind(1-out, out)
-                    ## glm models the second factor level, we treat the first as the
-                    ## event of interest. See Details in ?glm
-                    colnames(out) <-  modelFit$obsLevels
-                    out
-                  },
-                  predictors = function(x, ...) {
-                    predictors(x$terms)
-                  },
-                  levels = function(x) x$obsLevels,
-                  varImp = function(object, ...) {
-                    smoothed <- summary(object)$s.table[, "p-value", drop = FALSE]
-                    linear <- summary(object)$p.table
-                    linear <- linear[, grepl("^Pr", colnames(linear)), drop = FALSE]
-                    gams <- rbind(smoothed, linear)
-                    gams <- gams[rownames(gams) != "(Intercept)",,drop = FALSE]
-                    rownames(gams) <- gsub("^s\\(", "", rownames(gams))
-                    rownames(gams) <- gsub("\\)$", "", rownames(gams))
-                    colnames(gams)[1] <- "Overall"
-                    gams <- as.data.frame(gams, stringsAsFactors = TRUE)
-                    gams$Overall <- -log10(gams$Overall)
-                    allPreds <- colnames(attr(object$terms,"factors"))
-                    extras <- allPreds[!(allPreds %in% rownames(gams))]
-                    if(any(extras)) {
-                      tmp <- data.frame(Overall = rep(NA, length(extras)))
-                      rownames(tmp) <- extras
-                      gams <- rbind(gams, tmp)
-                    }
-                    gams
-                  },
-                  notes =
-                    paste(
-                      'Which terms enter the model in a nonlinear manner is determined',
-                      'by the number of unique values for the predictor. For example,',
-                      'if a predictor only has four unique values, most basis expansion',
-                      'method will fail because there are not enough granularity in the',
-                      'data. By default, a predictor must have at least 10 unique',
-                      'values to be used in a nonlinear basis expansion.',
-                      'Unlike other packages used by `train`, the `mgcv`',
-                      'package is fully loaded when this model is used.'
-                    ),
-                  tags = c("Generalized Linear Model", "Generalized Additive Model"),
-                  sort = function(x) x)
+    out <- do.call(mgcv::bam, modelArgs)
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    if (modelFit$problemType == "Classification") {
+      probs <- predict(modelFit, newdata, type = "response")
+      out <- ifelse(probs < .5, modelFit$obsLevel[1], modelFit$obsLevel[2])
+    } else {
+      out <- predict(modelFit, newdata, type = "response")
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    out <- predict(modelFit, newdata, type = "response")
+    out <- cbind(1 - out, out)
+    ## glm models the second factor level, we treat the first as the
+    ## event of interest. See Details in ?glm
+    colnames(out) <- modelFit$obsLevels
+    out
+  },
+  predictors = function(x, ...) {
+    predictors(x$terms)
+  },
+  levels = function(x) x$obsLevels,
+  varImp = function(object, ...) {
+    smoothed <- summary(object)$s.table[, "p-value", drop = FALSE]
+    linear <- summary(object)$p.table
+    linear <- linear[, grepl("^Pr", colnames(linear)), drop = FALSE]
+    gams <- rbind(smoothed, linear)
+    gams <- gams[rownames(gams) != "(Intercept)", , drop = FALSE]
+    rownames(gams) <- gsub("^s\\(", "", rownames(gams))
+    rownames(gams) <- gsub("\\)$", "", rownames(gams))
+    colnames(gams)[1] <- "Overall"
+    gams <- as.data.frame(gams, stringsAsFactors = TRUE)
+    gams$Overall <- -log10(gams$Overall)
+    allPreds <- colnames(attr(object$terms, "factors"))
+    extras <- allPreds[!(allPreds %in% rownames(gams))]
+    if (any(extras)) {
+      tmp <- data.frame(Overall = rep(NA, length(extras)))
+      rownames(tmp) <- extras
+      gams <- rbind(gams, tmp)
+    }
+    gams
+  },
+  notes = paste(
+    'Which terms enter the model in a nonlinear manner is determined',
+    'by the number of unique values for the predictor. For example,',
+    'if a predictor only has four unique values, most basis expansion',
+    'method will fail because there are not enough granularity in the',
+    'data. By default, a predictor must have at least 10 unique',
+    'values to be used in a nonlinear basis expansion.',
+    'Unlike other packages used by `train`, the `mgcv`',
+    'package is fully loaded when this model is used.'
+  ),
+  tags = c("Generalized Linear Model", "Generalized Additive Model"),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/bam.R
+++ b/inst/model_sources/files/bam.R
@@ -20,10 +20,10 @@ modelInfo <- list(
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
     require(mgcv)
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     modForm <- caret:::smootherFormula(x)
     if (is.factor(y)) {

--- a/inst/model_sources/files/bartMachine.R
+++ b/inst/model_sources/files/bartMachine.R
@@ -41,8 +41,8 @@ modelInfo <- list(
     if (!is.data.frame(x) | inherits(x, "tbl_df")) {
       x <- as.data.frame(x, stringsAsFactors = TRUE)
     }
-    out <- if (is.factor(y)) {
-      bartMachine::bartMachine(
+    if (is.factor(y)) {
+      out <- bartMachine::bartMachine(
         X = x,
         y = y,
         num_trees = param$num_trees,
@@ -51,7 +51,7 @@ modelInfo <- list(
         ...
       )
     } else {
-      bartMachine::bartMachine(
+      out <- bartMachine::bartMachine(
         X = x,
         y = y,
         num_trees = param$num_trees,
@@ -68,10 +68,10 @@ modelInfo <- list(
     if (!is.data.frame(newdata) | inherits(newdata, "tbl_df")) {
       newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
     }
-    out <- if (is.factor(modelFit$y)) {
-      predict(modelFit, newdata, type = "class")
+    if (is.factor(modelFit$y)) {
+      out <- predict(modelFit, newdata, type = "class")
     } else {
-      predict(modelFit, newdata)
+      out <- predict(modelFit, newdata)
     }
   },
   prob = function(modelFit, newdata, submodels = NULL) {

--- a/inst/model_sources/files/bartMachine.R
+++ b/inst/model_sources/files/bartMachine.R
@@ -1,82 +1,108 @@
-modelInfo <- list(label = "Bayesian Additive Regression Trees",
-                  library = "bartMachine",
-                  loop = NULL,
-                  type = c("Classification", "Regression"),
-                  parameters = data.frame(parameter = c("num_trees", "k", "alpha", "beta", "nu"),
-                                          class = rep("numeric", 5),
-                                          label = c("#Trees",
-                                                    "Prior Boundary",
-                                                    "Base Terminal Node Hyperparameter",
-                                                    "Power Terminal Node Hyperparameter",
-                                                    "Degrees of Freedom")),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(num_trees = 50,
-                                         k = (1:len)+ 1,
-                                         alpha = seq(.9, .99, length = len),
-                                         beta = seq(1, 3, length = len),
-                                         nu =  (1:len)+ 1)
-                    } else {
-                      out <- data.frame(num_trees = sample(10:100, replace = TRUE, size = len),
-                                        k = runif(len, min = 0, max = 5),
-                                        alpha = runif(len, min = .9, max = 1),
-                                        beta = runif(len, min = 0, max = 4),
-                                        nu = runif(len, min = 0, max = 5))
-                    }
-                    if(is.factor(y)) {
-                      out$k <- NA
-                      out$nu <- NA
-                    }
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    if(!is.data.frame(x) | inherits(x, "tbl_df"))
-                      x <- as.data.frame(x, stringsAsFactors = TRUE)
-                    out <- if(is.factor(y)) {
-                      bartMachine::bartMachine(X = x, y = y,
-                                               num_trees = param$num_trees,
-                                               alpha = param$alpha,
-                                               beta = param$beta,
-                                               ...)
-                    } else {
-                      bartMachine::bartMachine(X = x, y = y,
-                                               num_trees = param$num_trees,
-                                               k = param$k,
-                                               alpha = param$alpha,
-                                               beta = param$beta,
-                                               nu = param$nu,
-                                               ...)
-                    }
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata) | inherits(newdata, "tbl_df"))
-                      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    out <- if(is.factor(modelFit$y))
-                      predict(modelFit, newdata, type = "class") else
-                        predict(modelFit, newdata)
-                    },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata) | inherits(newdata, "tbl_df"))
-                      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    out <- predict(modelFit, newdata, type = "prob")
-                    out <- data.frame(y1 = 1- out, y2 = out)
-                    colnames(out) <- modelFit$y_levels
-                    out
-                    },
-                  predictors = function(x, ...)  colnames(x$X),
-                  varImp = function(object, ...){
-                    imps <- bartMachine::investigate_var_importance(object, plot = FALSE)
-                    imps <- imps$avg_var_props - 1.96*imps$sd_var_props
-                    missing_x <- !(colnames(object$X) %in% names(imps))
-                    if(any(missing_x)) {
-                      imps2 <- rep(0, sum(missing_x))
-                      names(imps2) <- colnames(object$X)[missing_x]
-                      imps <- c(imps, imps2)
-                    }
-                    out <- data.frame(Overall = as.vector(imps))
-                    rownames(out) <- names(imps)
-                    out
-                  },
-                  levels = function(x) x$y_levels,
-                  tags = c("Tree-Based Model", "Implicit Feature Selection", "Bayesian Model", "Two Class Only"),
-                  sort = function(x) x[order(-x[,"num_trees"]),])
+modelInfo <- list(
+  label = "Bayesian Additive Regression Trees",
+  library = "bartMachine",
+  loop = NULL,
+  type = c("Classification", "Regression"),
+  parameters = data.frame(
+    parameter = c("num_trees", "k", "alpha", "beta", "nu"),
+    class = rep("numeric", 5),
+    label = c(
+      "#Trees",
+      "Prior Boundary",
+      "Base Terminal Node Hyperparameter",
+      "Power Terminal Node Hyperparameter",
+      "Degrees of Freedom"
+    )
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        num_trees = 50,
+        k = (1:len) + 1,
+        alpha = seq(.9, .99, length = len),
+        beta = seq(1, 3, length = len),
+        nu = (1:len) + 1
+      )
+    } else {
+      out <- data.frame(
+        num_trees = sample(10:100, replace = TRUE, size = len),
+        k = runif(len, min = 0, max = 5),
+        alpha = runif(len, min = .9, max = 1),
+        beta = runif(len, min = 0, max = 4),
+        nu = runif(len, min = 0, max = 5)
+      )
+    }
+    if (is.factor(y)) {
+      out$k <- NA
+      out$nu <- NA
+    }
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (!is.data.frame(x) | inherits(x, "tbl_df")) {
+      x <- as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    out <- if (is.factor(y)) {
+      bartMachine::bartMachine(
+        X = x,
+        y = y,
+        num_trees = param$num_trees,
+        alpha = param$alpha,
+        beta = param$beta,
+        ...
+      )
+    } else {
+      bartMachine::bartMachine(
+        X = x,
+        y = y,
+        num_trees = param$num_trees,
+        k = param$k,
+        alpha = param$alpha,
+        beta = param$beta,
+        nu = param$nu,
+        ...
+      )
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata) | inherits(newdata, "tbl_df")) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    out <- if (is.factor(modelFit$y)) {
+      predict(modelFit, newdata, type = "class")
+    } else {
+      predict(modelFit, newdata)
+    }
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata) | inherits(newdata, "tbl_df")) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    out <- predict(modelFit, newdata, type = "prob")
+    out <- data.frame(y1 = 1 - out, y2 = out)
+    colnames(out) <- modelFit$y_levels
+    out
+  },
+  predictors = function(x, ...) colnames(x$X),
+  varImp = function(object, ...) {
+    imps <- bartMachine::investigate_var_importance(object, plot = FALSE)
+    imps <- imps$avg_var_props - 1.96 * imps$sd_var_props
+    missing_x <- !(colnames(object$X) %in% names(imps))
+    if (any(missing_x)) {
+      imps2 <- rep(0, sum(missing_x))
+      names(imps2) <- colnames(object$X)[missing_x]
+      imps <- c(imps, imps2)
+    }
+    out <- data.frame(Overall = as.vector(imps))
+    rownames(out) <- names(imps)
+    out
+  },
+  levels = function(x) x$y_levels,
+  tags = c(
+    "Tree-Based Model",
+    "Implicit Feature Selection",
+    "Bayesian Model",
+    "Two Class Only"
+  ),
+  sort = function(x) x[order(-x[, "num_trees"]), ]
+)

--- a/inst/model_sources/files/bayesglm.R
+++ b/inst/model_sources/files/bayesglm.R
@@ -12,15 +12,19 @@ modelInfo <- list(
     data.frame(parameter = "none")
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     theDots <- list(...)
     if (!any(names(theDots) == "family")) {
-      theDots$family <- if (is.factor(dat$.outcome)) binomial() else gaussian()
+      if (is.factor(dat$.outcome)) {
+        theDots$family <- binomial()
+      } else {
+        theDots$family <- gaussian()
+      }
     }
 
     ## pass in any model weights

--- a/inst/model_sources/files/bayesglm.R
+++ b/inst/model_sources/files/bayesglm.R
@@ -1,76 +1,97 @@
-modelInfo <- list(label = "Bayesian Generalized Linear Model",
-                  library = "arm",
-                  loop = NULL,
-                  type = c('Regression', 'Classification'),
-                  parameters = data.frame(parameter = "parameter",
-                                          class = "character",
-                                          label = "parameter"),
-                  grid = function(x, y, len = NULL, search = "grid") data.frame(parameter = "none"),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    theDots <- list(...)
-                    if(!any(names(theDots) == "family"))
-                      theDots$family <- if(is.factor(dat$.outcome)) binomial() else gaussian()
+modelInfo <- list(
+  label = "Bayesian Generalized Linear Model",
+  library = "arm",
+  loop = NULL,
+  type = c('Regression', 'Classification'),
+  parameters = data.frame(
+    parameter = "parameter",
+    class = "character",
+    label = "parameter"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(parameter = "none")
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    theDots <- list(...)
+    if (!any(names(theDots) == "family")) {
+      theDots$family <- if (is.factor(dat$.outcome)) binomial() else gaussian()
+    }
 
-                    ## pass in any model weights
-                    if(!is.null(wts)) theDots$weights <- wts
+    ## pass in any model weights
+    if (!is.null(wts)) {
+      theDots$weights <- wts
+    }
 
-                    modelArgs <- c(list(formula = as.formula(".outcome ~ ."),
-                                        data = dat),
-                                   theDots)
+    modelArgs <- c(
+      list(formula = as.formula(".outcome ~ ."), data = dat),
+      theDots
+    )
 
-                    out <- do.call(arm::bayesglm, modelArgs)
-                    out$call <- NULL
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    if(modelFit$problemType == "Classification") {
-                      probs <-  predict(modelFit, newdata, type = "response")
-                      out <- ifelse(probs < .5,
-                                    modelFit$obsLevel[1],
-                                    modelFit$obsLevel[2])
-                    } else {
-                      out <- predict(modelFit, newdata, type = "response")
-                    }
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    out <- predict(modelFit, newdata, type = "response")
-                    out <- cbind(1-out, out)
-                    ## glm models the second factor level. See Details in ?glm
-                    colnames(out) <-  modelFit$obsLevels
-                    out
-                  },
-                  levels = function(x) x$obsLevels,
-                  trim = function(x) {
-                    #Based off: http://www.win-vector.com/blog/2014/05/trimming-the-fat-from-glm-models-in-r/
-                    x$y = c()
-                    x$model = c()
+    out <- do.call(arm::bayesglm, modelArgs)
+    out$call <- NULL
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    if (modelFit$problemType == "Classification") {
+      probs <- predict(modelFit, newdata, type = "response")
+      out <- ifelse(probs < .5, modelFit$obsLevel[1], modelFit$obsLevel[2])
+    } else {
+      out <- predict(modelFit, newdata, type = "response")
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    out <- predict(modelFit, newdata, type = "response")
+    out <- cbind(1 - out, out)
+    ## glm models the second factor level. See Details in ?glm
+    colnames(out) <- modelFit$obsLevels
+    out
+  },
+  levels = function(x) x$obsLevels,
+  trim = function(x) {
+    #Based off: http://www.win-vector.com/blog/2014/05/trimming-the-fat-from-glm-models-in-r/
+    x$y = c()
+    x$model = c()
 
-                    x$residuals = c()
-                    x$fitted.values = c()
-                    x$effects = c()
-                    x$qr$qr = c()
-                    x$linear.predictors = c()
-                    x$weights = c()
-                    x$prior.weights = c()
-                    x$data = c()
+    x$residuals = c()
+    x$fitted.values = c()
+    x$effects = c()
+    x$qr$qr = c()
+    x$linear.predictors = c()
+    x$weights = c()
+    x$prior.weights = c()
+    x$data = c()
 
-                    x$family$variance = c()
-                    x$family$dev.resids = c()
-                    x$family$aic = c()
-                    x$family$validmu = c()
-                    x$family$simulate = c()
-                    attr(x$terms,".Environment") = c()
-                    attr(x$formula,".Environment") = c()
-                    x$R <- c() #Not in a glm
-                    x$xNames <- c()
-                    x$xlevels <- c()
-                    x
-                  },
-                  tags = c("Generalized Linear Model", "Logistic Regression", 
-                           "Linear Classifier", "Bayesian Model", "Accepts Case Weights"),
-                  sort = function(x) x)
+    x$family$variance = c()
+    x$family$dev.resids = c()
+    x$family$aic = c()
+    x$family$validmu = c()
+    x$family$simulate = c()
+    attr(x$terms, ".Environment") = c()
+    attr(x$formula, ".Environment") = c()
+    x$R <- c() #Not in a glm
+    x$xNames <- c()
+    x$xlevels <- c()
+    x
+  },
+  tags = c(
+    "Generalized Linear Model",
+    "Logistic Regression",
+    "Linear Classifier",
+    "Bayesian Model",
+    "Accepts Case Weights"
+  ),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/binda.R
+++ b/inst/model_sources/files/binda.R
@@ -1,29 +1,35 @@
-modelInfo <- list(label = "Binary Discriminant Analysis",
-                  library = "binda",
-                  loop = NULL,
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = c("lambda.freqs"),
-                                          class = c("numeric"),
-                                          label = c('Shrinkage Intensity')),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- data.frame(lambda.freqs = seq(0, 1, length = len))
-                    } else {
-                      out <- data.frame(lambda.freqs = runif(len, min = 0, max = 1))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    binda::binda(as.matrix(x), y, lambda.freqs = param$lambda.freqs, ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    as.character(predict(modelFit, as.matrix(newdata))$class)
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL){
-                    predict(modelFit, as.matrix(newdata))$posterior
-                  },
-                  varImp = NULL,
-                  predictors = function(x, ...) rownames(x$logp0),
-                  levels = function(x) if(any(names(x) == "obsLevels")) x$obsLevels else names(x$logfreqs),
-                  tags = c("Discriminant Analysis", "Two Class Only", "Binary Predictors Only"),
-                  sort = function(x) x)
+modelInfo <- list(
+  label = "Binary Discriminant Analysis",
+  library = "binda",
+  loop = NULL,
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = c("lambda.freqs"),
+    class = c("numeric"),
+    label = c('Shrinkage Intensity')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(lambda.freqs = seq(0, 1, length = len))
+    } else {
+      out <- data.frame(lambda.freqs = runif(len, min = 0, max = 1))
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    binda::binda(as.matrix(x), y, lambda.freqs = param$lambda.freqs, ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    as.character(predict(modelFit, as.matrix(newdata))$class)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, as.matrix(newdata))$posterior
+  },
+  varImp = NULL,
+  predictors = function(x, ...) rownames(x$logp0),
+  levels = function(x) {
+    if (any(names(x) == "obsLevels")) x$obsLevels else names(x$logfreqs)
+  },
+  tags = c("Discriminant Analysis", "Two Class Only", "Binary Predictors Only"),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/binda.R
+++ b/inst/model_sources/files/binda.R
@@ -28,7 +28,11 @@ modelInfo <- list(
   varImp = NULL,
   predictors = function(x, ...) rownames(x$logp0),
   levels = function(x) {
-    if (any(names(x) == "obsLevels")) x$obsLevels else names(x$logfreqs)
+    if (any(names(x) == "obsLevels")) {
+      x$obsLevels
+    } else {
+      names(x$logfreqs)
+    }
   },
   tags = c("Discriminant Analysis", "Two Class Only", "Binary Predictors Only"),
   sort = function(x) x

--- a/inst/model_sources/files/blackboost.R
+++ b/inst/model_sources/files/blackboost.R
@@ -1,112 +1,159 @@
-modelInfo <- list(label = "Boosted Tree", 
-                  library = c("party", "mboost", "plyr", "partykit"),
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('mstop', 'maxdepth'),
-                                          class = c("numeric", "numeric"),
-                                          label = c('#Trees', 'Max Tree Depth')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(maxdepth  = seq(1, len),
-                                         mstop = floor((1:len) * 50))
-                    } else {
-                      out <- data.frame(mstop = sample(1:1000, replace = TRUE, size = len),
-                                        maxdepth = sample(1:10, replace = TRUE, size = len))
-                    }
-                    out
-                  },
-                  loop = function(grid) {
-                    loop <- plyr::ddply(grid, plyr::`.`(maxdepth), function(x) c(mstop = max(x$mstop)))
-                    submodels <- vector(mode = "list", length = nrow(loop))
-                    for(i in seq(along = loop$mstop))  {
-                      index <- which(grid$maxdepth == loop$maxdepth[i])
-                      subStops <- grid[index, "mstop"] 
-                      submodels[[i]] <- data.frame(mstop = subStops[subStops != loop$mstop[i]])
-                    }     
-                    list(loop = loop, submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    theDots <- list(...)
-                    
-                    if(length(levels(y)) > 2) 
-                      stop("Two-class outcomes only. See ?mboost::Multinomial",
-                           call. = FALSE)
-                    
-                    if(any(names(theDots) == "tree_controls")) {
-                      theDots$tree_controls$maxdepth <- param$maxdepth 
-                      treeCtl <- theDots$tree_controls
-                      theDots$tree_controls <- NULL
+modelInfo <- list(
+  label = "Boosted Tree",
+  library = c("party", "mboost", "plyr", "partykit"),
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c('mstop', 'maxdepth'),
+    class = c("numeric", "numeric"),
+    label = c('#Trees', 'Max Tree Depth')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(maxdepth = seq(1, len), mstop = floor((1:len) * 50))
+    } else {
+      out <- data.frame(
+        mstop = sample(1:1000, replace = TRUE, size = len),
+        maxdepth = sample(1:10, replace = TRUE, size = len)
+      )
+    }
+    out
+  },
+  loop = function(grid) {
+    loop <- plyr::ddply(grid, plyr::`.`(maxdepth), function(x) {
+      c(mstop = max(x$mstop))
+    })
+    submodels <- vector(mode = "list", length = nrow(loop))
+    for (i in seq(along = loop$mstop)) {
+      index <- which(grid$maxdepth == loop$maxdepth[i])
+      subStops <- grid[index, "mstop"]
+      submodels[[i]] <- data.frame(mstop = subStops[subStops != loop$mstop[i]])
+    }
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    theDots <- list(...)
 
-                    } else treeCtl <- partykit::ctree_control(maxdepth = param$maxdepth)
+    if (length(levels(y)) > 2) {
+      stop("Two-class outcomes only. See ?mboost::Multinomial", call. = FALSE)
+    }
 
-                    if(any(names(theDots) == "control")) {
-                      theDots$control$mstop <- param$mstop 
-                      ctl <- theDots$control
-                      theDots$control <- NULL
+    if (any(names(theDots) == "tree_controls")) {
+      theDots$tree_controls$maxdepth <- param$maxdepth
+      treeCtl <- theDots$tree_controls
+      theDots$tree_controls <- NULL
+    } else {
+      treeCtl <- partykit::ctree_control(maxdepth = param$maxdepth)
+    }
 
-                    } else ctl <- mboost::boost_control(mstop = param$mstop)
+    if (any(names(theDots) == "control")) {
+      theDots$control$mstop <- param$mstop
+      ctl <- theDots$control
+      theDots$control <- NULL
+    } else {
+      ctl <- mboost::boost_control(mstop = param$mstop)
+    }
 
-                    if(!any(names(theDots) == "family")) {
-                      if(is.factor(y)) {
-                        theDots$family <- if(length(lev) == 2) mboost::Binomial() else mboost::Multinomial()
-                        } else theDots$family <- mboost::GaussReg()
-                    }
+    if (!any(names(theDots) == "family")) {
+      if (is.factor(y)) {
+        theDots$family <- if (length(lev) == 2) {
+          mboost::Binomial()
+        } else {
+          mboost::Multinomial()
+        }
+      } else {
+        theDots$family <- mboost::GaussReg()
+      }
+    }
 
-                    ## pass in any model weights
-                    if(!is.null(wts)) theDots$weights <- wts
-                    
-                    modelArgs <- c(list(formula = as.formula(".outcome ~ ."),
-                                        data = if(!is.data.frame(x)) as.data.frame(x, stringsAsFactors = TRUE) else x,
-                                        control = ctl,
-                                        tree_controls = treeCtl),
-                                   theDots)  
-                    modelArgs$data$.outcome <- y
+    ## pass in any model weights
+    if (!is.null(wts)) {
+      theDots$weights <- wts
+    }
 
-                    out <- do.call(mboost::blackboost, modelArgs)
-                    out$call["data"] <- "data"
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    predType <- ifelse(modelFit$problemType == "Classification", "class", "response")
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    out <- predict(modelFit, newdata, type = predType)
-                    
-                    if(!is.null(submodels)) {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- as.vector(out)
-                      
-                      for(j in seq(along = submodels$mstop)) {
-                        tmp[[j+1]]  <- as.vector(predict(modelFit[submodels$mstop[j]],
-                                                         newdata,
-                                                         type = predType))
-                      }
-                      
-                      out <- tmp
-                    }
-                    
-                    out  
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    probs <- predict(modelFit, newdata, type = "response")
-                    out <- cbind(1 - probs, probs)
-                    colnames(out) <- modelFit$obsLevels
-                    if(!is.null(submodels)) {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
-                      
-                      for(j in seq(along = submodels$mstop)) {                           
-                        tmpProb <- predict(modelFit[submodels$mstop[j]], newdata, type = "response")
-                        tmpProb <- cbind(1 - tmpProb, tmpProb)
-                        colnames(tmpProb) <- modelFit$obsLevels
-                        tmp[[j+1]] <- as.data.frame(tmpProb[, modelFit$obsLevels, drop = FALSE], stringsAsFactors = TRUE)           
-                      }
-                      out <- tmp
-                    }                        
-                    out
-                  },
-                  predictors = function(x, ...) {
-                    strsplit(variable.names(x), ", ")[[1]]
-                  },
-                  levels = function(x) levels(x$response),
-                  tags = c("Tree-Based Model", "Ensemble Model", "Boosting", "Accepts Case Weights"),
-                  sort = function(x) x[order(x$mstop, x$maxdepth),])
+    modelArgs <- c(
+      list(
+        formula = as.formula(".outcome ~ ."),
+        data = if (!is.data.frame(x)) {
+          as.data.frame(x, stringsAsFactors = TRUE)
+        } else {
+          x
+        },
+        control = ctl,
+        tree_controls = treeCtl
+      ),
+      theDots
+    )
+    modelArgs$data$.outcome <- y
+
+    out <- do.call(mboost::blackboost, modelArgs)
+    out$call["data"] <- "data"
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predType <- ifelse(
+      modelFit$problemType == "Classification",
+      "class",
+      "response"
+    )
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    out <- predict(modelFit, newdata, type = predType)
+
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- as.vector(out)
+
+      for (j in seq(along = submodels$mstop)) {
+        tmp[[j + 1]] <- as.vector(predict(
+          modelFit[submodels$mstop[j]],
+          newdata,
+          type = predType
+        ))
+      }
+
+      out <- tmp
+    }
+
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    probs <- predict(modelFit, newdata, type = "response")
+    out <- cbind(1 - probs, probs)
+    colnames(out) <- modelFit$obsLevels
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
+
+      for (j in seq(along = submodels$mstop)) {
+        tmpProb <- predict(
+          modelFit[submodels$mstop[j]],
+          newdata,
+          type = "response"
+        )
+        tmpProb <- cbind(1 - tmpProb, tmpProb)
+        colnames(tmpProb) <- modelFit$obsLevels
+        tmp[[j + 1]] <- as.data.frame(
+          tmpProb[, modelFit$obsLevels, drop = FALSE],
+          stringsAsFactors = TRUE
+        )
+      }
+      out <- tmp
+    }
+    out
+  },
+  predictors = function(x, ...) {
+    strsplit(variable.names(x), ", ")[[1]]
+  },
+  levels = function(x) levels(x$response),
+  tags = c(
+    "Tree-Based Model",
+    "Ensemble Model",
+    "Boosting",
+    "Accepts Case Weights"
+  ),
+  sort = function(x) x[order(x$mstop, x$maxdepth), ]
+)

--- a/inst/model_sources/files/blackboost.R
+++ b/inst/model_sources/files/blackboost.R
@@ -55,10 +55,10 @@ modelInfo <- list(
 
     if (!any(names(theDots) == "family")) {
       if (is.factor(y)) {
-        theDots$family <- if (length(lev) == 2) {
-          mboost::Binomial()
+        if (length(lev) == 2) {
+          theDots$family <- mboost::Binomial()
         } else {
-          mboost::Multinomial()
+          theDots$family <- mboost::Multinomial()
         }
       } else {
         theDots$family <- mboost::GaussReg()

--- a/inst/model_sources/files/blasso.R
+++ b/inst/model_sources/files/blasso.R
@@ -1,55 +1,69 @@
-modelInfo <- list(label = "The Bayesian lasso",
-                  library = "monomvn",
-                  type = "Regression",
-                  parameters = data.frame(parameter = 'sparsity',
-                                          class = "numeric",
-                                          label = 'Sparsity Threshold'),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(len == 1) return(data.frame(sparsity = .5))
-                    if(search == "grid") {
-                      out <-  expand.grid(sparsity = seq(.3, .7, length = len))
-                    } else {
-                      out <- data.frame(sparsity = runif(len, min = 0, max = 1))
-                    }
-                    out
-                  },
-                  loop = function(grid) {   
-                    grid <- grid[order(grid$sparsity, decreasing = TRUE),, drop = FALSE]
-                    loop <- grid[1,,drop = FALSE]
-                    submodels <- list(grid[-1,,drop = FALSE])     
-                    list(loop = loop, submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    mod <- monomvn::blasso(as.matrix(x), y, ...)
-                    mod$.percent <- apply(mod$beta, 2, function(x) mean(x != 0))
-                    mod$.sparsity <- param$sparsity
-                    mod$.betas <- colMeans(mod$beta)
-                    mod
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    betas <- modelFit$.betas
-                    betas[modelFit$.percent <= modelFit$.sparsity] <- 0
-                    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    out <- (newdata %*% betas)[,1]
-                    if(modelFit$icept) out <- out + mean(modelFit$mu)
+modelInfo <- list(
+  label = "The Bayesian lasso",
+  library = "monomvn",
+  type = "Regression",
+  parameters = data.frame(
+    parameter = 'sparsity',
+    class = "numeric",
+    label = 'Sparsity Threshold'
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (len == 1) {
+      return(data.frame(sparsity = .5))
+    }
+    if (search == "grid") {
+      out <- expand.grid(sparsity = seq(.3, .7, length = len))
+    } else {
+      out <- data.frame(sparsity = runif(len, min = 0, max = 1))
+    }
+    out
+  },
+  loop = function(grid) {
+    grid <- grid[order(grid$sparsity, decreasing = TRUE), , drop = FALSE]
+    loop <- grid[1, , drop = FALSE]
+    submodels <- list(grid[-1, , drop = FALSE])
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    mod <- monomvn::blasso(as.matrix(x), y, ...)
+    mod$.percent <- apply(mod$beta, 2, function(x) mean(x != 0))
+    mod$.sparsity <- param$sparsity
+    mod$.betas <- colMeans(mod$beta)
+    mod
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    betas <- modelFit$.betas
+    betas[modelFit$.percent <= modelFit$.sparsity] <- 0
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- (newdata %*% betas)[, 1]
+    if (modelFit$icept) {
+      out <- out + mean(modelFit$mu)
+    }
 
-                    if(!is.null(submodels)) {
-                      tmp <- vector(mode = "list", length = nrow(submodels))
-                      for(i in 1:nrow(submodels)) {
-                        betas <- modelFit$.betas
-                        betas[modelFit$.percent <= submodels$sparsity[i]] <- 0
-                        tmp[[i]] <- (newdata %*% betas)[,1]
-                        if(modelFit$icept) tmp[[i]] <- tmp[[i]] + mean(modelFit$mu)
-                      }
-                      out <- c(list(out), tmp) 
-                    }
-                    out        
-                  },
-                  predictors = function(x, s = NULL, ...) {
-                    x$xNames[x$.percent <= x$.sparsity]
-                  },
-                  notes = "This model creates predictions using the mean of the posterior distributions but sets some parameters specifically to zero based on the tuning parameter `sparsity`. For example, when `sparsity = .5`, only coefficients where at least half the posterior estimates are nonzero are used.",
-                  tags = c("Linear Regression", "Bayesian Model", 
-                           "Implicit Feature Selection", "L1 Regularization"),
-                  prob = NULL,
-                  sort = function(x) x[order(-x$sparsity),])
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels))
+      for (i in 1:nrow(submodels)) {
+        betas <- modelFit$.betas
+        betas[modelFit$.percent <= submodels$sparsity[i]] <- 0
+        tmp[[i]] <- (newdata %*% betas)[, 1]
+        if (modelFit$icept) tmp[[i]] <- tmp[[i]] + mean(modelFit$mu)
+      }
+      out <- c(list(out), tmp)
+    }
+    out
+  },
+  predictors = function(x, s = NULL, ...) {
+    x$xNames[x$.percent <= x$.sparsity]
+  },
+  notes = "This model creates predictions using the mean of the posterior distributions but sets some parameters specifically to zero based on the tuning parameter `sparsity`. For example, when `sparsity = .5`, only coefficients where at least half the posterior estimates are nonzero are used.",
+  tags = c(
+    "Linear Regression",
+    "Bayesian Model",
+    "Implicit Feature Selection",
+    "L1 Regularization"
+  ),
+  prob = NULL,
+  sort = function(x) x[order(-x$sparsity), ]
+)

--- a/inst/model_sources/files/blasso.R
+++ b/inst/model_sources/files/blasso.R
@@ -48,7 +48,9 @@ modelInfo <- list(
         betas <- modelFit$.betas
         betas[modelFit$.percent <= submodels$sparsity[i]] <- 0
         tmp[[i]] <- (newdata %*% betas)[, 1]
-        if (modelFit$icept) tmp[[i]] <- tmp[[i]] + mean(modelFit$mu)
+        if (modelFit$icept) {
+          tmp[[i]] <- tmp[[i]] + mean(modelFit$mu)
+        }
       }
       out <- c(list(out), tmp)
     }

--- a/inst/model_sources/files/blassoAveraged.R
+++ b/inst/model_sources/files/blassoAveraged.R
@@ -1,24 +1,34 @@
-modelInfo <- list(label = "Bayesian Ridge Regression (Model Averaged)",
-                  library = "monomvn",
-                  type = "Regression",
-                  parameters = data.frame(parameter = "parameter",
-                                          class = "character",
-                                          label = "parameter"),
-                  grid = function(x, y, len = NULL, search = "grid") data.frame(parameter = "none"),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    out <- monomvn::blasso(as.matrix(x), y, ...)
-                    out
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    out <- modelFit$beta %*% t(newdata)
-                    if(modelFit$icept) out <- out + (matrix(1, ncol = ncol(out), nrow = nrow(out)) * modelFit$mu)
-                    apply(out, 2, mean)        
-                  },
-                  predictors = function(x, s = NULL, ...) {
-                    x$xNames[apply(x$beta, 2, function(x) any(x != 0))]
-                  },
-                  notes = "This model makes predictions by averaging the predictions based on the posterior estimates of the regression coefficients. While it is possible that some of these posterior estimates are zero for non-informative predictors, the final predicted value may be a function of many (or even all) predictors. ",
-                  tags = c("Linear Regression", "Bayesian Model", "L1 Regularization"),
-                  prob = NULL,
-                  sort = function(x) x)
+modelInfo <- list(
+  label = "Bayesian Ridge Regression (Model Averaged)",
+  library = "monomvn",
+  type = "Regression",
+  parameters = data.frame(
+    parameter = "parameter",
+    class = "character",
+    label = "parameter"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(parameter = "none")
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    out <- monomvn::blasso(as.matrix(x), y, ...)
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- modelFit$beta %*% t(newdata)
+    if (modelFit$icept) {
+      out <- out + (matrix(1, ncol = ncol(out), nrow = nrow(out)) * modelFit$mu)
+    }
+    apply(out, 2, mean)
+  },
+  predictors = function(x, s = NULL, ...) {
+    x$xNames[apply(x$beta, 2, function(x) any(x != 0))]
+  },
+  notes = "This model makes predictions by averaging the predictions based on the posterior estimates of the regression coefficients. While it is possible that some of these posterior estimates are zero for non-informative predictors, the final predicted value may be a function of many (or even all) predictors. ",
+  tags = c("Linear Regression", "Bayesian Model", "L1 Regularization"),
+  prob = NULL,
+  sort = function(x) x
+)

--- a/inst/model_sources/files/bridge.R
+++ b/inst/model_sources/files/bridge.R
@@ -1,23 +1,33 @@
-modelInfo <- list(label = "Bayesian Ridge Regression",
-                  library = "monomvn",
-                  type = "Regression",
-                  parameters = data.frame(parameter = "parameter",
-                                          class = "character",
-                                          label = "parameter"),
-                  grid = function(x, y, len = NULL, search = "grid") data.frame(parameter = "none"),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    out <- monomvn::bridge(as.matrix(x), y, ...)
-                    out
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    out <- modelFit$beta %*% t(newdata)
-                    if(modelFit$icept) out <- out + (matrix(1, ncol = ncol(out), nrow = nrow(out)) * modelFit$mu)
-                    apply(out, 2, mean)        
-                  },
-                  predictors = function(x, s = NULL, ...) {
-                    x$xNames
-                  },
-                  tags = c("Linear Regression", "Bayesian Model", "L2 Regularization"),
-                  prob = NULL,
-                  sort = function(x) x)
+modelInfo <- list(
+  label = "Bayesian Ridge Regression",
+  library = "monomvn",
+  type = "Regression",
+  parameters = data.frame(
+    parameter = "parameter",
+    class = "character",
+    label = "parameter"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(parameter = "none")
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    out <- monomvn::bridge(as.matrix(x), y, ...)
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- modelFit$beta %*% t(newdata)
+    if (modelFit$icept) {
+      out <- out + (matrix(1, ncol = ncol(out), nrow = nrow(out)) * modelFit$mu)
+    }
+    apply(out, 2, mean)
+  },
+  predictors = function(x, s = NULL, ...) {
+    x$xNames
+  },
+  tags = c("Linear Regression", "Bayesian Model", "L2 Regularization"),
+  prob = NULL,
+  sort = function(x) x
+)

--- a/inst/model_sources/files/brnn.R
+++ b/inst/model_sources/files/brnn.R
@@ -1,25 +1,32 @@
-modelInfo <- list(label = "Bayesian Regularized Neural Networks",
-                  library = "brnn",
-                  type = "Regression",
-                  parameters = data.frame(parameter = 'neurons',
-                                          class = "numeric",
-                                          label = '# Neurons'),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(neurons = 1:len)
-                    } else {
-                      out <- data.frame(neurons = sample(1:20, replace = TRUE, size = len))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...)
-                    brnn::brnn(as.matrix(x), y, neurons = param$neurons, ...),
-                  predict = function(modelFit, newdata, submodels = NULL)
-                    predict(modelFit,as.matrix(newdata)),
-                  prob = NULL,
-                  predictors = function(x, s = NULL, ...) 
-                    names(x$x_spread),
-                  tags = c("Bayesian Model", "Neural Network", "Regularization"),
-                  prob = NULL,
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Bayesian Regularized Neural Networks",
+  library = "brnn",
+  type = "Regression",
+  parameters = data.frame(
+    parameter = 'neurons',
+    class = "numeric",
+    label = '# Neurons'
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(neurons = 1:len)
+    } else {
+      out <- data.frame(neurons = sample(1:20, replace = TRUE, size = len))
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    brnn::brnn(as.matrix(x), y, neurons = param$neurons, ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, as.matrix(newdata))
+  },
+  prob = NULL,
+  predictors = function(x, s = NULL, ...) {
+    names(x$x_spread)
+  },
+  tags = c("Bayesian Model", "Neural Network", "Regularization"),
+  prob = NULL,
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/bstSm.R
+++ b/inst/model_sources/files/bstSm.R
@@ -1,79 +1,112 @@
-modelInfo <- list(label = "Boosted Smoothing Spline", 
-                  library = c("bst", "plyr"),
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('mstop', 'nu'),
-                                          class = c("numeric", "numeric"),
-                                          label = c('# Boosting Iterations', 'Shrinkage')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(mstop = floor((1:len) * 50), nu = .1)
-                    } else {
-                      out <- data.frame(mstop = sample(1:500, replace = TRUE, size = len),        
-                                        nu = runif(len, min = .001, max = .6))
-                    }
-                    out
-                  },
-                  loop = function(grid) {
-                    loop <- plyr::ddply(grid, plyr::`.`(nu), function(x) c(mstop = max(x$mstop)))
-                    submodels <- vector(mode = "list", length = nrow(loop))
-                    for(i in seq(along = loop$mstop))
-                    {
-                      index <- which(grid$nu == loop$nu[i])
-                      subTrees <- grid[index, "mstop"] 
-                      submodels[[i]] <- data.frame(mstop = subTrees[subTrees != loop$mstop[i]])
-                    }      
-                    list(loop = loop, submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    if(!is.data.frame(x) | inherits(x, "tbl_df")) 
-                      x <- as.data.frame(x, stringsAsFactors = TRUE)
-                    
-                    theDots <- list(...)
-                    modDist <- if(is.factor(y)) "hinge" else "gaussian"
-                    
-                    y <- if(is.factor(y)) ifelse(y == lev[1], 1, -1) else y
-                    
-                    if(any(names(theDots) == "ctrl")) {
-                      theDots$ctrl$mstop <- param$mstop
-                      theDots$ctrl$nu <- param$nu
-                    } else {
-                      theDots$ctrl <- bst::bst_control(mstop = param$mstop, nu = param$nu)
-                    }
-                    
-                    modArgs <- list(x = x, y = y, family = modDist, learner = "sm")
-                    modArgs <- c(modArgs, theDots)
-                    
-                    out <- do.call(bst::bst, modArgs)
-                    out$call <- quote(redacted)
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata) | inherits(newdata, "tbl_df")) 
-                      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    if(modelFit$problemType == "Classification") {
-                      out <- predict(modelFit, newdata, type = "class", mstop = modelFit$submodels$mstop)
-                      out <- ifelse(out == 1, modelFit$obsLevels[1], modelFit$obsLevels[2])
-                    } else {
-                      out <- predict(modelFit, newdata, type = "response", mstop = modelFit$submodels$mstop)
-                    }
-                    
-                    if(!is.null(submodels))  {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
-                      
-                      for(j in seq(along = submodels$mstop))  {
-                        if(modelFit$problemType == "Classification") {
-                          bstPred <- predict(modelFit, newdata, type = "class", mstop = submodels$mstop[j])
-                          tmp[[j+1]] <- ifelse(bstPred == 1, modelFit$obsLevels[1], modelFit$obsLevels[2])
-                        } else {
-                          tmp[[j+1]]  <- predict(modelFit, newdata, type = "response", mstop = submodels$mstop[j])
-                        }
-                      }
-                      out <- tmp
-                    }
-                    out         
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("Ensemble Model", "Boosting", "Implicit Feature Selection"),
-                  prob = NULL,
-                  sort = function(x) x[order(x$mstop, x$nu),] )
+modelInfo <- list(
+  label = "Boosted Smoothing Spline",
+  library = c("bst", "plyr"),
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c('mstop', 'nu'),
+    class = c("numeric", "numeric"),
+    label = c('# Boosting Iterations', 'Shrinkage')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(mstop = floor((1:len) * 50), nu = .1)
+    } else {
+      out <- data.frame(
+        mstop = sample(1:500, replace = TRUE, size = len),
+        nu = runif(len, min = .001, max = .6)
+      )
+    }
+    out
+  },
+  loop = function(grid) {
+    loop <- plyr::ddply(grid, plyr::`.`(nu), function(x) {
+      c(mstop = max(x$mstop))
+    })
+    submodels <- vector(mode = "list", length = nrow(loop))
+    for (i in seq(along = loop$mstop)) {
+      index <- which(grid$nu == loop$nu[i])
+      subTrees <- grid[index, "mstop"]
+      submodels[[i]] <- data.frame(mstop = subTrees[subTrees != loop$mstop[i]])
+    }
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (!is.data.frame(x) | inherits(x, "tbl_df")) {
+      x <- as.data.frame(x, stringsAsFactors = TRUE)
+    }
+
+    theDots <- list(...)
+    modDist <- if (is.factor(y)) "hinge" else "gaussian"
+
+    y <- if (is.factor(y)) ifelse(y == lev[1], 1, -1) else y
+
+    if (any(names(theDots) == "ctrl")) {
+      theDots$ctrl$mstop <- param$mstop
+      theDots$ctrl$nu <- param$nu
+    } else {
+      theDots$ctrl <- bst::bst_control(mstop = param$mstop, nu = param$nu)
+    }
+
+    modArgs <- list(x = x, y = y, family = modDist, learner = "sm")
+    modArgs <- c(modArgs, theDots)
+
+    out <- do.call(bst::bst, modArgs)
+    out$call <- quote(redacted)
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata) | inherits(newdata, "tbl_df")) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    if (modelFit$problemType == "Classification") {
+      out <- predict(
+        modelFit,
+        newdata,
+        type = "class",
+        mstop = modelFit$submodels$mstop
+      )
+      out <- ifelse(out == 1, modelFit$obsLevels[1], modelFit$obsLevels[2])
+    } else {
+      out <- predict(
+        modelFit,
+        newdata,
+        type = "response",
+        mstop = modelFit$submodels$mstop
+      )
+    }
+
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
+
+      for (j in seq(along = submodels$mstop)) {
+        if (modelFit$problemType == "Classification") {
+          bstPred <- predict(
+            modelFit,
+            newdata,
+            type = "class",
+            mstop = submodels$mstop[j]
+          )
+          tmp[[j + 1]] <- ifelse(
+            bstPred == 1,
+            modelFit$obsLevels[1],
+            modelFit$obsLevels[2]
+          )
+        } else {
+          tmp[[j + 1]] <- predict(
+            modelFit,
+            newdata,
+            type = "response",
+            mstop = submodels$mstop[j]
+          )
+        }
+      }
+      out <- tmp
+    }
+    out
+  },
+  levels = function(x) x$obsLevels,
+  tags = c("Ensemble Model", "Boosting", "Implicit Feature Selection"),
+  prob = NULL,
+  sort = function(x) x[order(x$mstop, x$nu), ]
+)

--- a/inst/model_sources/files/bstSm.R
+++ b/inst/model_sources/files/bstSm.R
@@ -36,9 +36,15 @@ modelInfo <- list(
     }
 
     theDots <- list(...)
-    modDist <- if (is.factor(y)) "hinge" else "gaussian"
+    if (is.factor(y)) {
+      modDist <- "hinge"
+    } else {
+      modDist <- "gaussian"
+    }
 
-    y <- if (is.factor(y)) ifelse(y == lev[1], 1, -1) else y
+    if (is.factor(y)) {
+      y <- ifelse(y == lev[1], 1, -1)
+    }
 
     if (any(names(theDots) == "ctrl")) {
       theDots$ctrl$mstop <- param$mstop

--- a/inst/model_sources/files/bstTree.R
+++ b/inst/model_sources/files/bstTree.R
@@ -1,88 +1,113 @@
-modelInfo <- list(label = "Boosted Tree", 
-                  library = c("bst", "plyr"),
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('mstop', 'maxdepth', 'nu'),
-                                          class = c("numeric", "numeric", "numeric"),
-                                          label = c('# Boosting Iterations', 'Max Tree Depth', 'Shrinkage')),
-                  grid = function(x, y, len = NULL, search = "grid")  {
-                    if(search == "grid") {
-                      out <- expand.grid(mstop = floor((1:len) * 50), 
-                                         maxdepth = seq(1, len), 
-                                         nu = .1)
-                    } else {
-                      out <- data.frame(mstop = sample(1:500, replace = TRUE, size = len),        
-                                        maxdepth = sample(1:10, replace = TRUE, size = len),         
-                                        nu = runif(len, min = .001, max = .6))
-                    }
-                    out
-                  },
-                  loop = function(grid) {
-                    loop <- plyr::ddply(grid, plyr::`.`(maxdepth, nu), function(x) c(mstop = max(x$mstop)))
-                    submodels <- vector(mode = "list", length = nrow(loop))
-                    for(i in seq(along = loop$mstop))
-                    {
-                      index <- which( grid$maxdepth == loop$maxdepth[i] & grid$nu == loop$nu[i])
-                      subTrees <- grid[index, "mstop"] 
-                      submodels[[i]] <- data.frame(mstop = subTrees[subTrees != loop$mstop[i]])
-                    }      
-                    list(loop = loop, submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    
-                    theDots <- list(...)
-                    modDist <- if(is.factor(y)) "hinge" else "gaussian"
-                    
-                    y <- if(is.factor(y)) ifelse(y == lev[1], 1, -1) else y
-                    
-                    if(any(names(theDots) == "ctrl"))
-                    {
-                      theDots$ctrl$mstop <- param$mstop
-                      theDots$ctrl$nu <- param$nu
-                    } else {
-                      theDots$ctrl <- bst::bst_control(mstop = param$mstop, nu = param$nu)
-                    }
-                    if(any(names(theDots) == "control.tree"))
-                    {
-                      theDots$control.tree$maxdepth <- param$maxdepth
-                    } else {
-                      theDots$control.tree <- list(maxdepth = param$maxdepth)
-                    }
-                    
-                    
-                    modArgs <- list(x = x, y = y, family = modDist, learner = "tree")
-                    modArgs <- c(modArgs, theDots)
+modelInfo <- list(
+  label = "Boosted Tree",
+  library = c("bst", "plyr"),
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c('mstop', 'maxdepth', 'nu'),
+    class = c("numeric", "numeric", "numeric"),
+    label = c('# Boosting Iterations', 'Max Tree Depth', 'Shrinkage')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        mstop = floor((1:len) * 50),
+        maxdepth = seq(1, len),
+        nu = .1
+      )
+    } else {
+      out <- data.frame(
+        mstop = sample(1:500, replace = TRUE, size = len),
+        maxdepth = sample(1:10, replace = TRUE, size = len),
+        nu = runif(len, min = .001, max = .6)
+      )
+    }
+    out
+  },
+  loop = function(grid) {
+    loop <- plyr::ddply(grid, plyr::`.`(maxdepth, nu), function(x) {
+      c(mstop = max(x$mstop))
+    })
+    submodels <- vector(mode = "list", length = nrow(loop))
+    for (i in seq(along = loop$mstop)) {
+      index <- which(grid$maxdepth == loop$maxdepth[i] & grid$nu == loop$nu[i])
+      subTrees <- grid[index, "mstop"]
+      submodels[[i]] <- data.frame(mstop = subTrees[subTrees != loop$mstop[i]])
+    }
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    theDots <- list(...)
+    modDist <- if (is.factor(y)) "hinge" else "gaussian"
 
-                    do.call(bst::bst, modArgs)
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(modelFit$problemType == "Classification")
-                    {
-                      out <- predict(modelFit, newdata, type = "class", mstop = modelFit$submodels$mstop)
-                      out <- ifelse(out == 1, modelFit$obsLevels[1], modelFit$obsLevels[2])
-                    } else {
-                      out <- predict(modelFit, newdata, type = "response", mstop = modelFit$submodels$mstop)
-                    }
-                    
-                    if(!is.null(submodels))
-                    {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
-                      
-                      for(j in seq(along = submodels$mstop))
-                      {
-                        if(modelFit$problemType == "Classification")
-                        {
-                          bstPred <- predict(modelFit, newdata, type = "class", mstop = submodels$mstop[j])
-                          tmp[[j+1]] <- ifelse(bstPred == 1, modelFit$obsLevels[1], modelFit$obsLevels[2])
-                        } else {
-                          tmp[[j+1]]  <- predict(modelFit, newdata, type = "response", mstop = submodels$mstop[j])
-                        }
-                      }
-                      out <- tmp
-                    }
-                    out         
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("Tree-Based Model", "Ensemble Model", "Boosting"),
-                  prob = NULL,
-                  sort = function(x) x[order(x$mstop, x$maxdepth, x$nu),] )
+    y <- if (is.factor(y)) ifelse(y == lev[1], 1, -1) else y
+
+    if (any(names(theDots) == "ctrl")) {
+      theDots$ctrl$mstop <- param$mstop
+      theDots$ctrl$nu <- param$nu
+    } else {
+      theDots$ctrl <- bst::bst_control(mstop = param$mstop, nu = param$nu)
+    }
+    if (any(names(theDots) == "control.tree")) {
+      theDots$control.tree$maxdepth <- param$maxdepth
+    } else {
+      theDots$control.tree <- list(maxdepth = param$maxdepth)
+    }
+
+    modArgs <- list(x = x, y = y, family = modDist, learner = "tree")
+    modArgs <- c(modArgs, theDots)
+
+    do.call(bst::bst, modArgs)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (modelFit$problemType == "Classification") {
+      out <- predict(
+        modelFit,
+        newdata,
+        type = "class",
+        mstop = modelFit$submodels$mstop
+      )
+      out <- ifelse(out == 1, modelFit$obsLevels[1], modelFit$obsLevels[2])
+    } else {
+      out <- predict(
+        modelFit,
+        newdata,
+        type = "response",
+        mstop = modelFit$submodels$mstop
+      )
+    }
+
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
+
+      for (j in seq(along = submodels$mstop)) {
+        if (modelFit$problemType == "Classification") {
+          bstPred <- predict(
+            modelFit,
+            newdata,
+            type = "class",
+            mstop = submodels$mstop[j]
+          )
+          tmp[[j + 1]] <- ifelse(
+            bstPred == 1,
+            modelFit$obsLevels[1],
+            modelFit$obsLevels[2]
+          )
+        } else {
+          tmp[[j + 1]] <- predict(
+            modelFit,
+            newdata,
+            type = "response",
+            mstop = submodels$mstop[j]
+          )
+        }
+      }
+      out <- tmp
+    }
+    out
+  },
+  levels = function(x) x$obsLevels,
+  tags = c("Tree-Based Model", "Ensemble Model", "Boosting"),
+  prob = NULL,
+  sort = function(x) x[order(x$mstop, x$maxdepth, x$nu), ]
+)

--- a/inst/model_sources/files/bstTree.R
+++ b/inst/model_sources/files/bstTree.R
@@ -37,9 +37,15 @@ modelInfo <- list(
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
     theDots <- list(...)
-    modDist <- if (is.factor(y)) "hinge" else "gaussian"
+    if (is.factor(y)) {
+      modDist <- "hinge"
+    } else {
+      modDist <- "gaussian"
+    }
 
-    y <- if (is.factor(y)) ifelse(y == lev[1], 1, -1) else y
+    if (is.factor(y)) {
+      y <- ifelse(y == lev[1], 1, -1)
+    }
 
     if (any(names(theDots) == "ctrl")) {
       theDots$ctrl$mstop <- param$mstop

--- a/inst/model_sources/files/cforest.R
+++ b/inst/model_sources/files/cforest.R
@@ -1,79 +1,113 @@
-modelInfo <- list(label = "Conditional Inference Random Forest",
-                  library = "party",
-                  loop = NULL,
-                  type = c("Classification", "Regression"),
-                  parameters = data.frame(parameter = 'mtry',
-                                          class = 'numeric',
-                                          label = "#Randomly Selected Predictors"),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- data.frame(mtry = caret::var_seq(p = ncol(x), 
-                                                              classification = is.factor(y), 
-                                                              len = len))
-                    } else {
-                      out <- data.frame(mtry = unique(sample(1:ncol(x), replace = TRUE, size = len)))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    theDots <- list(...)
-                    
-                    if(any(names(theDots) == "controls"))
-                    {
-                      theDots$controls@gtctrl@mtry <- as.integer(param$mtry) 
-                      ctl <- theDots$controls
-                      theDots$controls <- NULL
+modelInfo <- list(
+  label = "Conditional Inference Random Forest",
+  library = "party",
+  loop = NULL,
+  type = c("Classification", "Regression"),
+  parameters = data.frame(
+    parameter = 'mtry',
+    class = 'numeric',
+    label = "#Randomly Selected Predictors"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(
+        mtry = caret::var_seq(
+          p = ncol(x),
+          classification = is.factor(y),
+          len = len
+        )
+      )
+    } else {
+      out <- data.frame(
+        mtry = unique(sample(1:ncol(x), replace = TRUE, size = len))
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    theDots <- list(...)
 
-                    } else ctl <- party::cforest_control(mtry = min(param$mtry, ncol(x)))
+    if (any(names(theDots) == "controls")) {
+      theDots$controls@gtctrl@mtry <- as.integer(param$mtry)
+      ctl <- theDots$controls
+      theDots$controls <- NULL
+    } else {
+      ctl <- party::cforest_control(mtry = min(param$mtry, ncol(x)))
+    }
 
-                    ## pass in any model weights
-                    if(!is.null(wts)) theDots$weights <- wts
-                    
-                    modelArgs <- c(list(formula = as.formula(.outcome ~ .),
-                                        data = dat,
-                                        controls = ctl),
-                                   theDots)
+    ## pass in any model weights
+    if (!is.null(wts)) {
+      theDots$weights <- wts
+    }
 
-                    out <- do.call(party::cforest, modelArgs)
-                    out
-                  },
-                  predict = function(modelFit, newdata = NULL, submodels = NULL) {
-                    if(!is.null(newdata) && !is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    ## party builds the levels into the model object, so I'm
-                    ## going to assume that all the levels will be passed to
-                    ## the output
-                    out <- party:::predict.RandomForest(modelFit, newdata = newdata, OOB = TRUE)
-                    if(is.matrix(out)) out <- out[,1]
-                    if(!is.null(modelFit@responses@levels$.outcome)) out <- as.character(out)
-                    
-                    out
-                  },
-                  prob = function(modelFit, newdata = NULL, submodels = NULL) {
-                    if(!is.null(newdata) && !is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    obsLevels <- levels(modelFit@data@get("response")[,1])
-                    rawProbs <- party::treeresponse(modelFit, newdata = newdata, OOB = TRUE)
-                    probMatrix <- matrix(unlist(rawProbs), ncol = length(obsLevels), byrow = TRUE)
-                    out <- data.frame(probMatrix)
-                    colnames(out) <- obsLevels
-                    rownames(out) <- NULL
-                    out
-                  },
-                  predictors = function(x, ...) {
-                    vi <- party::varimp(x, ...)
-                    names(vi)[vi != 0]
-                  },
-                  varImp = function(object, ...) {
-                    variableImp <- party::varimp(object, ...)
-                    out <- data.frame(Overall = variableImp)
-                    out
-                  },
-                  tags = c("Random Forest", "Ensemble Model", "Bagging", "Implicit Feature Selection", "Accepts Case Weights"),
-                  levels = function(x) levels(x@data@get("response")[,1]),
-                  sort = function(x) x[order(x[,1]),],
-                  oob = function(x) {
-                    obs <- x@data@get("response")[,1]
-                    pred <- party:::predict.RandomForest(x, OOB = TRUE)
-                    postResample(pred, obs)
-                  })
+    modelArgs <- c(
+      list(formula = as.formula(.outcome ~ .), data = dat, controls = ctl),
+      theDots
+    )
+
+    out <- do.call(party::cforest, modelArgs)
+    out
+  },
+  predict = function(modelFit, newdata = NULL, submodels = NULL) {
+    if (!is.null(newdata) && !is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    ## party builds the levels into the model object, so I'm
+    ## going to assume that all the levels will be passed to
+    ## the output
+    out <- party:::predict.RandomForest(modelFit, newdata = newdata, OOB = TRUE)
+    if (is.matrix(out)) {
+      out <- out[, 1]
+    }
+    if (!is.null(modelFit@responses@levels$.outcome)) {
+      out <- as.character(out)
+    }
+
+    out
+  },
+  prob = function(modelFit, newdata = NULL, submodels = NULL) {
+    if (!is.null(newdata) && !is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    obsLevels <- levels(modelFit@data@get("response")[, 1])
+    rawProbs <- party::treeresponse(modelFit, newdata = newdata, OOB = TRUE)
+    probMatrix <- matrix(
+      unlist(rawProbs),
+      ncol = length(obsLevels),
+      byrow = TRUE
+    )
+    out <- data.frame(probMatrix)
+    colnames(out) <- obsLevels
+    rownames(out) <- NULL
+    out
+  },
+  predictors = function(x, ...) {
+    vi <- party::varimp(x, ...)
+    names(vi)[vi != 0]
+  },
+  varImp = function(object, ...) {
+    variableImp <- party::varimp(object, ...)
+    out <- data.frame(Overall = variableImp)
+    out
+  },
+  tags = c(
+    "Random Forest",
+    "Ensemble Model",
+    "Bagging",
+    "Implicit Feature Selection",
+    "Accepts Case Weights"
+  ),
+  levels = function(x) levels(x@data@get("response")[, 1]),
+  sort = function(x) x[order(x[, 1]), ],
+  oob = function(x) {
+    obs <- x@data@get("response")[, 1]
+    pred <- party:::predict.RandomForest(x, OOB = TRUE)
+    postResample(pred, obs)
+  }
+)

--- a/inst/model_sources/files/cforest.R
+++ b/inst/model_sources/files/cforest.R
@@ -25,10 +25,10 @@ modelInfo <- list(
     out
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     theDots <- list(...)

--- a/inst/model_sources/files/chaid.R
+++ b/inst/model_sources/files/chaid.R
@@ -30,10 +30,10 @@ modelInfo <- list(
     out
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     theDots <- list(...)

--- a/inst/model_sources/files/chaid.R
+++ b/inst/model_sources/files/chaid.R
@@ -1,59 +1,91 @@
-modelInfo <- list(label = "CHi-squared Automated Interaction Detection",
-                  library = "CHAID",
-                  loop = NULL,
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = c('alpha2', 'alpha3', 'alpha4'),
-                                          class = rep('numeric', 3),
-                                          label = c('Merging Threshold', 
-                                                    "Splitting former Merged Threshold", "
-                                                    Splitting former Merged Threshold")),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- data.frame(alpha2 = seq(from = .05, to = 0.01, length = len),
-                                        alpha3 = -1,
-                                        alpha4 = seq(from = .05, to = 0.01, length = len))
-                    } else {
-                      out <- data.frame(alpha2 = runif(len, min = 0.000001, max = .1),
-                                        alpha3 = runif(len, min =-.1, max = .1),
-                                        alpha4 = runif(len, min = 0.000001, max = .1))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    theDots <- list(...)
-                    if(any(names(theDots) == "control")) {
-                        theDots$control$alpha2 <- param$alpha2
-                        theDots$control$alpha3 <- param$alpha3
-                        theDots$control$alpha4 <- param$alpha4
-                        ctl <- theDots$control
-                        theDots$control <- NULL
-                      } else ctl <- CHAID::chaid_control(alpha2 = param$alpha2,
-                                                         alpha3 = param$alpha3,
-                                                         alpha4 = param$alpha4)
-                    ## pass in any model weights
-                    if(!is.null(wts)) theDots$weights <- wts
-                    modelArgs <- c(
-                                   list(
-                                        formula = as.formula(".outcome ~ ."),
-                                        data = dat,
-                                        control = ctl),
-                                   theDots)
-                    out <- do.call(CHAID::chaid, modelArgs)
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata)
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata, type = "prob")
-                  },
-                  levels = function(x) x$obsLevels,
-                  predictors = function(x, surrogate = TRUE, ...) {
-                    predictors(terms(x))
-                  },
-                  tags = c('Tree-Based Model', "Implicit Feature Selection", "Two Class Only", "Accepts Case Weights"),
-                  sort = function(x) x[order(-x$alpha2, -x$alpha4, -x$alpha3),])
+modelInfo <- list(
+  label = "CHi-squared Automated Interaction Detection",
+  library = "CHAID",
+  loop = NULL,
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = c('alpha2', 'alpha3', 'alpha4'),
+    class = rep('numeric', 3),
+    label = c(
+      'Merging Threshold',
+      "Splitting former Merged Threshold",
+      "
+                                                    Splitting former Merged Threshold"
+    )
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(
+        alpha2 = seq(from = .05, to = 0.01, length = len),
+        alpha3 = -1,
+        alpha4 = seq(from = .05, to = 0.01, length = len)
+      )
+    } else {
+      out <- data.frame(
+        alpha2 = runif(len, min = 0.000001, max = .1),
+        alpha3 = runif(len, min = -.1, max = .1),
+        alpha4 = runif(len, min = 0.000001, max = .1)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    theDots <- list(...)
+    if (any(names(theDots) == "control")) {
+      theDots$control$alpha2 <- param$alpha2
+      theDots$control$alpha3 <- param$alpha3
+      theDots$control$alpha4 <- param$alpha4
+      ctl <- theDots$control
+      theDots$control <- NULL
+    } else {
+      ctl <- CHAID::chaid_control(
+        alpha2 = param$alpha2,
+        alpha3 = param$alpha3,
+        alpha4 = param$alpha4
+      )
+    }
+    ## pass in any model weights
+    if (!is.null(wts)) {
+      theDots$weights <- wts
+    }
+    modelArgs <- c(
+      list(
+        formula = as.formula(".outcome ~ ."),
+        data = dat,
+        control = ctl
+      ),
+      theDots
+    )
+    out <- do.call(CHAID::chaid, modelArgs)
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata, type = "prob")
+  },
+  levels = function(x) x$obsLevels,
+  predictors = function(x, surrogate = TRUE, ...) {
+    predictors(terms(x))
+  },
+  tags = c(
+    'Tree-Based Model',
+    "Implicit Feature Selection",
+    "Two Class Only",
+    "Accepts Case Weights"
+  ),
+  sort = function(x) x[order(-x$alpha2, -x$alpha4, -x$alpha3), ]
+)

--- a/inst/model_sources/files/ctree.R
+++ b/inst/model_sources/files/ctree.R
@@ -17,10 +17,10 @@ modelInfo <- list(
     out
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     theDots <- list(...)

--- a/inst/model_sources/files/ctree.R
+++ b/inst/model_sources/files/ctree.R
@@ -1,70 +1,99 @@
-modelInfo <- list(label = "Conditional Inference Tree",
-                  library = "party",
-                  loop = NULL,
-                  type = c("Classification", "Regression"),
-                  parameters = data.frame(parameter = 'mincriterion',
-                                          class = 'numeric',
-                                          label = '1 - P-Value Threshold'),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- data.frame(mincriterion = seq(from = .99, to = 0.01, length = len))
-                    } else {
-                      out <- data.frame(mincriterion = runif(len, min = 0, max = 1))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    theDots <- list(...)
-                    if(any(names(theDots) == "controls"))
-                      {
-                        theDots$controls@gtctrl@mincriterion <- param$mincriterion
-                        ctl <- theDots$controls
-                        theDots$controls <- NULL
-                      } else ctl <- do.call(getFromNamespace("ctree_control", "party"), 
-                                            list(mincriterion = param$mincriterion))
-                    ## pass in any model weights
-                    if(!is.null(wts)) theDots$weights <- wts
-                    modelArgs <- c(
-                                   list(
-                                        formula = as.formula(".outcome ~ ."),
-                                        data = dat,
-                                        controls = ctl),
-                                   theDots)
-                    out <- do.call(party::ctree, modelArgs)
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    out <- predict(modelFit, newdata)
-                    if(!is.null(modelFit@responses@levels$.outcome)) out <- as.character(out)
-                    if(is.matrix(out)) out <- out[,1]
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    obsLevels <- levels(modelFit@data@get("response")[,1])
-                    rawProbs <- party::treeresponse(modelFit, newdata)
-                    probMatrix <- matrix(unlist(rawProbs), ncol = length(obsLevels), byrow = TRUE)
-                    out <- data.frame(probMatrix)
-                    colnames(out) <- obsLevels
-                    rownames(out) <- NULL
-                    out
-                  },
-                  predictors = function(x, surrogate = TRUE, ...) {
-                    treeObj <- unlist(nodes(x, 1))
-                    target <- "psplit\\.variableName"
-                    vars <- treeObj[grep(target, names(treeObj))]
-                    if(surrogate)
-                    {
-                      target2 <- "ssplits\\.variableName"
-                      svars <- treeObj[grep(target, names(treeObj))]
-                      vars <- c(vars, svars)
-                      
-                    }
-                    unique(vars)
-                  },
-                  tags = c('Tree-Based Model', "Implicit Feature Selection", "Accepts Case Weights"),
-                  levels = function(x) levels(x@data@get("response")[,1]),
-                  sort = function(x) x[order(-x$mincriterion),])
+modelInfo <- list(
+  label = "Conditional Inference Tree",
+  library = "party",
+  loop = NULL,
+  type = c("Classification", "Regression"),
+  parameters = data.frame(
+    parameter = 'mincriterion',
+    class = 'numeric',
+    label = '1 - P-Value Threshold'
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(mincriterion = seq(from = .99, to = 0.01, length = len))
+    } else {
+      out <- data.frame(mincriterion = runif(len, min = 0, max = 1))
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    theDots <- list(...)
+    if (any(names(theDots) == "controls")) {
+      theDots$controls@gtctrl@mincriterion <- param$mincriterion
+      ctl <- theDots$controls
+      theDots$controls <- NULL
+    } else {
+      ctl <- do.call(
+        getFromNamespace("ctree_control", "party"),
+        list(mincriterion = param$mincriterion)
+      )
+    }
+    ## pass in any model weights
+    if (!is.null(wts)) {
+      theDots$weights <- wts
+    }
+    modelArgs <- c(
+      list(
+        formula = as.formula(".outcome ~ ."),
+        data = dat,
+        controls = ctl
+      ),
+      theDots
+    )
+    out <- do.call(party::ctree, modelArgs)
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    out <- predict(modelFit, newdata)
+    if (!is.null(modelFit@responses@levels$.outcome)) {
+      out <- as.character(out)
+    }
+    if (is.matrix(out)) {
+      out <- out[, 1]
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    obsLevels <- levels(modelFit@data@get("response")[, 1])
+    rawProbs <- party::treeresponse(modelFit, newdata)
+    probMatrix <- matrix(
+      unlist(rawProbs),
+      ncol = length(obsLevels),
+      byrow = TRUE
+    )
+    out <- data.frame(probMatrix)
+    colnames(out) <- obsLevels
+    rownames(out) <- NULL
+    out
+  },
+  predictors = function(x, surrogate = TRUE, ...) {
+    treeObj <- unlist(nodes(x, 1))
+    target <- "psplit\\.variableName"
+    vars <- treeObj[grep(target, names(treeObj))]
+    if (surrogate) {
+      target2 <- "ssplits\\.variableName"
+      svars <- treeObj[grep(target, names(treeObj))]
+      vars <- c(vars, svars)
+    }
+    unique(vars)
+  },
+  tags = c(
+    'Tree-Based Model',
+    "Implicit Feature Selection",
+    "Accepts Case Weights"
+  ),
+  levels = function(x) levels(x@data@get("response")[, 1]),
+  sort = function(x) x[order(-x$mincriterion), ]
+)

--- a/inst/model_sources/files/ctree2.R
+++ b/inst/model_sources/files/ctree2.R
@@ -1,74 +1,106 @@
-modelInfo <- list(label = "Conditional Inference Tree",
-                  library = "party",
-                  loop = NULL,
-                  type = c('Regression', 'Classification'),
-                  parameters = data.frame(parameter = c('maxdepth', 'mincriterion'),
-                                          class = c('numeric', 'numeric'),
-                                          label = c('Max Tree Depth', '1 - P-Value Threshold')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(maxdepth = 1:len, mincriterion = seq(from = .99, to = 0.01, length = len))
-                    } else {
-                      out <- data.frame(maxdepth = sample(1:15, replace = TRUE, size = len),
-                                        mincriterion = runif(len, min = 0, max = 1))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    theDots <- list(...)
-                    if(any(names(theDots) == "controls"))
-                    {
-                      theDots$controls@tgctrl@maxdepth <- param$maxdepth
-                      theDots$controls@gtctrl@mincriterion <- param$mincriterion
-                      ctl <- theDots$controls
-                      theDots$controls <- NULL
-                      
-                    } else ctl <- do.call(party::ctree_control, 
-                                          list(maxdepth = param$maxdepth,
-                                               mincriterion = param$mincriterion))
-                    ## pass in any model weights
-                    if(!is.null(wts)) theDots$weights <- wts
-                    modelArgs <- c(
-                                   list(
-                                        formula = as.formula(".outcome ~ ."),
-                                        data = dat,
-                                        controls = ctl),
-                                   theDots)
-                    out <- do.call(party::ctree, modelArgs)
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    out <- predict(modelFit, newdata)
-                    if(!is.null(modelFit@responses@levels$.outcome)) out <- as.character(out)
-                    if(is.matrix(out)) out <- out[,1]
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    obsLevels <- levels(modelFit@data@get("response")[,1])
-                    rawProbs <- party::treeresponse(modelFit, newdata)
-                    probMatrix <- matrix(unlist(rawProbs), ncol = length(obsLevels), byrow = TRUE)
-                    out <- data.frame(probMatrix)
-                    colnames(out) <- obsLevels
-                    rownames(out) <- NULL
-                    out
-                  },
-                  predictors = function(x, surrogate = TRUE, ...) {
-                    treeObj <- unlist(nodes(x, 1))
-                    target <- "psplit\\.variableName"
-                    vars <- treeObj[grep(target, names(treeObj))]
-                    if(surrogate)
-                    {
-                      target2 <- "ssplits\\.variableName"
-                      svars <- treeObj[grep(target, names(treeObj))]
-                      vars <- c(vars, svars)
-                      
-                    }
-                    unique(vars)
-                  },
-                  tags = c('Tree-Based Model', "Implicit Feature Selection", "Accepts Case Weights"),
-                  levels = function(x) levels(x@data@get("response")[,1]),
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Conditional Inference Tree",
+  library = "party",
+  loop = NULL,
+  type = c('Regression', 'Classification'),
+  parameters = data.frame(
+    parameter = c('maxdepth', 'mincriterion'),
+    class = c('numeric', 'numeric'),
+    label = c('Max Tree Depth', '1 - P-Value Threshold')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        maxdepth = 1:len,
+        mincriterion = seq(from = .99, to = 0.01, length = len)
+      )
+    } else {
+      out <- data.frame(
+        maxdepth = sample(1:15, replace = TRUE, size = len),
+        mincriterion = runif(len, min = 0, max = 1)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    theDots <- list(...)
+    if (any(names(theDots) == "controls")) {
+      theDots$controls@tgctrl@maxdepth <- param$maxdepth
+      theDots$controls@gtctrl@mincriterion <- param$mincriterion
+      ctl <- theDots$controls
+      theDots$controls <- NULL
+    } else {
+      ctl <- do.call(
+        party::ctree_control,
+        list(maxdepth = param$maxdepth, mincriterion = param$mincriterion)
+      )
+    }
+    ## pass in any model weights
+    if (!is.null(wts)) {
+      theDots$weights <- wts
+    }
+    modelArgs <- c(
+      list(
+        formula = as.formula(".outcome ~ ."),
+        data = dat,
+        controls = ctl
+      ),
+      theDots
+    )
+    out <- do.call(party::ctree, modelArgs)
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    out <- predict(modelFit, newdata)
+    if (!is.null(modelFit@responses@levels$.outcome)) {
+      out <- as.character(out)
+    }
+    if (is.matrix(out)) {
+      out <- out[, 1]
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    obsLevels <- levels(modelFit@data@get("response")[, 1])
+    rawProbs <- party::treeresponse(modelFit, newdata)
+    probMatrix <- matrix(
+      unlist(rawProbs),
+      ncol = length(obsLevels),
+      byrow = TRUE
+    )
+    out <- data.frame(probMatrix)
+    colnames(out) <- obsLevels
+    rownames(out) <- NULL
+    out
+  },
+  predictors = function(x, surrogate = TRUE, ...) {
+    treeObj <- unlist(nodes(x, 1))
+    target <- "psplit\\.variableName"
+    vars <- treeObj[grep(target, names(treeObj))]
+    if (surrogate) {
+      target2 <- "ssplits\\.variableName"
+      svars <- treeObj[grep(target, names(treeObj))]
+      vars <- c(vars, svars)
+    }
+    unique(vars)
+  },
+  tags = c(
+    'Tree-Based Model',
+    "Implicit Feature Selection",
+    "Accepts Case Weights"
+  ),
+  levels = function(x) levels(x@data@get("response")[, 1]),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/ctree2.R
+++ b/inst/model_sources/files/ctree2.R
@@ -23,10 +23,10 @@ modelInfo <- list(
     out
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     theDots <- list(...)

--- a/inst/model_sources/files/cubist.R
+++ b/inst/model_sources/files/cubist.R
@@ -1,77 +1,100 @@
-modelInfo <- list(label = "Cubist",
-                  library = "Cubist",
-                  loop = function(grid) {
-                    ## Here, we want `loop` to be a data frame with the unique values
-                    ## of `committees`. We don't need `neighbors` until `predit.cubist`
-                    ## is used.
+modelInfo <- list(
+  label = "Cubist",
+  library = "Cubist",
+  loop = function(grid) {
+    ## Here, we want `loop` to be a data frame with the unique values
+    ## of `committees`. We don't need `neighbors` until `predit.cubist`
+    ## is used.
 
-                    grid <- grid[order(-grid$committees,
-                                       grid$neighbors,
-                                       decreasing = TRUE),,
-                                 drop = FALSE]
+    grid <- grid[
+      order(-grid$committees, grid$neighbors, decreasing = TRUE),
+      ,
+      drop = FALSE
+    ]
 
-                    uniqueCom <- unique(grid$committees)
+    uniqueCom <- unique(grid$committees)
 
-                    loop <- data.frame(committees = uniqueCom)
-                    loop$neighbors <- NA
+    loop <- data.frame(committees = uniqueCom)
+    loop$neighbors <- NA
 
-                    submodels <- vector(mode = "list", length = length(uniqueCom))
-                    ## For each value of committees, find the largest
-                    ## value of `neighbors` and assign it to `loop`.
-                    ## Then save the rest to a data frame and add it to
-                    ## `submodels`.
-                    for(i in seq(along = uniqueCom)) {
-                      subK <- grid[grid$committees == uniqueCom[i],"neighbors"]
-                      loop$neighbors[loop$committees == uniqueCom[i]] <- subK[which.max(subK)]
-                      submodels[[i]] <- data.frame(neighbors = subK[-which.max(subK)])
-                    }
-                    list(loop = loop, submodels = submodels)
-                  },
-                  type = "Regression",
-                  parameters = data.frame(parameter = c('committees', 'neighbors'),
-                                          class = rep('numeric', 2),
-                                          label = c('#Committees', '#Instances')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(neighbors = c(0, 5, 9), committees = c(1, 10, 20))
-                    } else {
-                      out <- data.frame(neighbors = sample(0:9, replace = TRUE, size = len),
-                                        committees = sample(1:100, replace = TRUE, size = len))
-                    }
+    submodels <- vector(mode = "list", length = length(uniqueCom))
+    ## For each value of committees, find the largest
+    ## value of `neighbors` and assign it to `loop`.
+    ## Then save the rest to a data frame and add it to
+    ## `submodels`.
+    for (i in seq(along = uniqueCom)) {
+      subK <- grid[grid$committees == uniqueCom[i], "neighbors"]
+      loop$neighbors[loop$committees == uniqueCom[i]] <- subK[which.max(subK)]
+      submodels[[i]] <- data.frame(neighbors = subK[-which.max(subK)])
+    }
+    list(loop = loop, submodels = submodels)
+  },
+  type = "Regression",
+  parameters = data.frame(
+    parameter = c('committees', 'neighbors'),
+    class = rep('numeric', 2),
+    label = c('#Committees', '#Instances')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(neighbors = c(0, 5, 9), committees = c(1, 10, 20))
+    } else {
+      out <- data.frame(
+        neighbors = sample(0:9, replace = TRUE, size = len),
+        committees = sample(1:100, replace = TRUE, size = len)
+      )
+    }
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    out <- Cubist::cubist(x, y, committees = param$committees, ...)
+    if (last) {
+      out$tuneValue$neighbors <- param$neighbors
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata, neighbors = modelFit$tuneValue$neighbors)
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
 
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    out <- Cubist::cubist(x, y, committees =  param$committees,  ...)
-                    if(last) out$tuneValue$neighbors <- param$neighbors
-                    out
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata, neighbors = modelFit$tuneValue$neighbors)
-                    if(!is.null(submodels)) {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
+      for (j in seq(along = submodels$neighbors)) {
+        tmp[[j + 1]] <- predict(
+          modelFit,
+          newdata,
+          neighbors = submodels$neighbors[j]
+        )
+      }
 
-                      for(j in seq(along = submodels$neighbors))
-                        tmp[[j+1]] <- predict(modelFit, newdata, neighbors = submodels$neighbors[j])
-
-                      out <- tmp
-                    }
-                    out
-                  },
-                  varImp = function(object, weights = c(0.5, 0.5), ...) {
-                    if(length(weights) != 2) stop("two weights must be given")
-                    weights <- weights/sum(weights)
-                    out <- data.frame(Overall =
-                                        object$usage$Conditions*weights[1] +
-                                        object$usage$Model*weights[2])
-                    rownames(out) <- object$usage$Variable
-                    out
-                  },
-                  predictors = function(x, ...) {
-                    subset(x$usage, Conditions > 0 | Model > 0)$Variable
-                  },
-                  tags = c("Rule-Based Model", "Boosting", "Ensemble Model",
-                           "Prototype Models", "Model Tree", "Linear Regression",
-                           "Implicit Feature Selection"),
-                  prob = NULL,
-                  sort = function(x) x[order(x$committees,  x$neighbors),])
+      out <- tmp
+    }
+    out
+  },
+  varImp = function(object, weights = c(0.5, 0.5), ...) {
+    if (length(weights) != 2) {
+      stop("two weights must be given")
+    }
+    weights <- weights / sum(weights)
+    out <- data.frame(
+      Overall = object$usage$Conditions *
+        weights[1] +
+        object$usage$Model * weights[2]
+    )
+    rownames(out) <- object$usage$Variable
+    out
+  },
+  predictors = function(x, ...) {
+    subset(x$usage, Conditions > 0 | Model > 0)$Variable
+  },
+  tags = c(
+    "Rule-Based Model",
+    "Boosting",
+    "Ensemble Model",
+    "Prototype Models",
+    "Model Tree",
+    "Linear Regression",
+    "Implicit Feature Selection"
+  ),
+  prob = NULL,
+  sort = function(x) x[order(x$committees, x$neighbors), ]
+)

--- a/inst/model_sources/files/dda.R
+++ b/inst/model_sources/files/dda.R
@@ -49,7 +49,11 @@ modelInfo <- list(
     )
   },
   predictors = function(x, ...) {
-    if (hasTerms(x)) predictors(x$terms) else colnames(x$means)
+    if (hasTerms(x)) {
+      predictors(x$terms)
+    } else {
+      colnames(x$means)
+    }
   },
   tags = c(
     "Discriminant Analysis",

--- a/inst/model_sources/files/dda.R
+++ b/inst/model_sources/files/dda.R
@@ -1,40 +1,62 @@
-modelInfo <- list(label = "Diagonal Discriminant Analysis",
-                  library = "sparsediscrim",
-                  loop = NULL,
-                  type = "Classification",
-                  parameters = data.frame(parameter = c("model", "shrinkage"),
-                                          class = rep("character", 2),
-                                          label = c("Model", "Shrinkage Type")),
-                  grid = function(x, y, len = NULL, search = "grid") 
-                    data.frame(model = rep(c("Linear", "Quadratic"), each = 3),
-                               shrinkage = rep(c("None", "Variance", "Mean"), 2)),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    if(param$model == "Linear") {
-                      if(param$shrinkage == "None") {
-                        out <- sparsediscrim::dlda(x, y, ...)
-                      } else {
-                        if(param$shrinkage == "Variance") {
-                          out <- sparsediscrim::sdlda(x, y, ...)
-                        } else out <- sparsediscrim::smdlda(x, y, ...)
-                      }
-                    } else {
-                      if(param$shrinkage == "None") {
-                        out <- sparsediscrim::dqda(x, y, ...)
-                      } else {
-                        if(param$shrinkage == "Variance") {
-                          out <- sparsediscrim::sdqda(x, y, ...)
-                        } else out <- sparsediscrim::smdqda(x, y, ...)
-                      }
-                    }
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) 
-                    predict(modelFit, newdata)$class,
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata)$scores
-                    as.data.frame(t(apply(out, 2, function(x) exp(-x)/sum(exp(-x)))), stringsAsFactors = TRUE)
-                    },
-                  predictors = function(x, ...) if(hasTerms(x)) predictors(x$terms) else colnames(x$means),
-                  tags = c("Discriminant Analysis", "Linear Classifier", "Polynomial Model", "Regularization"),
-                  levels = function(x) names(x$prior),
-                  sort = function(x) x)
+modelInfo <- list(
+  label = "Diagonal Discriminant Analysis",
+  library = "sparsediscrim",
+  loop = NULL,
+  type = "Classification",
+  parameters = data.frame(
+    parameter = c("model", "shrinkage"),
+    class = rep("character", 2),
+    label = c("Model", "Shrinkage Type")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(
+      model = rep(c("Linear", "Quadratic"), each = 3),
+      shrinkage = rep(c("None", "Variance", "Mean"), 2)
+    )
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (param$model == "Linear") {
+      if (param$shrinkage == "None") {
+        out <- sparsediscrim::dlda(x, y, ...)
+      } else {
+        if (param$shrinkage == "Variance") {
+          out <- sparsediscrim::sdlda(x, y, ...)
+        } else {
+          out <- sparsediscrim::smdlda(x, y, ...)
+        }
+      }
+    } else {
+      if (param$shrinkage == "None") {
+        out <- sparsediscrim::dqda(x, y, ...)
+      } else {
+        if (param$shrinkage == "Variance") {
+          out <- sparsediscrim::sdqda(x, y, ...)
+        } else {
+          out <- sparsediscrim::smdqda(x, y, ...)
+        }
+      }
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)$class
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata)$scores
+    as.data.frame(
+      t(apply(out, 2, function(x) exp(-x) / sum(exp(-x)))),
+      stringsAsFactors = TRUE
+    )
+  },
+  predictors = function(x, ...) {
+    if (hasTerms(x)) predictors(x$terms) else colnames(x$means)
+  },
+  tags = c(
+    "Discriminant Analysis",
+    "Linear Classifier",
+    "Polynomial Model",
+    "Regularization"
+  ),
+  levels = function(x) names(x$prior),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/deepboost.R
+++ b/inst/model_sources/files/deepboost.R
@@ -1,68 +1,87 @@
-modelInfo <- list(label = "DeepBoost",
-                  library = "deepboost",
-                  loop = NULL,
-                  type = 'Classification',
-                  parameters = data.frame(
-                    parameter = c('num_iter', "tree_depth", 'beta', 'lambda', "loss_type"),
-                    class = c(rep('numeric', 4), "character"),
-                    label = c('# Boosting Iterations', 'Tree Depth', 'L1 Regularization',
-                              'Tree Depth Regularization', "Loss")
-                    ),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(
-                        tree_depth = seq(1, len),
-                        num_iter = floor((1:len) * 50),
-                        beta = 2^seq(-8, -4, length = len),
-                        lambda = 2^seq(-6, -2, length = len),
-                        loss_type = "l"
-                        )
-                    } else {
-                      out <- data.frame(
-                        num_iter = floor(runif(len, min = 1, max = 500)),
-                        tree_depth = sample(1:20, replace = TRUE, size = len),         
-                        beta = runif(len, max = .25),
-                        lambda = runif(len, max = .25),
-                        loss_type = sample(c("l"), replace = TRUE, size = len) 
-                        )
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    if(!is.data.frame(x)) x <- as.data.frame(x, stringsAsFactors = TRUE)
-                    if(is.null(wts)) {
-                      dat <- x
-                      dat$.outcome <- y
-                      out <- deepboost::deepboost(
-                        .outcome ~ ., data = dat,
-                        tree_depth = param$tree_depth,
-                        num_iter = param$num_iter,
-                        beta = param$beta,
-                        lambda = param$lambda,
-                        loss_type = as.character(param$loss_type), 
-                        ...
-                        )
-                    } else {
-                      out <- deepboost::deepboost(
-                        .outcome ~ ., data = dat,
-                        tree_depth = param$tree_depth,
-                        instance_weights = wts,
-                        num_iter = param$num_iter,
-                        beta = param$beta,
-                        lambda = param$lambda,
-                        loss_type = as.character(param$loss_type), 
-                        ...
-                      )             
-                    }
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) 
-                      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    deepboost:::predict(modelFit, newdata)
-                  },
-                  levels = function(x) x@classes,
-                  prob =  NULL,
-                  tags = c("Tree-Based Model", "Boosting", "Ensemble Model", "Implicit Feature Selection", 
-                           "Accepts Case Weights", "L1 Regularization", "Two Class Only"),
-                  sort = function(x) x[order(x$num_iter, x$tree_depth, x$beta),] )
+modelInfo <- list(
+  label = "DeepBoost",
+  library = "deepboost",
+  loop = NULL,
+  type = 'Classification',
+  parameters = data.frame(
+    parameter = c('num_iter', "tree_depth", 'beta', 'lambda', "loss_type"),
+    class = c(rep('numeric', 4), "character"),
+    label = c(
+      '# Boosting Iterations',
+      'Tree Depth',
+      'L1 Regularization',
+      'Tree Depth Regularization',
+      "Loss"
+    )
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        tree_depth = seq(1, len),
+        num_iter = floor((1:len) * 50),
+        beta = 2^seq(-8, -4, length = len),
+        lambda = 2^seq(-6, -2, length = len),
+        loss_type = "l"
+      )
+    } else {
+      out <- data.frame(
+        num_iter = floor(runif(len, min = 1, max = 500)),
+        tree_depth = sample(1:20, replace = TRUE, size = len),
+        beta = runif(len, max = .25),
+        lambda = runif(len, max = .25),
+        loss_type = sample(c("l"), replace = TRUE, size = len)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (!is.data.frame(x)) {
+      x <- as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    if (is.null(wts)) {
+      dat <- x
+      dat$.outcome <- y
+      out <- deepboost::deepboost(
+        .outcome ~ .,
+        data = dat,
+        tree_depth = param$tree_depth,
+        num_iter = param$num_iter,
+        beta = param$beta,
+        lambda = param$lambda,
+        loss_type = as.character(param$loss_type),
+        ...
+      )
+    } else {
+      out <- deepboost::deepboost(
+        .outcome ~ .,
+        data = dat,
+        tree_depth = param$tree_depth,
+        instance_weights = wts,
+        num_iter = param$num_iter,
+        beta = param$beta,
+        lambda = param$lambda,
+        loss_type = as.character(param$loss_type),
+        ...
+      )
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    deepboost:::predict(modelFit, newdata)
+  },
+  levels = function(x) x@classes,
+  prob = NULL,
+  tags = c(
+    "Tree-Based Model",
+    "Boosting",
+    "Ensemble Model",
+    "Implicit Feature Selection",
+    "Accepts Case Weights",
+    "L1 Regularization",
+    "Two Class Only"
+  ),
+  sort = function(x) x[order(x$num_iter, x$tree_depth, x$beta), ]
+)

--- a/inst/model_sources/files/dnn.R
+++ b/inst/model_sources/files/dnn.R
@@ -1,52 +1,82 @@
-modelInfo <- list(label = "Stacked AutoEncoder Deep Neural Network",
-                  library = "deepnet",
-                  loop = NULL,
-                  type = c("Classification", "Regression"),
-                  parameters = data.frame(parameter = c("layer1", "layer2", "layer3", "hidden_dropout", "visible_dropout"),
-                                          class = rep("numeric", 5),
-                                          label = c("Hidden Layer 1", "Hidden Layer 2", "Hidden Layer 3", 
-                                                    "Hidden Dropouts", "Visible Dropout")),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(layer1 = 1:len, layer2 = 0:(len -1), layer3 = 0:(len -1),
-                                         hidden_dropout = seq(0, .7, length = len), 
-                                         visible_dropout = seq(0, .7, length = len))
-                    } else {
-                      out <- data.frame(layer1 = sample(2:20, replace = TRUE, size = len),
-                                        layer2 = sample(2:20, replace = TRUE, size = len),
-                                        layer3 = sample(2:20, replace = TRUE, size = len),
-                                        hidden_dropout = runif(len, min = 0, max = .7),
-                                        visible_dropout = runif(len, min = 0, max = .7))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    if(!is.matrix(x)) x <- as.matrix(x)
-                    is_class <- is.factor(y)
-                    if (is_class) y <- caret:::class2ind(y)
-                    layers <- c(param$layer1, param$layer2, param$layer3)
-                    layers <- layers[layers > 0]
-                    deepnet::sae.dnn.train(x, y, hidden = layers,
-                                           output = if(is_class) "sigm" else "linear",
-                                           hidden_dropout = param$hidden_dropout,
-                                           visible_dropout = param$visible_dropout,
-                                           ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    pred <- deepnet::nn.predict(modelFit, as.matrix(newdata))
-                    if(ncol(pred) > 1)
-                      pred <- modelFit$obsLevels[apply(pred, 1, which.max)]
-                    pred
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- exp(deepnet::nn.predict(modelFit, as.matrix(newdata)))
-                    out <- apply(out, 1, function(x) x/sum(x))
-                    t(out)
-                  },
-                  predictors = function(x, ...) {
-                    NULL
-                  },
-                  varImp = NULL,
-                  levels = function(x) x$classes,
-                  tags = c("Neural Network"),
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Stacked AutoEncoder Deep Neural Network",
+  library = "deepnet",
+  loop = NULL,
+  type = c("Classification", "Regression"),
+  parameters = data.frame(
+    parameter = c(
+      "layer1",
+      "layer2",
+      "layer3",
+      "hidden_dropout",
+      "visible_dropout"
+    ),
+    class = rep("numeric", 5),
+    label = c(
+      "Hidden Layer 1",
+      "Hidden Layer 2",
+      "Hidden Layer 3",
+      "Hidden Dropouts",
+      "Visible Dropout"
+    )
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        layer1 = 1:len,
+        layer2 = 0:(len - 1),
+        layer3 = 0:(len - 1),
+        hidden_dropout = seq(0, .7, length = len),
+        visible_dropout = seq(0, .7, length = len)
+      )
+    } else {
+      out <- data.frame(
+        layer1 = sample(2:20, replace = TRUE, size = len),
+        layer2 = sample(2:20, replace = TRUE, size = len),
+        layer3 = sample(2:20, replace = TRUE, size = len),
+        hidden_dropout = runif(len, min = 0, max = .7),
+        visible_dropout = runif(len, min = 0, max = .7)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (!is.matrix(x)) {
+      x <- as.matrix(x)
+    }
+    is_class <- is.factor(y)
+    if (is_class) {
+      y <- caret:::class2ind(y)
+    }
+    layers <- c(param$layer1, param$layer2, param$layer3)
+    layers <- layers[layers > 0]
+    deepnet::sae.dnn.train(
+      x,
+      y,
+      hidden = layers,
+      output = if (is_class) "sigm" else "linear",
+      hidden_dropout = param$hidden_dropout,
+      visible_dropout = param$visible_dropout,
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    pred <- deepnet::nn.predict(modelFit, as.matrix(newdata))
+    if (ncol(pred) > 1) {
+      pred <- modelFit$obsLevels[apply(pred, 1, which.max)]
+    }
+    pred
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- exp(deepnet::nn.predict(modelFit, as.matrix(newdata)))
+    out <- apply(out, 1, function(x) x / sum(x))
+    t(out)
+  },
+  predictors = function(x, ...) {
+    NULL
+  },
+  varImp = NULL,
+  levels = function(x) x$classes,
+  tags = c("Neural Network"),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/dwdLinear.R
+++ b/inst/model_sources/files/dwdLinear.R
@@ -1,55 +1,80 @@
-modelInfo <- list(label = "Linear Distance Weighted Discrimination",
-                  library = "kerndwd",
-                  type = "Classification",
-                  parameters = data.frame(parameter = c('lambda', "qval"),
-                                          class = rep("numeric", 2),
-                                          label = c('Regularization Parameter', 'q')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(length(levels(y)) != 2) stop("Two class problems only")
-                    if(search == "grid") {
-                      out <-  expand.grid(lambda = 10^seq(-5, 1, length = len),
-                                          qval = 1)
-                    } else {
-                      out <- data.frame(lambda = 10^runif(len, min = -5, 1),
-                                        qval = runif(len, min = 0, 3))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    if(!is.matrix(x)) x <- as.matrix(x)
-                    out <- kerndwd::kerndwd(x = x,
-                                            y = ifelse(y == lev[1], 1, -1),
-                                            qval = param$qval,
-                                            lambda = param$lambda,
-                                            kern = kernlab::vanilladot(),
-                                            ...)
-                    out$kern <- kernlab::vanilladot()
-                    out$x <- x
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    out <- predict(object = modelFit,
-                                   newx = newdata,
-                                   kern = modelFit$kern,
-                                   x = modelFit$x)[,1]
-                    ifelse(out == 1, modelFit$obsLevels[1], modelFit$obsLevels[2])        
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    out <- predict(object = modelFit,
-                                   newx = newdata,
-                                   kern = modelFit$kern,
-                                   x = modelFit$x, type = "link")[,1]
-                    out <- binomial()$linkinv(out)
-                    out <- cbind(out, 1 - out)
-                    colnames(out) <- modelFit$obsLevels
-                    out
-                  },
-                  levels = function(x) x$obsLevels,
-                  predictors = function(x, s = NULL, ...) x$xNames,
-                  tags = c("Discriminant Analysis", "L2 Regularization", 
-                           "Kernel Method", "Linear Classifier",
-                           "Distance Weighted Discrimination", "Two Class Only"),
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Linear Distance Weighted Discrimination",
+  library = "kerndwd",
+  type = "Classification",
+  parameters = data.frame(
+    parameter = c('lambda', "qval"),
+    class = rep("numeric", 2),
+    label = c('Regularization Parameter', 'q')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (length(levels(y)) != 2) {
+      stop("Two class problems only")
+    }
+    if (search == "grid") {
+      out <- expand.grid(lambda = 10^seq(-5, 1, length = len), qval = 1)
+    } else {
+      out <- data.frame(
+        lambda = 10^runif(len, min = -5, 1),
+        qval = runif(len, min = 0, 3)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (!is.matrix(x)) {
+      x <- as.matrix(x)
+    }
+    out <- kerndwd::kerndwd(
+      x = x,
+      y = ifelse(y == lev[1], 1, -1),
+      qval = param$qval,
+      lambda = param$lambda,
+      kern = kernlab::vanilladot(),
+      ...
+    )
+    out$kern <- kernlab::vanilladot()
+    out$x <- x
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- predict(
+      object = modelFit,
+      newx = newdata,
+      kern = modelFit$kern,
+      x = modelFit$x
+    )[, 1]
+    ifelse(out == 1, modelFit$obsLevels[1], modelFit$obsLevels[2])
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- predict(
+      object = modelFit,
+      newx = newdata,
+      kern = modelFit$kern,
+      x = modelFit$x,
+      type = "link"
+    )[, 1]
+    out <- binomial()$linkinv(out)
+    out <- cbind(out, 1 - out)
+    colnames(out) <- modelFit$obsLevels
+    out
+  },
+  levels = function(x) x$obsLevels,
+  predictors = function(x, s = NULL, ...) x$xNames,
+  tags = c(
+    "Discriminant Analysis",
+    "L2 Regularization",
+    "Kernel Method",
+    "Linear Classifier",
+    "Distance Weighted Discrimination",
+    "Two Class Only"
+  ),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/dwdPoly.R
+++ b/inst/model_sources/files/dwdPoly.R
@@ -1,60 +1,92 @@
-modelInfo <- list(label = "Distance Weighted Discrimination with Polynomial Kernel",
-                  library = "kerndwd",
-                  type = "Classification",
-                  parameters = data.frame(parameter = c('lambda', "qval", 'degree', 'scale'),
-                                          class = rep("numeric", 4),
-                                          label = c('Regularization Parameter', 'q', 'Polynomial Degree','Scale')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(length(levels(y)) != 2) stop("Two class problems only")
-                    if(search == "grid") {
-                      out <-  expand.grid(lambda = 10^seq(-5, 1, length = len),
-                                          qval = 1,
-                                          degree = seq(1, min(len, 3)),      
-                                          scale = 10 ^((1:len) - 4))
-                    } else {
-                      out <- data.frame(lambda = 10^runif(len, min = -5, 1),
-                                        qval = runif(len, min = 0, 3),
-                                        degree = sample(1:3, size = len, replace = TRUE),
-                                        scale = 10^runif(len, min = -5, 0))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    if(!is.matrix(x)) x <- as.matrix(x)
-                    kobj <- kernlab::polydot(degree = param$degree, scale = param$scale, offset = 1)
-                    out <- kerndwd::kerndwd(x = x,
-                                            y = ifelse(y == lev[1], 1, -1),
-                                            qval = param$qval,
-                                            lambda = param$lambda,
-                                            kern = kobj,
-                                            ...)
-                    out$kern <- kobj
-                    out$x <- x
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    out <- predict(object = modelFit,
-                                   newx = newdata,
-                                   kern = modelFit$kern,
-                                   x = modelFit$x)[,1]
-                    ifelse(out == 1, modelFit$obsLevels[1], modelFit$obsLevels[2])        
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    out <- predict(object = modelFit,
-                                   newx = newdata,
-                                   kern = modelFit$kern,
-                                   x = modelFit$x, type = "link")[,1]
-                    out <- binomial()$linkinv(out)
-                    out <- cbind(out, 1 - out)
-                    colnames(out) <- modelFit$obsLevels
-                    out
-                  },
-                  levels = function(x) x$obsLevels,
-                  predictors = function(x, s = NULL, ...) x$xNames,
-                  tags = c("Discriminant Analysis", "L2 Regularization", 
-                           "Kernel Method", "Polynomial Model",
-                           "Distance Weighted Discrimination", "Two Class Only"),
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Distance Weighted Discrimination with Polynomial Kernel",
+  library = "kerndwd",
+  type = "Classification",
+  parameters = data.frame(
+    parameter = c('lambda', "qval", 'degree', 'scale'),
+    class = rep("numeric", 4),
+    label = c('Regularization Parameter', 'q', 'Polynomial Degree', 'Scale')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (length(levels(y)) != 2) {
+      stop("Two class problems only")
+    }
+    if (search == "grid") {
+      out <- expand.grid(
+        lambda = 10^seq(-5, 1, length = len),
+        qval = 1,
+        degree = seq(1, min(len, 3)),
+        scale = 10^((1:len) - 4)
+      )
+    } else {
+      out <- data.frame(
+        lambda = 10^runif(len, min = -5, 1),
+        qval = runif(len, min = 0, 3),
+        degree = sample(1:3, size = len, replace = TRUE),
+        scale = 10^runif(len, min = -5, 0)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (!is.matrix(x)) {
+      x <- as.matrix(x)
+    }
+    kobj <- kernlab::polydot(
+      degree = param$degree,
+      scale = param$scale,
+      offset = 1
+    )
+    out <- kerndwd::kerndwd(
+      x = x,
+      y = ifelse(y == lev[1], 1, -1),
+      qval = param$qval,
+      lambda = param$lambda,
+      kern = kobj,
+      ...
+    )
+    out$kern <- kobj
+    out$x <- x
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- predict(
+      object = modelFit,
+      newx = newdata,
+      kern = modelFit$kern,
+      x = modelFit$x
+    )[, 1]
+    ifelse(out == 1, modelFit$obsLevels[1], modelFit$obsLevels[2])
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- predict(
+      object = modelFit,
+      newx = newdata,
+      kern = modelFit$kern,
+      x = modelFit$x,
+      type = "link"
+    )[, 1]
+    out <- binomial()$linkinv(out)
+    out <- cbind(out, 1 - out)
+    colnames(out) <- modelFit$obsLevels
+    out
+  },
+  levels = function(x) x$obsLevels,
+  predictors = function(x, s = NULL, ...) x$xNames,
+  tags = c(
+    "Discriminant Analysis",
+    "L2 Regularization",
+    "Kernel Method",
+    "Polynomial Model",
+    "Distance Weighted Discrimination",
+    "Two Class Only"
+  ),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/dwdRadial.R
+++ b/inst/model_sources/files/dwdRadial.R
@@ -1,60 +1,88 @@
-modelInfo <- list(label = "Distance Weighted Discrimination with Radial Basis Function Kernel",
-                  library = c("kernlab", "kerndwd"),
-                  type = "Classification",
-                  parameters = data.frame(parameter = c('lambda', "qval", 'sigma'),
-                                          class = rep("numeric", 3),
-                                          label = c('Regularization Parameter', 'q', 'Sigma')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    sigmas <- kernlab::sigest(as.matrix(x), na.action = na.omit, scaled = TRUE)  
-                    if(length(levels(y)) != 2) stop("Two class problems only")
-                    if(search == "grid") {
-                      out <-  expand.grid(lambda = 10^seq(-5, 1, length = len),
-                                          qval = 1,
-                                          sigma = mean(as.vector(sigmas[-2])))
-                    } else {
-                      rng <- extendrange(log(sigmas), f = .75)
-                      out <- data.frame(lambda = 10^runif(len, min = -5, 1),
-                                        qval = runif(len, min = 0, 3),
-                                        sigma = exp(runif(len, min = rng[1], max = rng[2])))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    if(!is.matrix(x)) x <- as.matrix(x)
-                    kobj <- kernlab::rbfdot(sigma = param$sigma)
-                    out <- kerndwd::kerndwd(x = x,
-                                            y = ifelse(y == lev[1], 1, -1),
-                                            qval = param$qval,
-                                            lambda = param$lambda,
-                                            kern = kobj,
-                                            ...)
-                    out$kern <- kobj
-                    out$x <- x
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    out <- predict(object = modelFit,
-                                   newx = newdata,
-                                   kern = modelFit$kern,
-                                   x = modelFit$x)[,1]
-                    ifelse(out == 1, modelFit$obsLevels[1], modelFit$obsLevels[2])        
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    out <- predict(object = modelFit,
-                                   newx = newdata,
-                                   kern = modelFit$kern,
-                                   x = modelFit$x, type = "link")[,1]
-                    out <- binomial()$linkinv(out)
-                    out <- cbind(out, 1 - out)
-                    colnames(out) <- modelFit$obsLevels
-                    out
-                  },
-                  levels = function(x) x$obsLevels,
-                  predictors = function(x, s = NULL, ...) x$xNames,
-                  tags = c("Discriminant Analysis", "L2 Regularization", 
-                           "Kernel Method", "Radial Basis Function",
-                           "Distance Weighted Discrimination", "Two Class Only"),
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Distance Weighted Discrimination with Radial Basis Function Kernel",
+  library = c("kernlab", "kerndwd"),
+  type = "Classification",
+  parameters = data.frame(
+    parameter = c('lambda', "qval", 'sigma'),
+    class = rep("numeric", 3),
+    label = c('Regularization Parameter', 'q', 'Sigma')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    sigmas <- kernlab::sigest(as.matrix(x), na.action = na.omit, scaled = TRUE)
+    if (length(levels(y)) != 2) {
+      stop("Two class problems only")
+    }
+    if (search == "grid") {
+      out <- expand.grid(
+        lambda = 10^seq(-5, 1, length = len),
+        qval = 1,
+        sigma = mean(as.vector(sigmas[-2]))
+      )
+    } else {
+      rng <- extendrange(log(sigmas), f = .75)
+      out <- data.frame(
+        lambda = 10^runif(len, min = -5, 1),
+        qval = runif(len, min = 0, 3),
+        sigma = exp(runif(len, min = rng[1], max = rng[2]))
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (!is.matrix(x)) {
+      x <- as.matrix(x)
+    }
+    kobj <- kernlab::rbfdot(sigma = param$sigma)
+    out <- kerndwd::kerndwd(
+      x = x,
+      y = ifelse(y == lev[1], 1, -1),
+      qval = param$qval,
+      lambda = param$lambda,
+      kern = kobj,
+      ...
+    )
+    out$kern <- kobj
+    out$x <- x
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- predict(
+      object = modelFit,
+      newx = newdata,
+      kern = modelFit$kern,
+      x = modelFit$x
+    )[, 1]
+    ifelse(out == 1, modelFit$obsLevels[1], modelFit$obsLevels[2])
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- predict(
+      object = modelFit,
+      newx = newdata,
+      kern = modelFit$kern,
+      x = modelFit$x,
+      type = "link"
+    )[, 1]
+    out <- binomial()$linkinv(out)
+    out <- cbind(out, 1 - out)
+    colnames(out) <- modelFit$obsLevels
+    out
+  },
+  levels = function(x) x$obsLevels,
+  predictors = function(x, s = NULL, ...) x$xNames,
+  tags = c(
+    "Discriminant Analysis",
+    "L2 Regularization",
+    "Kernel Method",
+    "Radial Basis Function",
+    "Distance Weighted Discrimination",
+    "Two Class Only"
+  ),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/earth.R
+++ b/inst/model_sources/files/earth.R
@@ -1,170 +1,199 @@
-modelInfo <- list(label = "Multivariate Adaptive Regression Spline",
-                  library = "earth",
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('nprune', 'degree'),
-                                          class = c("numeric", "numeric"),
-                                          label = c('#Terms', 'Product Degree')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    dat <- if (is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
+modelInfo <- list(
+  label = "Multivariate Adaptive Regression Spline",
+  library = "earth",
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c('nprune', 'degree'),
+    class = c("numeric", "numeric"),
+    label = c('#Terms', 'Product Degree')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
 
-                    mod <- earth::earth( .outcome~., data = dat, pmethod = "none")
-                    maxTerms <- nrow(mod$dirs)
+    mod <- earth::earth(.outcome ~ ., data = dat, pmethod = "none")
+    maxTerms <- nrow(mod$dirs)
 
-                    maxTerms <- min(200, floor(maxTerms * .75) + 2)
-                    if (search == "grid") {
-                      out <- data.frame(nprune = unique(floor(seq(2, to = maxTerms, length = len))),
-                                        degree = 1)
-                    } else {
-                      out <- data.frame(nprune = sample(2:maxTerms, size = len, replace = TRUE),
-                                        degree = sample(1:2, size = len, replace = TRUE))
-                    }
-                  },
-                  loop = function(grid) {
-                    deg <- unique(grid$degree)
+    maxTerms <- min(200, floor(maxTerms * .75) + 2)
+    if (search == "grid") {
+      out <- data.frame(
+        nprune = unique(floor(seq(2, to = maxTerms, length = len))),
+        degree = 1
+      )
+    } else {
+      out <- data.frame(
+        nprune = sample(2:maxTerms, size = len, replace = TRUE),
+        degree = sample(1:2, size = len, replace = TRUE)
+      )
+    }
+  },
+  loop = function(grid) {
+    deg <- unique(grid$degree)
 
-                    loop <- data.frame(degree = deg)
-                    loop$nprune <- NA
+    loop <- data.frame(degree = deg)
+    loop$nprune <- NA
 
-                    submodels <- vector(mode = "list", length = length(deg))
-                    for (i in seq(along = deg)) {
-                      np <- grid[grid$degree == deg[i],"nprune"]
-                      loop$nprune[loop$degree == deg[i]] <- np[which.max(np)]
-                      submodels[[i]] <- data.frame(nprune = np[-which.max(np)])
-                    }
-                    list(loop = loop, submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    require(earth)
-                    theDots <- list(...)
-                    theDots$keepxy <- TRUE
+    submodels <- vector(mode = "list", length = length(deg))
+    for (i in seq(along = deg)) {
+      np <- grid[grid$degree == deg[i], "nprune"]
+      loop$nprune[loop$degree == deg[i]] <- np[which.max(np)]
+      submodels[[i]] <- data.frame(nprune = np[-which.max(np)])
+    }
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    require(earth)
+    theDots <- list(...)
+    theDots$keepxy <- TRUE
 
-                    ## pass in any model weights
-                    if (!is.null(wts)) theDots$weights <- wts
+    ## pass in any model weights
+    if (!is.null(wts)) {
+      theDots$weights <- wts
+    }
 
-                    modelArgs <- c(list(x = x, y = y,
-                                        degree = param$degree,
-                                        nprune = param$nprune),
-                                   theDots)
-                    if (is.factor(y) & !any(names(theDots) == "glm")) {
-                      modelArgs$glm <- list(family = binomial, maxit = 100)
-                    }
+    modelArgs <- c(
+      list(x = x, y = y, degree = param$degree, nprune = param$nprune),
+      theDots
+    )
+    if (is.factor(y) & !any(names(theDots) == "glm")) {
+      modelArgs$glm <- list(family = binomial, maxit = 100)
+    }
 
-                    tmp <- do.call(earth::earth, modelArgs)
+    tmp <- do.call(earth::earth, modelArgs)
 
-                    tmp$call["nprune"] <- param$nprune
-                    tmp$call["degree"] <- param$degree
-                    tmp
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if (modelFit$problemType == "Classification") {
-                      out <- earth:::predict.earth(modelFit, newdata,  type = "class")
-                    } else {
-                      out <- earth:::predict.earth(modelFit, newdata)
-                    }
+    tmp$call["nprune"] <- param$nprune
+    tmp$call["degree"] <- param$degree
+    tmp
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (modelFit$problemType == "Classification") {
+      out <- earth:::predict.earth(modelFit, newdata, type = "class")
+    } else {
+      out <- earth:::predict.earth(modelFit, newdata)
+    }
 
-                    if (!is.null(submodels)) {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- if (is.matrix(out)) out[,1] else out
-                      for(j in seq(along = submodels$nprune)) {
-                        prunedFit <- earth:::update.earth(modelFit, nprune = submodels$nprune[j])
-                        if (modelFit$problemType == "Classification") {
-                          tmp[[j+1]] <- earth:::predict.earth(prunedFit, newdata,  type = "class")
-                        } else {
-                          tmp[[j+1]] <- earth:::predict.earth(prunedFit, newdata)
-                        }
-                        if (is.matrix(tmp[[j+1]])) tmp[[j+1]] <- tmp[[j+1]][,1]
-                      }
-                      out <- tmp
-                    }
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- earth:::predict.earth(modelFit, newdata, type= "response")
-                    if (ncol(out) > 1) {
-                      out <- t(apply(out, 1, function(x) x / sum(x)))
-                    } else {
-                      out <- cbind(1 - out[, 1], out[, 1])
-                      colnames(out) <- modelFit$obsLevels
-                    }
-                    out <- as.data.frame(out, stringsAsFactors = TRUE)
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- if (is.matrix(out)) out[, 1] else out
+      for (j in seq(along = submodels$nprune)) {
+        prunedFit <- earth:::update.earth(
+          modelFit,
+          nprune = submodels$nprune[j]
+        )
+        if (modelFit$problemType == "Classification") {
+          tmp[[j + 1]] <- earth:::predict.earth(
+            prunedFit,
+            newdata,
+            type = "class"
+          )
+        } else {
+          tmp[[j + 1]] <- earth:::predict.earth(prunedFit, newdata)
+        }
+        if (is.matrix(tmp[[j + 1]])) tmp[[j + 1]] <- tmp[[j + 1]][, 1]
+      }
+      out <- tmp
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- earth:::predict.earth(modelFit, newdata, type = "response")
+    if (ncol(out) > 1) {
+      out <- t(apply(out, 1, function(x) x / sum(x)))
+    } else {
+      out <- cbind(1 - out[, 1], out[, 1])
+      colnames(out) <- modelFit$obsLevels
+    }
+    out <- as.data.frame(out, stringsAsFactors = TRUE)
 
-                    if (!is.null(submodels)) {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
 
-                      for(j in seq(along = submodels$nprune)) {
-                        prunedFit <- earth:::update.earth(modelFit, nprune = submodels$nprune[j])
-                        tmp2 <- earth:::predict.earth(prunedFit, newdata, type= "response")
-                        if (ncol(tmp2) > 1) {
-                          tmp2 <- t(apply(tmp2, 1, function(x) x / sum(x)))
-                        } else {
-                          tmp2 <- cbind(1 - tmp2[, 1], tmp2[, 1])
-                          colnames(tmp2) <- modelFit$obsLevels
-                        }
-                        tmp2 <- as.data.frame(tmp2, stringsAsFactors = TRUE)
-                        tmp[[j+1]] <- tmp2
-                      }
-                      out <- tmp
-                    }
-                    out
-                  },
-                  predictors = function(x, ...) {
-                    vi <- varImp(x)
-                    notZero <- sort(unique(unlist(lapply(vi, function(x) which(x > 0)))))
-                    if (length(notZero) > 0) rownames(vi)[notZero] else NULL
-                  },
-                  varImp = function(object, value = "gcv", ...) {
-                    earthImp <- earth::evimp(object)
-                    if (!is.matrix(earthImp)) earthImp <- t(as.matrix(earthImp))
+      for (j in seq(along = submodels$nprune)) {
+        prunedFit <- earth:::update.earth(
+          modelFit,
+          nprune = submodels$nprune[j]
+        )
+        tmp2 <- earth:::predict.earth(prunedFit, newdata, type = "response")
+        if (ncol(tmp2) > 1) {
+          tmp2 <- t(apply(tmp2, 1, function(x) x / sum(x)))
+        } else {
+          tmp2 <- cbind(1 - tmp2[, 1], tmp2[, 1])
+          colnames(tmp2) <- modelFit$obsLevels
+        }
+        tmp2 <- as.data.frame(tmp2, stringsAsFactors = TRUE)
+        tmp[[j + 1]] <- tmp2
+      }
+      out <- tmp
+    }
+    out
+  },
+  predictors = function(x, ...) {
+    vi <- varImp(x)
+    notZero <- sort(unique(unlist(lapply(vi, function(x) which(x > 0)))))
+    if (length(notZero) > 0) rownames(vi)[notZero] else NULL
+  },
+  varImp = function(object, value = "gcv", ...) {
+    earthImp <- earth::evimp(object)
+    if (!is.matrix(earthImp)) {
+      earthImp <- t(as.matrix(earthImp))
+    }
 
-                    # get other variable names and padd with zeros
+    # get other variable names and padd with zeros
 
-                    out <- earthImp
-                    perfCol <- which(colnames(out) == value)
+    out <- earthImp
+    perfCol <- which(colnames(out) == value)
 
-                    increaseInd <- out[,perfCol + 1]
-                    out <- as.data.frame(out[,perfCol, drop = FALSE], stringsAsFactors = TRUE)
-                    colnames(out) <- "Overall"
+    increaseInd <- out[, perfCol + 1]
+    out <- as.data.frame(out[, perfCol, drop = FALSE], stringsAsFactors = TRUE)
+    colnames(out) <- "Overall"
 
-                    # At this point, we still may have some variables
-                    # that are not in the model but have non-zero
-                    # importance. We'll set those to zero
-                    if (any(earthImp[,"used"] == 0)) {
-                      dropList <- grep("-unused", rownames(earthImp), value = TRUE)
-                      out$Overall[rownames(out) %in% dropList] <- 0
-                    }
-                    rownames(out) <- gsub("-unused", "", rownames(out))
-                    out <- as.data.frame(out, stringsAsFactors = TRUE)
-                    # fill in zeros for any variabels not  in out
+    # At this point, we still may have some variables
+    # that are not in the model but have non-zero
+    # importance. We'll set those to zero
+    if (any(earthImp[, "used"] == 0)) {
+      dropList <- grep("-unused", rownames(earthImp), value = TRUE)
+      out$Overall[rownames(out) %in% dropList] <- 0
+    }
+    rownames(out) <- gsub("-unused", "", rownames(out))
+    out <- as.data.frame(out, stringsAsFactors = TRUE)
+    # fill in zeros for any variabels not  in out
 
-                    xNames <- object$namesx.org
-                    if (any(!(xNames %in% rownames(out)))) {
-                      xNames <- xNames[!(xNames %in% rownames(out))]
-                      others <- data.frame(
-                        Overall = rep(0, length(xNames)),
-                        row.names = xNames)
-                      out <- rbind(out, others)
-                    }
-                    out
-                  },
-                  levels = function(x) x$levels,
-                  trim = function(x) {
-                    # earth is fit with keepxy = TRUE (needed for update.earth on
-                    # submodels during tuning); the final model keeps copies of the
-                    # data and a large call that prediction/varImp don't need.
-                    # (fitted.values/residuals are kept: predict.earth(type="class")
-                    # uses fitted.values to size its output.)
-                    x$x <- NULL
-                    x$y <- NULL
-                    x$call <- NULL
-                    x
-                  },
-                  tags = c("Multivariate Adaptive Regression Splines",
-                           "Implicit Feature Selection",
-                           "Accepts Case Weights"),
-                  notes = paste(
-                    "Unlike other packages used by `train`, the `earth`",
-                    "package is fully loaded when this model is used."
-                  ),
-                  sort = function(x) x[order(x$degree, x$nprune),])
+    xNames <- object$namesx.org
+    if (any(!(xNames %in% rownames(out)))) {
+      xNames <- xNames[!(xNames %in% rownames(out))]
+      others <- data.frame(
+        Overall = rep(0, length(xNames)),
+        row.names = xNames
+      )
+      out <- rbind(out, others)
+    }
+    out
+  },
+  levels = function(x) x$levels,
+  trim = function(x) {
+    # earth is fit with keepxy = TRUE (needed for update.earth on
+    # submodels during tuning); the final model keeps copies of the
+    # data and a large call that prediction/varImp don't need.
+    # (fitted.values/residuals are kept: predict.earth(type="class")
+    # uses fitted.values to size its output.)
+    x$x <- NULL
+    x$y <- NULL
+    x$call <- NULL
+    x
+  },
+  tags = c(
+    "Multivariate Adaptive Regression Splines",
+    "Implicit Feature Selection",
+    "Accepts Case Weights"
+  ),
+  notes = paste(
+    "Unlike other packages used by `train`, the `earth`",
+    "package is fully loaded when this model is used."
+  ),
+  sort = function(x) x[order(x$degree, x$nprune), ]
+)

--- a/inst/model_sources/files/earth.R
+++ b/inst/model_sources/files/earth.R
@@ -8,10 +8,10 @@ modelInfo <- list(
     label = c('#Terms', 'Product Degree')
   ),
   grid = function(x, y, len = NULL, search = "grid") {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
 
@@ -78,7 +78,11 @@ modelInfo <- list(
 
     if (!is.null(submodels)) {
       tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-      tmp[[1]] <- if (is.matrix(out)) out[, 1] else out
+      if (is.matrix(out)) {
+        tmp[[1]] <- out[, 1]
+      } else {
+        tmp[[1]] <- out
+      }
       for (j in seq(along = submodels$nprune)) {
         prunedFit <- earth:::update.earth(
           modelFit,
@@ -93,7 +97,9 @@ modelInfo <- list(
         } else {
           tmp[[j + 1]] <- earth:::predict.earth(prunedFit, newdata)
         }
-        if (is.matrix(tmp[[j + 1]])) tmp[[j + 1]] <- tmp[[j + 1]][, 1]
+        if (is.matrix(tmp[[j + 1]])) {
+          tmp[[j + 1]] <- tmp[[j + 1]][, 1]
+        }
       }
       out <- tmp
     }
@@ -135,7 +141,11 @@ modelInfo <- list(
   predictors = function(x, ...) {
     vi <- varImp(x)
     notZero <- sort(unique(unlist(lapply(vi, function(x) which(x > 0)))))
-    if (length(notZero) > 0) rownames(vi)[notZero] else NULL
+    if (length(notZero) > 0) {
+      rownames(vi)[notZero]
+    } else {
+      NULL
+    }
   },
   varImp = function(object, value = "gcv", ...) {
     earthImp <- earth::evimp(object)

--- a/inst/model_sources/files/elm.R
+++ b/inst/model_sources/files/elm.R
@@ -1,68 +1,72 @@
-modelInfo <- list(label = "Extreme Learning Machine",
-                  library = "elmNN",
-                  loop = NULL,
-                  type = c("Classification", "Regression"),
-                  parameters = data.frame(parameter = c('nhid', 'actfun'),
-                                          class = c("numeric", "character"),
-                                          label = c('#Hidden Units', 'Activation Function')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    funs <- c("sin", "radbas", "purelin", "tansig")
-                    if(search == "grid") {
-                      out <- expand.grid(nhid = ((1:len) * 2) - 1, actfun = funs)
-                    } else {
-                      out <- data.frame(nhid = floor(runif(len, min = 1, max = 20)),
-                                        actfun = sample(funs, replace = TRUE, size = len))
-                    }
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    if(is.factor(y)) {
-                      factor2ind <- function(x) {
-                        x <- model.matrix(~x - 1, contrasts = list(x = "contr.treatment"))
-                        colnames(x) <- gsub("^x", "", colnames(x))
-                        att <- attributes(x)
-                        att$assign <- NULL
-                        att$contrasts <- NULL
-                        attributes(x) <- att
-                        x
-                      }
-                      out <- elmNN::elmtrain.default(
-                        x = x,
-                        y = factor2ind(y),
-                        nhid = param$nhid,
-                        actfun = param$actfun,
-                        ...
-                        )
-                      out$lev <- levels(y)
-
-                    } else {
-                      out <- elmNN::elmtrain.default(
-                        x = x,
-                        y = y,
-                        nhid = param$nhid,
-                        actfun = param$actfun,
-                        ...
-                        )
-                    }
-                    out$xNames <- colnames(x)
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL)
-                  {
-                    out <- elmNN::predict.elmNN(modelFit, newdata)
-                    if(modelFit$problemType == "Classification") {
-                      out <- modelFit$lev[apply(out, 1, which.max)]
-                      out <- factor(out, levels = modelFit$lev)
-                    }
-                    out
-                  },
-                  prob = NULL,
-                  varImp = NULL,
-                  predictors = function(x, ...) x$xNames,
-                  tags = c("Neural Network"),
-                  levels = function(x) x$lev,
-                  notes = paste(
-                    "The package is no longer on CRAN but can be installed",
-                    "from the archive at ",
-                    "https://cran.r-project.org/src/contrib/Archive/elmNN/"
-                  ),
-                  sort = function(x) x[order(x$nhid),])
+modelInfo <- list(
+  label = "Extreme Learning Machine",
+  library = "elmNN",
+  loop = NULL,
+  type = c("Classification", "Regression"),
+  parameters = data.frame(
+    parameter = c('nhid', 'actfun'),
+    class = c("numeric", "character"),
+    label = c('#Hidden Units', 'Activation Function')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    funs <- c("sin", "radbas", "purelin", "tansig")
+    if (search == "grid") {
+      out <- expand.grid(nhid = ((1:len) * 2) - 1, actfun = funs)
+    } else {
+      out <- data.frame(
+        nhid = floor(runif(len, min = 1, max = 20)),
+        actfun = sample(funs, replace = TRUE, size = len)
+      )
+    }
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (is.factor(y)) {
+      factor2ind <- function(x) {
+        x <- model.matrix(~ x - 1, contrasts = list(x = "contr.treatment"))
+        colnames(x) <- gsub("^x", "", colnames(x))
+        att <- attributes(x)
+        att$assign <- NULL
+        att$contrasts <- NULL
+        attributes(x) <- att
+        x
+      }
+      out <- elmNN::elmtrain.default(
+        x = x,
+        y = factor2ind(y),
+        nhid = param$nhid,
+        actfun = param$actfun,
+        ...
+      )
+      out$lev <- levels(y)
+    } else {
+      out <- elmNN::elmtrain.default(
+        x = x,
+        y = y,
+        nhid = param$nhid,
+        actfun = param$actfun,
+        ...
+      )
+    }
+    out$xNames <- colnames(x)
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- elmNN::predict.elmNN(modelFit, newdata)
+    if (modelFit$problemType == "Classification") {
+      out <- modelFit$lev[apply(out, 1, which.max)]
+      out <- factor(out, levels = modelFit$lev)
+    }
+    out
+  },
+  prob = NULL,
+  varImp = NULL,
+  predictors = function(x, ...) x$xNames,
+  tags = c("Neural Network"),
+  levels = function(x) x$lev,
+  notes = paste(
+    "The package is no longer on CRAN but can be installed",
+    "from the archive at ",
+    "https://cran.r-project.org/src/contrib/Archive/elmNN/"
+  ),
+  sort = function(x) x[order(x$nhid), ]
+)

--- a/inst/model_sources/files/enet.R
+++ b/inst/model_sources/files/enet.R
@@ -1,87 +1,109 @@
-modelInfo <- list(label = "Elasticnet",
-                  library = "elasticnet",
-                  type = "Regression",
-                  parameters = data.frame(parameter = c('fraction', 'lambda'),
-                                          class = c("numeric", "numeric"),
-                                          label = c('Fraction of Full Solution', 'Weight Decay')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(lambda = c(0, 10 ^ seq(-1, -4, length = len - 1)),
-                                         fraction = seq(0.05, 1, length = len))
-                    } else {
-                      out <- data.frame(lambda = 10^runif(len, min = -5, 1),
-                                        fraction = runif(len, min = 0, max = 1))
-                    }
-                    out
-                  },
-                  loop = function(grid) {
-                    grid <- grid[order(grid$lambda, grid$fraction, decreasing = TRUE),, drop = FALSE]
-                    uniqueLambda <- unique(grid$lambda)
-                    loop <- data.frame(lambda = uniqueLambda)
-                    loop$fraction <- NA
+modelInfo <- list(
+  label = "Elasticnet",
+  library = "elasticnet",
+  type = "Regression",
+  parameters = data.frame(
+    parameter = c('fraction', 'lambda'),
+    class = c("numeric", "numeric"),
+    label = c('Fraction of Full Solution', 'Weight Decay')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        lambda = c(0, 10^seq(-1, -4, length = len - 1)),
+        fraction = seq(0.05, 1, length = len)
+      )
+    } else {
+      out <- data.frame(
+        lambda = 10^runif(len, min = -5, 1),
+        fraction = runif(len, min = 0, max = 1)
+      )
+    }
+    out
+  },
+  loop = function(grid) {
+    grid <- grid[
+      order(grid$lambda, grid$fraction, decreasing = TRUE),
+      ,
+      drop = FALSE
+    ]
+    uniqueLambda <- unique(grid$lambda)
+    loop <- data.frame(lambda = uniqueLambda)
+    loop$fraction <- NA
 
-                    submodels <- vector(mode = "list", length = length(uniqueLambda))
+    submodels <- vector(mode = "list", length = length(uniqueLambda))
 
-                    for(i in seq(along = uniqueLambda))
-                    {
-                      subFrac <- grid[grid$lambda == uniqueLambda[i],"fraction"]
-                      loop$fraction[loop$lambda == uniqueLambda[i]] <- subFrac[which.max(subFrac)]
-                      submodels[[i]] <- data.frame(fraction = subFrac[-which.max(subFrac)])
-                    }
-                    list(loop = loop, submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    elasticnet::enet(as.matrix(x), y, lambda = param$lambda)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- elasticnet::predict.enet(modelFit, newdata,
-                                   s = modelFit$tuneValue$fraction,
-                                   mode = "fraction")$fit
+    for (i in seq(along = uniqueLambda)) {
+      subFrac <- grid[grid$lambda == uniqueLambda[i], "fraction"]
+      loop$fraction[loop$lambda == uniqueLambda[i]] <- subFrac[which.max(
+        subFrac
+      )]
+      submodels[[i]] <- data.frame(fraction = subFrac[-which.max(subFrac)])
+    }
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    elasticnet::enet(as.matrix(x), y, lambda = param$lambda)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- elasticnet::predict.enet(
+      modelFit,
+      newdata,
+      s = modelFit$tuneValue$fraction,
+      mode = "fraction"
+    )$fit
 
-                    if(!is.null(submodels))
-                    {
-                      if(nrow(submodels) > 1)
-                      {
-                        out <- c(
-                          list(if(is.matrix(out)) out[,1]  else out),
-                          as.list(
-                            as.data.frame(
-                              elasticnet::predict.enet(modelFit,
-                                                       newx = newdata,
-                                                       s = submodels$fraction,
-                                                       mode = "fraction")$fit,
-                              stringsAsFactor = FALSE
-                            )
-                          )
-                        )
-
-                      } else {
-                        tmp <- elasticnet::predict.enet(modelFit,
-                                       newx = newdata,
-                                       s = submodels$fraction,
-                                       mode = "fraction")$fit
-                        out <- c(list(if(is.matrix(out)) out[,1]  else out),  list(tmp))
-                      }
-                    }
-                    out
-                  },
-                  predictors = function(x, s = NULL, ...) {
-                    if(is.null(s))
-                    {
-                      if(!is.null(x$tuneValue))
-                      {
-                        s <- x$tuneValue$fraction
-                      } else stop("must supply a vaue of s")
-                      out <- elasticnet::predict.enet(x, s = s,
-                                     type = "coefficients",
-                                     mode = "fraction")$coefficients
-
-                    } else {
-                      out <- elasticnet::predict.enet(x, s = s)$coefficients
-
-                    }
-                    names(out)[out != 0]
-                  },
-                  tags = c("Linear Regression", "Implicit Feature Selection", "L1 Regularization"),
-                  prob = NULL,
-                  sort = function(x) x[order(x$fraction, -x$lambda),])
+    if (!is.null(submodels)) {
+      if (nrow(submodels) > 1) {
+        out <- c(
+          list(if (is.matrix(out)) out[, 1] else out),
+          as.list(
+            as.data.frame(
+              elasticnet::predict.enet(
+                modelFit,
+                newx = newdata,
+                s = submodels$fraction,
+                mode = "fraction"
+              )$fit,
+              stringsAsFactor = FALSE
+            )
+          )
+        )
+      } else {
+        tmp <- elasticnet::predict.enet(
+          modelFit,
+          newx = newdata,
+          s = submodels$fraction,
+          mode = "fraction"
+        )$fit
+        out <- c(list(if (is.matrix(out)) out[, 1] else out), list(tmp))
+      }
+    }
+    out
+  },
+  predictors = function(x, s = NULL, ...) {
+    if (is.null(s)) {
+      if (!is.null(x$tuneValue)) {
+        s <- x$tuneValue$fraction
+      } else {
+        stop("must supply a vaue of s")
+      }
+      out <- elasticnet::predict.enet(
+        x,
+        s = s,
+        type = "coefficients",
+        mode = "fraction"
+      )$coefficients
+    } else {
+      out <- elasticnet::predict.enet(x, s = s)$coefficients
+    }
+    names(out)[out != 0]
+  },
+  tags = c(
+    "Linear Regression",
+    "Implicit Feature Selection",
+    "L1 Regularization"
+  ),
+  prob = NULL,
+  sort = function(x) x[order(x$fraction, -x$lambda), ]
+)

--- a/inst/model_sources/files/evtree.R
+++ b/inst/model_sources/files/evtree.R
@@ -17,10 +17,10 @@ modelInfo <- list(
     out
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     theDots <- list(...)

--- a/inst/model_sources/files/evtree.R
+++ b/inst/model_sources/files/evtree.R
@@ -1,49 +1,68 @@
-modelInfo <- list(label = "Tree Models from Genetic Algorithms",
-                  library = c("evtree"),
-                  loop = NULL,
-                  type = c('Regression', 'Classification'),
-                  parameters = data.frame(parameter = c('alpha'),
-                                          class = c('numeric'),
-                                          label = c('Complexity Parameter')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- data.frame(alpha = seq(1, 3, length = len)) 
-                    } else {
-                      out <- data.frame(alpha = runif(len, min = 1, max = 5))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...){
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    theDots <- list(...)
-                    
-                    if(any(names(theDots) == "control"))
-                    {
-                      theDots$control$alpha <- param$alpha 
-                      ctl <- theDots$control
-                      theDots$control <- NULL
-                    } else ctl <- evtree::evtree.control(alpha = param$alpha)
+modelInfo <- list(
+  label = "Tree Models from Genetic Algorithms",
+  library = c("evtree"),
+  loop = NULL,
+  type = c('Regression', 'Classification'),
+  parameters = data.frame(
+    parameter = c('alpha'),
+    class = c('numeric'),
+    label = c('Complexity Parameter')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(alpha = seq(1, 3, length = len))
+    } else {
+      out <- data.frame(alpha = runif(len, min = 1, max = 5))
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    theDots <- list(...)
 
-                    ## pass in any model weights
-                    if(!is.null(wts)) theDots$weights <- wts
-                    
-                    modelArgs <- c(list(formula = as.formula(".outcome ~ ."),
-                                        data = dat,
-                                        control = ctl),
-                                   theDots)
+    if (any(names(theDots) == "control")) {
+      theDots$control$alpha <- param$alpha
+      ctl <- theDots$control
+      theDots$control <- NULL
+    } else {
+      ctl <- evtree::evtree.control(alpha = param$alpha)
+    }
 
-                    out <- do.call(evtree::evtree, modelArgs)
-                    out
-                  },
-                  levels = function(x) x$obsLevels,
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata)
-                    },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata, type = "prob")
-                    },
-                  tags = c("Tree-Based Model", "Implicit Feature Selection", "Accepts Case Weights"),
-                  sort = function(x) x[order(x[,1]),])
+    ## pass in any model weights
+    if (!is.null(wts)) {
+      theDots$weights <- wts
+    }
+
+    modelArgs <- c(
+      list(formula = as.formula(".outcome ~ ."), data = dat, control = ctl),
+      theDots
+    )
+
+    out <- do.call(evtree::evtree, modelArgs)
+    out
+  },
+  levels = function(x) x$obsLevels,
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata, type = "prob")
+  },
+  tags = c(
+    "Tree-Based Model",
+    "Implicit Feature Selection",
+    "Accepts Case Weights"
+  ),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/extraTrees.R
+++ b/inst/model_sources/files/extraTrees.R
@@ -1,27 +1,51 @@
-    modelInfo <- list(label = "Random Forest by Randomization",
-                      library = c("extraTrees"),
-                      loop = NULL,
-                      type = c('Regression', 'Classification'),
-                      parameters = data.frame(parameter = c('mtry', 'numRandomCuts'),
-                                              class = c('numeric', 'numeric'),
-                                              label = c('# Randomly Selected Predictors', '# Random Cuts')),
-                      grid = function(x, y, len = NULL, search = "grid"){
-                        if(search == "grid") {
-                          out <- expand.grid(mtry = caret::var_seq(p = ncol(x),
-                                                                   classification = is.factor(y),
-                                                                   len = len),
-                                             numRandomCuts = 1:len)
-                        } else {
-                          out <- data.frame(mtry = sample(1:ncol(x), size = len, replace = TRUE),
-                                            numRandomCuts = sample(1:25, size = len, replace = TRUE))
-                        }
-                      },
-                      fit = function(x, y, wts, param, lev, last, classProbs, ...)
-                        extraTrees::extraTrees(x, y, mtry = min(param$mtry, ncol(x)), numRandomCuts = param$numRandomCuts, ...),
-                      predict = function(modelFit, newdata, submodels = NULL)
-                        predict(modelFit, newdata),
-                      prob = function(modelFit, newdata, submodels = NULL)
-                        predict(modelFit, newdata, probability = TRUE),
-                      levels = function(x) x$obsLevels,
-                      tags = c("Random Forest", "Ensemble Model", "Bagging", "Implicit Feature Selection"),
-                      sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Random Forest by Randomization",
+  library = c("extraTrees"),
+  loop = NULL,
+  type = c('Regression', 'Classification'),
+  parameters = data.frame(
+    parameter = c('mtry', 'numRandomCuts'),
+    class = c('numeric', 'numeric'),
+    label = c('# Randomly Selected Predictors', '# Random Cuts')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        mtry = caret::var_seq(
+          p = ncol(x),
+          classification = is.factor(y),
+          len = len
+        ),
+        numRandomCuts = 1:len
+      )
+    } else {
+      out <- data.frame(
+        mtry = sample(1:ncol(x), size = len, replace = TRUE),
+        numRandomCuts = sample(1:25, size = len, replace = TRUE)
+      )
+    }
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    extraTrees::extraTrees(
+      x,
+      y,
+      mtry = min(param$mtry, ncol(x)),
+      numRandomCuts = param$numRandomCuts,
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata, probability = TRUE)
+  },
+  levels = function(x) x$obsLevels,
+  tags = c(
+    "Random Forest",
+    "Ensemble Model",
+    "Bagging",
+    "Implicit Feature Selection"
+  ),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/fda.R
+++ b/inst/model_sources/files/fda.R
@@ -9,10 +9,10 @@ modelInfo <- list(
     label = c('Product Degree', '#Terms')
   ),
   grid = function(x, y, len = NULL, search = "grid") {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
 
@@ -34,10 +34,10 @@ modelInfo <- list(
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
     require(earth)
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
 
@@ -70,7 +70,11 @@ modelInfo <- list(
   predictors = function(x, ...) {
     code <- getModelInfo("earth", regex = FALSE)[[1]]$predictors
     tmp <- predictors(x$terms)
-    out <- if (class(x$fit) == "earth") code(x$fit) else tmp
+    if (class(x$fit) == "earth") {
+      out <- code(x$fit)
+    } else {
+      out <- tmp
+    }
     out
   },
   varImp = function(object, value = "gcv", ...) {

--- a/inst/model_sources/files/fda.R
+++ b/inst/model_sources/files/fda.R
@@ -1,54 +1,80 @@
-modelInfo <- list(label = "Flexible Discriminant Analysis",
-                  library = c("earth", "mda"),
-                  loop = NULL,
-                  type = "Classification",
-                  parameters = data.frame(parameter = c("degree", "nprune"),
-                                          class = c("numeric", "numeric"),
-                                          label = c('Product Degree', '#Terms')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
+modelInfo <- list(
+  label = "Flexible Discriminant Analysis",
+  library = c("earth", "mda"),
+  loop = NULL,
+  type = "Classification",
+  parameters = data.frame(
+    parameter = c("degree", "nprune"),
+    class = c("numeric", "numeric"),
+    label = c('Product Degree', '#Terms')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
 
-                    mod <- earth::earth( .outcome~., data = dat, pmethod = "none")
-                    maxTerms <- nrow(mod$dirs)
+    mod <- earth::earth(.outcome ~ ., data = dat, pmethod = "none")
+    maxTerms <- nrow(mod$dirs)
 
-                    maxTerms <- min(200, floor(maxTerms * .75) + 2)
-                    if(search == "grid") {
-                      out <- data.frame(nprune = unique(floor(seq(2, to = maxTerms, length = len))),
-                                        degree = 1)
-                    } else {
-                      out <- data.frame(nprune = sample(2:maxTerms, size = len, replace = TRUE),
-                                        degree = sample(1:2, size = len, replace = TRUE))
-                    }
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                  	require(earth)
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
+    maxTerms <- min(200, floor(maxTerms * .75) + 2)
+    if (search == "grid") {
+      out <- data.frame(
+        nprune = unique(floor(seq(2, to = maxTerms, length = len))),
+        degree = 1
+      )
+    } else {
+      out <- data.frame(
+        nprune = sample(2:maxTerms, size = len, replace = TRUE),
+        degree = sample(1:2, size = len, replace = TRUE)
+      )
+    }
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    require(earth)
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
 
-                    mda::fda(.outcome ~ ., data = dat, method = earth::earth,
-                        degree = param$degree,
-                        nprune = param$nprune,
-                        weights = wts,
-                        ...)
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("Multivariate Adaptive Regression Splines", "Implicit Feature Selection",
-                           "Accepts Case Weights"),
-                  notes = paste(
-                    "Unlike other packages used by `train`, the `earth`",
-                    "package is fully loaded when this model is used."
-                  ),
-                  predict = function(modelFit, newdata, submodels = NULL)
-                    predict(modelFit , newdata),
-                  prob = function(modelFit, newdata, submodels = NULL)
-                    predict(modelFit, newdata, type= "posterior"),
-                  predictors = function(x, ...) {
-                    code <- getModelInfo("earth", regex = FALSE)[[1]]$predictors
-                    tmp <- predictors(x$terms)
-                    out <- if(class(x$fit) == "earth") code(x$fit) else tmp
-                    out
-                  },
-                  varImp = function(object, value = "gcv", ...)
-                    varImp(object$fit, value = value, ...),
-                  sort = function(x) x[order(x$degree, x$nprune),])
+    mda::fda(
+      .outcome ~ .,
+      data = dat,
+      method = earth::earth,
+      degree = param$degree,
+      nprune = param$nprune,
+      weights = wts,
+      ...
+    )
+  },
+  levels = function(x) x$obsLevels,
+  tags = c(
+    "Multivariate Adaptive Regression Splines",
+    "Implicit Feature Selection",
+    "Accepts Case Weights"
+  ),
+  notes = paste(
+    "Unlike other packages used by `train`, the `earth`",
+    "package is fully loaded when this model is used."
+  ),
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata, type = "posterior")
+  },
+  predictors = function(x, ...) {
+    code <- getModelInfo("earth", regex = FALSE)[[1]]$predictors
+    tmp <- predictors(x$terms)
+    out <- if (class(x$fit) == "earth") code(x$fit) else tmp
+    out
+  },
+  varImp = function(object, value = "gcv", ...) {
+    varImp(object$fit, value = value, ...)
+  },
+  sort = function(x) x[order(x$degree, x$nprune), ]
+)

--- a/inst/model_sources/files/foba.R
+++ b/inst/model_sources/files/foba.R
@@ -1,59 +1,88 @@
-modelInfo <- list(label = "Ridge Regression with Variable Selection",
-                  library = "foba",
-                  type = "Regression",
-                  parameters = data.frame(parameter = c('k', 'lambda'),
-                                          class = c("numeric", "numeric"),
-                                          label = c('#Variables Retained', 'L2 Penalty')),
-                  grid = function(x, y, len = NULL, search = "grid")  {   
-                    if(search == "grid") {
-                      out <- expand.grid(lambda = 10 ^ seq(-5, -1, length = len),
-                                         k = caret::var_seq(p = ncol(x), 
-                                                            classification = is.factor(y), 
-                                                            len = len))
-                    } else {
-                      out <- data.frame(lambda = 10^runif(len, min = -5, 1),
-                                        k = sample(1:ncol(x), replace = TRUE, size = len))
-                    }
-                    out
-                    },
-                  loop = function(grid) {   
-                    grid <- grid[order(grid$lambda, grid$k, decreasing = TRUE),, drop = FALSE]  
-                    uniqueLambda <- unique(grid$lambda)
-                    loop <- data.frame(lambda = uniqueLambda)
-                    loop$k <- NA
-                    
-                    submodels <- vector(mode = "list", length = length(uniqueLambda))
-                    
-                    for(i in seq(along = uniqueLambda)) {
-                      subK <- grid[grid$lambda == uniqueLambda[i],"k"]
-                      loop$k[loop$lambda == uniqueLambda[i]] <- subK[which.max(subK)]
-                      submodels[[i]] <- data.frame(k = subK[-which.max(subK)])
-                    }  
-                    list(loop = loop, submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...)
-                    foba::foba(as.matrix(x), y, lambda = param$lambda, ...),
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata, k = modelFit$tuneValue$k, type = "fit")$fit
-                    
-                    if(!is.null(submodels))  {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
-                      
-                      for(j in seq(along = submodels$k)) {
-                        tmp[[j+1]] <- predict(modelFit, newdata, k = submodels$k[j], type = "fit")$fit
-                      }
-                      out <- tmp
-                    }
-                    out       
-                  },
-                  predictors = function(x, k = NULL, ...) {
-                    if(is.null(k)) {
-                      if(!is.null(x$tuneValue)) k <- x$tuneValue$k[1]  else stop("Please specify k")
-                    }
-                    names(predict(x, k = k, type = "coefficients")$selected.variables)
-                  },
-                  tags = c("Linear Regression", "Ridge Regression", 
-                           "L2 Regularization", "Feature Selection Wrapper"),
-                  prob = NULL,
-                  sort = function(x) x[order(x$k, -x$lambda),])
+modelInfo <- list(
+  label = "Ridge Regression with Variable Selection",
+  library = "foba",
+  type = "Regression",
+  parameters = data.frame(
+    parameter = c('k', 'lambda'),
+    class = c("numeric", "numeric"),
+    label = c('#Variables Retained', 'L2 Penalty')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        lambda = 10^seq(-5, -1, length = len),
+        k = caret::var_seq(
+          p = ncol(x),
+          classification = is.factor(y),
+          len = len
+        )
+      )
+    } else {
+      out <- data.frame(
+        lambda = 10^runif(len, min = -5, 1),
+        k = sample(1:ncol(x), replace = TRUE, size = len)
+      )
+    }
+    out
+  },
+  loop = function(grid) {
+    grid <- grid[order(grid$lambda, grid$k, decreasing = TRUE), , drop = FALSE]
+    uniqueLambda <- unique(grid$lambda)
+    loop <- data.frame(lambda = uniqueLambda)
+    loop$k <- NA
+
+    submodels <- vector(mode = "list", length = length(uniqueLambda))
+
+    for (i in seq(along = uniqueLambda)) {
+      subK <- grid[grid$lambda == uniqueLambda[i], "k"]
+      loop$k[loop$lambda == uniqueLambda[i]] <- subK[which.max(subK)]
+      submodels[[i]] <- data.frame(k = subK[-which.max(subK)])
+    }
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    foba::foba(as.matrix(x), y, lambda = param$lambda, ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(
+      modelFit,
+      newdata,
+      k = modelFit$tuneValue$k,
+      type = "fit"
+    )$fit
+
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
+
+      for (j in seq(along = submodels$k)) {
+        tmp[[j + 1]] <- predict(
+          modelFit,
+          newdata,
+          k = submodels$k[j],
+          type = "fit"
+        )$fit
+      }
+      out <- tmp
+    }
+    out
+  },
+  predictors = function(x, k = NULL, ...) {
+    if (is.null(k)) {
+      if (!is.null(x$tuneValue)) {
+        k <- x$tuneValue$k[1]
+      } else {
+        stop("Please specify k")
+      }
+    }
+    names(predict(x, k = k, type = "coefficients")$selected.variables)
+  },
+  tags = c(
+    "Linear Regression",
+    "Ridge Regression",
+    "L2 Regularization",
+    "Feature Selection Wrapper"
+  ),
+  prob = NULL,
+  sort = function(x) x[order(x$k, -x$lambda), ]
+)

--- a/inst/model_sources/files/gam.R
+++ b/inst/model_sources/files/gam.R
@@ -1,97 +1,114 @@
-modelInfo <- list(label = "Generalized Additive Model using Splines",
-                  library = "mgcv",
-                  loop = NULL,
-                  type = c('Regression', 'Classification'),
-                  parameters = data.frame(parameter = c('select', 'method'),
-                                          class = c('logical', 'character'),
-                                          label = c('Feature Selection', 'Method')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(select = c(TRUE, FALSE)[1:min(2,len)], method = "GCV.Cp")
-                    } else {
-                      out <- data.frame(select = sample(c(TRUE, FALSE), size = len, replace = TRUE),
-                                        method = sample(c("GCV.Cp", "ML"), size = len, replace = TRUE))
-                    }
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    require(mgcv)
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    modForm <- caret:::smootherFormula(x)
-                    if(is.factor(y)) {
-                      dat$.outcome <- ifelse(y == lev[1], 0, 1)
-                      dist <- binomial()
-                    } else {
-                      dat$.outcome <- y
-                      dist <- gaussian()
-                    }
-                    modelArgs <- list(formula = modForm,
-                                      data = dat,
-                                      select = param$select,
-                                      method = as.character(param$method))
-                    ## Intercept family if passed in
-                    theDots <- list(...)
-                    if(!any(names(theDots) == "family")) modelArgs$family <- dist
-                    modelArgs <- c(modelArgs, theDots)
+modelInfo <- list(
+  label = "Generalized Additive Model using Splines",
+  library = "mgcv",
+  loop = NULL,
+  type = c('Regression', 'Classification'),
+  parameters = data.frame(
+    parameter = c('select', 'method'),
+    class = c('logical', 'character'),
+    label = c('Feature Selection', 'Method')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        select = c(TRUE, FALSE)[1:min(2, len)],
+        method = "GCV.Cp"
+      )
+    } else {
+      out <- data.frame(
+        select = sample(c(TRUE, FALSE), size = len, replace = TRUE),
+        method = sample(c("GCV.Cp", "ML"), size = len, replace = TRUE)
+      )
+    }
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    require(mgcv)
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    modForm <- caret:::smootherFormula(x)
+    if (is.factor(y)) {
+      dat$.outcome <- ifelse(y == lev[1], 0, 1)
+      dist <- binomial()
+    } else {
+      dat$.outcome <- y
+      dist <- gaussian()
+    }
+    modelArgs <- list(
+      formula = modForm,
+      data = dat,
+      select = param$select,
+      method = as.character(param$method)
+    )
+    ## Intercept family if passed in
+    theDots <- list(...)
+    if (!any(names(theDots) == "family")) {
+      modelArgs$family <- dist
+    }
+    modelArgs <- c(modelArgs, theDots)
 
-                    out <- do.call(mgcv::gam, modelArgs)
-                    out
-
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    if(modelFit$problemType == "Classification") {
-                      probs <-  predict(modelFit, newdata, type = "response")
-                      out <- ifelse(probs < .5,
-                                    modelFit$obsLevel[1],
-                                    modelFit$obsLevel[2])
-                    } else {
-                      out <- predict(modelFit, newdata, type = "response")
-                    }
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL){
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    out <- predict(modelFit, newdata, type = "response")
-                    out <- cbind(1-out, out)
-                    ## glm models the second factor level, we treat the first as the
-                    ## event of interest. See Details in ?glm
-                    colnames(out) <-  modelFit$obsLevels
-                    out
-                  },
-                  predictors = function(x, ...) {
-                    predictors(x$terms)
-                  },
-                  levels = function(x) x$obsLevels,
-                  varImp = function(object, ...) {
-                    smoothed <- summary(object)$s.table[, "p-value", drop = FALSE]
-                    linear <- summary(object)$p.table
-                    linear <- linear[, grepl("^Pr", colnames(linear)), drop = FALSE]
-                    gams <- rbind(smoothed, linear)
-                    gams <- gams[rownames(gams) != "(Intercept)",,drop = FALSE]
-                    rownames(gams) <- gsub("^s\\(", "", rownames(gams))
-                    rownames(gams) <- gsub("\\)$", "", rownames(gams))
-                    colnames(gams)[1] <- "Overall"
-                    gams <- as.data.frame(gams, stringsAsFactors = TRUE)
-                    gams$Overall <- -log10(gams$Overall)
-                    allPreds <- colnames(attr(object$terms,"factors"))
-                    extras <- allPreds[!(allPreds %in% rownames(gams))]
-                    if(any(extras)) {
-                      tmp <- data.frame(Overall = rep(NA, length(extras)))
-                      rownames(tmp) <- extras
-                      gams <- rbind(gams, tmp)
-                    }
-                    gams
-                  },
-                  notes =
-                    paste(
-                      'Which terms enter the model in a nonlinear manner is determined',
-                      'by the number of unique values for the predictor. For example,',
-                      'if a predictor only has four unique values, most basis expansion',
-                      'method will fail because there are not enough granularity in the',
-                      'data. By default, a predictor must have at least 10 unique',
-                      'values to be used in a nonlinear basis expansion.',
-                      'Unlike other packages used by `train`, the `mgcv`',
-                      'package is fully loaded when this model is used.'
-                    ),
-                  tags = c("Generalized Linear Model", "Generalized Additive Model"),
-                  sort = function(x) x)
+    out <- do.call(mgcv::gam, modelArgs)
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    if (modelFit$problemType == "Classification") {
+      probs <- predict(modelFit, newdata, type = "response")
+      out <- ifelse(probs < .5, modelFit$obsLevel[1], modelFit$obsLevel[2])
+    } else {
+      out <- predict(modelFit, newdata, type = "response")
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    out <- predict(modelFit, newdata, type = "response")
+    out <- cbind(1 - out, out)
+    ## glm models the second factor level, we treat the first as the
+    ## event of interest. See Details in ?glm
+    colnames(out) <- modelFit$obsLevels
+    out
+  },
+  predictors = function(x, ...) {
+    predictors(x$terms)
+  },
+  levels = function(x) x$obsLevels,
+  varImp = function(object, ...) {
+    smoothed <- summary(object)$s.table[, "p-value", drop = FALSE]
+    linear <- summary(object)$p.table
+    linear <- linear[, grepl("^Pr", colnames(linear)), drop = FALSE]
+    gams <- rbind(smoothed, linear)
+    gams <- gams[rownames(gams) != "(Intercept)", , drop = FALSE]
+    rownames(gams) <- gsub("^s\\(", "", rownames(gams))
+    rownames(gams) <- gsub("\\)$", "", rownames(gams))
+    colnames(gams)[1] <- "Overall"
+    gams <- as.data.frame(gams, stringsAsFactors = TRUE)
+    gams$Overall <- -log10(gams$Overall)
+    allPreds <- colnames(attr(object$terms, "factors"))
+    extras <- allPreds[!(allPreds %in% rownames(gams))]
+    if (any(extras)) {
+      tmp <- data.frame(Overall = rep(NA, length(extras)))
+      rownames(tmp) <- extras
+      gams <- rbind(gams, tmp)
+    }
+    gams
+  },
+  notes = paste(
+    'Which terms enter the model in a nonlinear manner is determined',
+    'by the number of unique values for the predictor. For example,',
+    'if a predictor only has four unique values, most basis expansion',
+    'method will fail because there are not enough granularity in the',
+    'data. By default, a predictor must have at least 10 unique',
+    'values to be used in a nonlinear basis expansion.',
+    'Unlike other packages used by `train`, the `mgcv`',
+    'package is fully loaded when this model is used.'
+  ),
+  tags = c("Generalized Linear Model", "Generalized Additive Model"),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/gam.R
+++ b/inst/model_sources/files/gam.R
@@ -23,10 +23,10 @@ modelInfo <- list(
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
     require(mgcv)
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     modForm <- caret:::smootherFormula(x)
     if (is.factor(y)) {

--- a/inst/model_sources/files/gamLoess.R
+++ b/inst/model_sources/files/gamLoess.R
@@ -38,7 +38,11 @@ modelInfo <- list(
     theDots <- list(...)
 
     if (!any(names(theDots) == "family")) {
-      args$family <- if (is.factor(y)) binomial else gaussian
+      if (is.factor(y)) {
+        args$family <- binomial
+      } else {
+        args$family <- gaussian
+      }
     }
 
     if (length(theDots) > 0) {

--- a/inst/model_sources/files/gamLoess.R
+++ b/inst/model_sources/files/gamLoess.R
@@ -1,114 +1,147 @@
-modelInfo <- list(label = "Generalized Additive Model using LOESS",
-                  library = "gam",
-                  loop = NULL,
-                  type = c('Regression', 'Classification'),
-                  parameters = data.frame(parameter = c('span', 'degree'),
-                                          class = c('numeric', 'numeric'),
-                                          label = c('Span', 'Degree')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(span = .5, degree = 1)
-                    } else {
-                      out <- data.frame(span = runif(len, min = 0, max = 1),
-                                        degree = sample(1:2, size = len, replace = TRUE))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    require(gam)
-                    args <- list(data = if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE))
-                    args$data$.outcome <- y
-                    args$formula <- caret:::smootherFormula(x,
-                                                            smoother = "lo",
-                                                            span = param$span,
-                                                            degree = param$degree)
-                    theDots <- list(...)
-                    
-                    
-                    if(!any(names(theDots) == "family")) 
-                      args$family <- if(is.factor(y)) binomial else gaussian
-                    
-                    if(length(theDots) > 0) args <- c(args, theDots)
+modelInfo <- list(
+  label = "Generalized Additive Model using LOESS",
+  library = "gam",
+  loop = NULL,
+  type = c('Regression', 'Classification'),
+  parameters = data.frame(
+    parameter = c('span', 'degree'),
+    class = c('numeric', 'numeric'),
+    label = c('Span', 'Degree')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(span = .5, degree = 1)
+    } else {
+      out <- data.frame(
+        span = runif(len, min = 0, max = 1),
+        degree = sample(1:2, size = len, replace = TRUE)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    require(gam)
+    args <- list(
+      data = if (is.data.frame(x)) {
+        x
+      } else {
+        as.data.frame(x, stringsAsFactors = TRUE)
+      }
+    )
+    args$data$.outcome <- y
+    args$formula <- caret:::smootherFormula(
+      x,
+      smoother = "lo",
+      span = param$span,
+      degree = param$degree
+    )
+    theDots <- list(...)
 
-                    do.call(gam::gam, args)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    if(modelFit$problemType == "Classification") {
-                      probs <-  gam:::predict.Gam(modelFit, newdata, type = "response")
-                      out <- ifelse(probs < .5,
-                                    modelFit$obsLevel[1],
-                                    modelFit$obsLevel[2])
-                    } else {
-                      out <- gam:::predict.Gam(modelFit, newdata, type = "response")
-                    }
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL){
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    out <- predict(modelFit, newdata, type = "response")
-                    out <- cbind(1-out, out)
-                    ## glm models the second factor level, we treat the first as the
-                    ## event of interest. See Details in ?glm
-                    colnames(out) <-  modelFit$obsLevels
-                    out
-                  },
-                  predictors = function(x, ...) {
-                    getNames <- function(x) {
-                      x <- strsplit(x, "(\\()|(,)|(\\))")
-                      x <- lapply(x, function(x) x[!(x %in% c("s", "lo", ""))])
-                      unlist(lapply(x, function(x) x[1]))
-                    }
-                    getNames(predictors(x$terms))
-                  },
-                  varImp = function(object, ...) {
-                    getNames <- function(x) {
-                      x <- strsplit(x, "(\\()|(,)|(\\))")
-                      x <- lapply(x, function(x) x[!(x %in% c("s", "lo", ""))])
-                      unlist(lapply(x, function(x) x[1]))
-                    }
-                    gamSummary <- gam:::summary.Gam(object)
-                    smoothed <- gamSummary$anova
-                    smoothed <- smoothed[complete.cases(smoothed), grepl("^P", colnames(smoothed)), drop = FALSE] 
-                    linear <- gamSummary$parametric.anova
-                    linear <- linear[complete.cases(linear), grepl("^P", colnames(linear)), drop = FALSE] 
-                    linear <- linear[!(rownames(linear) %in% rownames(smoothed)),,drop = FALSE]
-                    colnames(smoothed) <- colnames(linear) <- "pval"
-                    gams <- rbind(smoothed, linear)
-                    gams <- gams[rownames(gams) != "(Intercept)",,drop = FALSE]
-                    rownames(gams) <- getNames(rownames(gams))
-                    colnames(gams)[1] <- "Overall"
-                    gams <- as.data.frame(gams, stringsAsFactors = TRUE)
-                    gams$Overall <- -log10(gams$Overall)
-                    allPreds <- getNames(colnames(attr(object$terms,"factors")))
-                    extras <- allPreds[!(allPreds %in% rownames(gams))]
-                    if(any(extras)) {
-                      tmp <- data.frame(Overall = rep(NA, length(extras)))
-                      rownames(tmp) <- extras
-                      gams <- rbind(gams, tmp)
-                    }
-                    gams
-                  },
-                  levels = function(x) x$obsLevels,
-                  notes = 
-                    paste(
-                      'Which terms enter the model in a nonlinear manner is determined',
-                      'by the number of unique values for the predictor. For example,',
-                      'if a predictor only has four unique values, most basis expansion',
-                      'method will fail because there are not enough granularity in the',
-                      'data. By default, a predictor must have at least 10 unique',
-                      'values to be used in a nonlinear basis expansion.',
-                      'Unlike other packages used by `train`, the `gam`',
-                      'package is fully loaded when this model is used.'
-                    ),
-                  tags = c("Generalized Linear Model", "Generalized Additive Model"),
-                  sort = function(x) x,
-                  check = function(pkg) {
-                    requireNamespace("gam")
-                    current <- packageDescription("gam")$Version
-                    expected <- "1.15"
-                    if(compareVersion(current, expected) < 0)
-                      stop("This modeling workflow requires kohonen version ",
-                           expected, "or greater.", call. = FALSE)
-                  }
-                  )
+    if (!any(names(theDots) == "family")) {
+      args$family <- if (is.factor(y)) binomial else gaussian
+    }
+
+    if (length(theDots) > 0) {
+      args <- c(args, theDots)
+    }
+
+    do.call(gam::gam, args)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    if (modelFit$problemType == "Classification") {
+      probs <- gam:::predict.Gam(modelFit, newdata, type = "response")
+      out <- ifelse(probs < .5, modelFit$obsLevel[1], modelFit$obsLevel[2])
+    } else {
+      out <- gam:::predict.Gam(modelFit, newdata, type = "response")
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    out <- predict(modelFit, newdata, type = "response")
+    out <- cbind(1 - out, out)
+    ## glm models the second factor level, we treat the first as the
+    ## event of interest. See Details in ?glm
+    colnames(out) <- modelFit$obsLevels
+    out
+  },
+  predictors = function(x, ...) {
+    getNames <- function(x) {
+      x <- strsplit(x, "(\\()|(,)|(\\))")
+      x <- lapply(x, function(x) x[!(x %in% c("s", "lo", ""))])
+      unlist(lapply(x, function(x) x[1]))
+    }
+    getNames(predictors(x$terms))
+  },
+  varImp = function(object, ...) {
+    getNames <- function(x) {
+      x <- strsplit(x, "(\\()|(,)|(\\))")
+      x <- lapply(x, function(x) x[!(x %in% c("s", "lo", ""))])
+      unlist(lapply(x, function(x) x[1]))
+    }
+    gamSummary <- gam:::summary.Gam(object)
+    smoothed <- gamSummary$anova
+    smoothed <- smoothed[
+      complete.cases(smoothed),
+      grepl("^P", colnames(smoothed)),
+      drop = FALSE
+    ]
+    linear <- gamSummary$parametric.anova
+    linear <- linear[
+      complete.cases(linear),
+      grepl("^P", colnames(linear)),
+      drop = FALSE
+    ]
+    linear <- linear[
+      !(rownames(linear) %in% rownames(smoothed)),
+      ,
+      drop = FALSE
+    ]
+    colnames(smoothed) <- colnames(linear) <- "pval"
+    gams <- rbind(smoothed, linear)
+    gams <- gams[rownames(gams) != "(Intercept)", , drop = FALSE]
+    rownames(gams) <- getNames(rownames(gams))
+    colnames(gams)[1] <- "Overall"
+    gams <- as.data.frame(gams, stringsAsFactors = TRUE)
+    gams$Overall <- -log10(gams$Overall)
+    allPreds <- getNames(colnames(attr(object$terms, "factors")))
+    extras <- allPreds[!(allPreds %in% rownames(gams))]
+    if (any(extras)) {
+      tmp <- data.frame(Overall = rep(NA, length(extras)))
+      rownames(tmp) <- extras
+      gams <- rbind(gams, tmp)
+    }
+    gams
+  },
+  levels = function(x) x$obsLevels,
+  notes = paste(
+    'Which terms enter the model in a nonlinear manner is determined',
+    'by the number of unique values for the predictor. For example,',
+    'if a predictor only has four unique values, most basis expansion',
+    'method will fail because there are not enough granularity in the',
+    'data. By default, a predictor must have at least 10 unique',
+    'values to be used in a nonlinear basis expansion.',
+    'Unlike other packages used by `train`, the `gam`',
+    'package is fully loaded when this model is used.'
+  ),
+  tags = c("Generalized Linear Model", "Generalized Additive Model"),
+  sort = function(x) x,
+  check = function(pkg) {
+    requireNamespace("gam")
+    current <- packageDescription("gam")$Version
+    expected <- "1.15"
+    if (compareVersion(current, expected) < 0) {
+      stop(
+        "This modeling workflow requires kohonen version ",
+        expected,
+        "or greater.",
+        call. = FALSE
+      )
+    }
+  }
+)

--- a/inst/model_sources/files/gamSpline.R
+++ b/inst/model_sources/files/gamSpline.R
@@ -1,113 +1,140 @@
-modelInfo <- list(label = "Generalized Additive Model using Splines",
-                  library = "gam",
-                  loop = NULL,
-                  type = c('Regression', 'Classification'),
-                  parameters = data.frame(parameter = c('df'),
-                                          class = c('numeric'),
-                                          label = c('Degrees of Freedom')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(df = seq(1, 3, length = len))
-                    } else {
-                      out <- data.frame(df = runif(len, min = 0, max = 5))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    require(gam)
-                    args <- list(data = if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE))
-                    args$data$.outcome <- y
-                    ## if(!is.null(wts))  args$weights <- wts
-                    args$formula <- caret:::smootherFormula(x,
-                                                            smoother = "s",
-                                                            df = param$df)
-                    theDots <- list(...)
-                    
-                    
-                    if(!any(names(theDots) == "family")) 
-                      args$family <- if(is.factor(y)) binomial else gaussian
-                    
-                    if(length(theDots) > 0) args <- c(args, theDots)
+modelInfo <- list(
+  label = "Generalized Additive Model using Splines",
+  library = "gam",
+  loop = NULL,
+  type = c('Regression', 'Classification'),
+  parameters = data.frame(
+    parameter = c('df'),
+    class = c('numeric'),
+    label = c('Degrees of Freedom')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(df = seq(1, 3, length = len))
+    } else {
+      out <- data.frame(df = runif(len, min = 0, max = 5))
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    require(gam)
+    args <- list(
+      data = if (is.data.frame(x)) {
+        x
+      } else {
+        as.data.frame(x, stringsAsFactors = TRUE)
+      }
+    )
+    args$data$.outcome <- y
+    ## if(!is.null(wts))  args$weights <- wts
+    args$formula <- caret:::smootherFormula(x, smoother = "s", df = param$df)
+    theDots <- list(...)
 
-                    do.call(gam::gam, args)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    if(modelFit$problemType == "Classification") {
-                      probs <-  gam:::predict.Gam(modelFit, newdata, type = "response")
-                      out <- ifelse(probs < .5,
-                                    modelFit$obsLevel[1],
-                                    modelFit$obsLevel[2])
-                    } else {
-                      out <- gam:::predict.Gam(modelFit, newdata, type = "response")
-                    }
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL){
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    out <- gam:::predict.Gam(modelFit, newdata, type = "response")
-                    out <- cbind(1-out, out)
-                    ## glm models the second factor level, we treat the first as the
-                    ## event of interest. See Details in ?glm
-                    colnames(out) <-  modelFit$obsLevels
-                    out
-                  },
-                  levels = function(x) x$obsLevels,
-                  predictors = function(x, ...) {
-                    getNames <- function(x) {
-                      x <- strsplit(x, "(\\()|(,)|(\\))")
-                      x <- lapply(x, function(x) x[!(x %in% c("s", "lo", ""))])
-                      unlist(lapply(x, function(x) x[1]))
-                    }
-                    getNames(predictors(x$terms))
-                  },
-                  varImp = function(object, ...) {
-                    getNames <- function(x) {
-                      x <- strsplit(x, "(\\()|(,)|(\\))")
-                      x <- lapply(x, function(x) x[!(x %in% c("s", "lo", ""))])
-                      unlist(lapply(x, function(x) x[1]))
-                    }
-                    gamSummary <- gam:::summary.Gam(object)
-                    smoothed <- gamSummary$anova
-                    smoothed <- smoothed[complete.cases(smoothed), grepl("^P", colnames(smoothed)), drop = FALSE] 
-                    linear <- gamSummary$parametric.anova
-                    linear <- linear[complete.cases(linear), grepl("^P", colnames(linear)), drop = FALSE] 
-                    linear <- linear[!(rownames(linear) %in% rownames(smoothed)),,drop = FALSE]
-                    colnames(smoothed) <- colnames(linear) <- "pval"
-                    gams <- rbind(smoothed, linear)
-                    gams <- gams[rownames(gams) != "(Intercept)",,drop = FALSE]
-                    rownames(gams) <- getNames(rownames(gams))
-                    colnames(gams)[1] <- "Overall"
-                    gams <- as.data.frame(gams, stringsAsFactors = TRUE)
-                    gams$Overall <- -log10(gams$Overall)
-                    allPreds <- getNames(colnames(attr(object$terms,"factors")))
-                    extras <- allPreds[!(allPreds %in% rownames(gams))]
-                    if(any(extras)) {
-                      tmp <- data.frame(Overall = rep(NA, length(extras)))
-                      rownames(tmp) <- extras
-                      gams <- rbind(gams, tmp)
-                    }
-                    gams
-                  },
-                  notes = 
-                    paste(
-                      'Which terms enter the model in a nonlinear manner is determined',
-                      'by the number of unique values for the predictor. For example,',
-                      'if a predictor only has four unique values, most basis expansion',
-                      'method will fail because there are not enough granularity in the',
-                      'data. By default, a predictor must have at least 10 unique',
-                      'values to be used in a nonlinear basis expansion.',
-                      'Unlike other packages used by `train`, the `gam`',
-                      'package is fully loaded when this model is used.'
-                    ),
-                  tags = c("Generalized Linear Model", "Generalized Additive Model"),
-                  sort = function(x) x,
-                  check = function(pkg) {
-                    requireNamespace("gam")
-                    current <- packageDescription("gam")$Version
-                    expected <- "1.15"
-                    if(compareVersion(current, expected) < 0)
-                      stop("This modeling workflow requires kohonen version ",
-                           expected, "or greater.", call. = FALSE)
-                  }
-                  )
+    if (!any(names(theDots) == "family")) {
+      args$family <- if (is.factor(y)) binomial else gaussian
+    }
+
+    if (length(theDots) > 0) {
+      args <- c(args, theDots)
+    }
+
+    do.call(gam::gam, args)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    if (modelFit$problemType == "Classification") {
+      probs <- gam:::predict.Gam(modelFit, newdata, type = "response")
+      out <- ifelse(probs < .5, modelFit$obsLevel[1], modelFit$obsLevel[2])
+    } else {
+      out <- gam:::predict.Gam(modelFit, newdata, type = "response")
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    out <- gam:::predict.Gam(modelFit, newdata, type = "response")
+    out <- cbind(1 - out, out)
+    ## glm models the second factor level, we treat the first as the
+    ## event of interest. See Details in ?glm
+    colnames(out) <- modelFit$obsLevels
+    out
+  },
+  levels = function(x) x$obsLevels,
+  predictors = function(x, ...) {
+    getNames <- function(x) {
+      x <- strsplit(x, "(\\()|(,)|(\\))")
+      x <- lapply(x, function(x) x[!(x %in% c("s", "lo", ""))])
+      unlist(lapply(x, function(x) x[1]))
+    }
+    getNames(predictors(x$terms))
+  },
+  varImp = function(object, ...) {
+    getNames <- function(x) {
+      x <- strsplit(x, "(\\()|(,)|(\\))")
+      x <- lapply(x, function(x) x[!(x %in% c("s", "lo", ""))])
+      unlist(lapply(x, function(x) x[1]))
+    }
+    gamSummary <- gam:::summary.Gam(object)
+    smoothed <- gamSummary$anova
+    smoothed <- smoothed[
+      complete.cases(smoothed),
+      grepl("^P", colnames(smoothed)),
+      drop = FALSE
+    ]
+    linear <- gamSummary$parametric.anova
+    linear <- linear[
+      complete.cases(linear),
+      grepl("^P", colnames(linear)),
+      drop = FALSE
+    ]
+    linear <- linear[
+      !(rownames(linear) %in% rownames(smoothed)),
+      ,
+      drop = FALSE
+    ]
+    colnames(smoothed) <- colnames(linear) <- "pval"
+    gams <- rbind(smoothed, linear)
+    gams <- gams[rownames(gams) != "(Intercept)", , drop = FALSE]
+    rownames(gams) <- getNames(rownames(gams))
+    colnames(gams)[1] <- "Overall"
+    gams <- as.data.frame(gams, stringsAsFactors = TRUE)
+    gams$Overall <- -log10(gams$Overall)
+    allPreds <- getNames(colnames(attr(object$terms, "factors")))
+    extras <- allPreds[!(allPreds %in% rownames(gams))]
+    if (any(extras)) {
+      tmp <- data.frame(Overall = rep(NA, length(extras)))
+      rownames(tmp) <- extras
+      gams <- rbind(gams, tmp)
+    }
+    gams
+  },
+  notes = paste(
+    'Which terms enter the model in a nonlinear manner is determined',
+    'by the number of unique values for the predictor. For example,',
+    'if a predictor only has four unique values, most basis expansion',
+    'method will fail because there are not enough granularity in the',
+    'data. By default, a predictor must have at least 10 unique',
+    'values to be used in a nonlinear basis expansion.',
+    'Unlike other packages used by `train`, the `gam`',
+    'package is fully loaded when this model is used.'
+  ),
+  tags = c("Generalized Linear Model", "Generalized Additive Model"),
+  sort = function(x) x,
+  check = function(pkg) {
+    requireNamespace("gam")
+    current <- packageDescription("gam")$Version
+    expected <- "1.15"
+    if (compareVersion(current, expected) < 0) {
+      stop(
+        "This modeling workflow requires kohonen version ",
+        expected,
+        "or greater.",
+        call. = FALSE
+      )
+    }
+  }
+)

--- a/inst/model_sources/files/gamSpline.R
+++ b/inst/model_sources/files/gamSpline.R
@@ -31,7 +31,11 @@ modelInfo <- list(
     theDots <- list(...)
 
     if (!any(names(theDots) == "family")) {
-      args$family <- if (is.factor(y)) binomial else gaussian
+      if (is.factor(y)) {
+        args$family <- binomial
+      } else {
+        args$family <- gaussian
+      }
     }
 
     if (length(theDots) > 0) {

--- a/inst/model_sources/files/gamboost.R
+++ b/inst/model_sources/files/gamboost.R
@@ -1,127 +1,181 @@
-modelInfo <- list(label = "Boosted Generalized Additive Model",
-                  library = c("mboost", "plyr", "import"),
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('mstop', 'prune'),
-                                          class = c("numeric", "character"),
-                                          label = c('# Boosting Iterations', 'AIC Prune?')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- data.frame(mstop = floor((1:len) * 50), prune = "no")
-                    } else {
-                      out <- data.frame(mstop = sample(1:1000, size = len, replace = TRUE),
-                                        prune = sample(c("yes", "no"), size = len, replace = TRUE))
-                    }
-                  },
-                  loop = function(grid) {
-                    grid <- grid[order(-grid$mstop, grid$prune),]
-                    loop <- plyr::ddply(grid, plyr::`.`(prune), function(x) data.frame(mstop = max(x$mstop)))
-                    submodels <- vector(mode = "list", length = nrow(loop))
-                    for(i in seq(along = loop$mstop)) {
-                      submodels[[i]] <- subset(grid, prune == loop$prune[i] & mstop < loop$mstop[i])
-                    }
-                    list(loop = loop[, c("mstop", "prune")], submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    import::from(mboost, bbs, .into = "mboost")
-                    ##check for control list and over-write mstop
-                    theDots <- list(...)
-                    if(any(names(theDots) == "control")) {
-                      theDots$control$mstop <- param$mstop
-                      ctl <- theDots$control
-                      theDots$control <- NULL
-                    } else ctl <- mboost::boost_control(mstop = param$mstop)
+modelInfo <- list(
+  label = "Boosted Generalized Additive Model",
+  library = c("mboost", "plyr", "import"),
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c('mstop', 'prune'),
+    class = c("numeric", "character"),
+    label = c('# Boosting Iterations', 'AIC Prune?')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(mstop = floor((1:len) * 50), prune = "no")
+    } else {
+      out <- data.frame(
+        mstop = sample(1:1000, size = len, replace = TRUE),
+        prune = sample(c("yes", "no"), size = len, replace = TRUE)
+      )
+    }
+  },
+  loop = function(grid) {
+    grid <- grid[order(-grid$mstop, grid$prune), ]
+    loop <- plyr::ddply(grid, plyr::`.`(prune), function(x) {
+      data.frame(mstop = max(x$mstop))
+    })
+    submodels <- vector(mode = "list", length = nrow(loop))
+    for (i in seq(along = loop$mstop)) {
+      submodels[[i]] <- subset(
+        grid,
+        prune == loop$prune[i] & mstop < loop$mstop[i]
+      )
+    }
+    list(loop = loop[, c("mstop", "prune")], submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    import::from(mboost, bbs, .into = "mboost")
+    ##check for control list and over-write mstop
+    theDots <- list(...)
+    if (any(names(theDots) == "control")) {
+      theDots$control$mstop <- param$mstop
+      ctl <- theDots$control
+      theDots$control <- NULL
+    } else {
+      ctl <- mboost::boost_control(mstop = param$mstop)
+    }
 
-                    if(!any(names(theDots) == "family"))
-                      theDots$family <- if(is.factor(y)) mboost::Binomial() else mboost::GaussReg()
+    if (!any(names(theDots) == "family")) {
+      theDots$family <- if (is.factor(y)) {
+        mboost::Binomial()
+      } else {
+        mboost::GaussReg()
+      }
+    }
 
-                    ## pass in any model weights
-                    if(!is.null(wts)) theDots$weights <- wts
+    ## pass in any model weights
+    if (!is.null(wts)) {
+      theDots$weights <- wts
+    }
 
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    modelArgs <- c(list(formula = as.formula(".outcome ~ ."),
-                                        data = dat, control = ctl),
-                                   theDots)
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    modelArgs <- c(
+      list(formula = as.formula(".outcome ~ ."), data = dat, control = ctl),
+      theDots
+    )
 
-                    out <- do.call(mboost::gamboost, modelArgs)
-                    ## from `?mstop`: The [.mboost function can be used to enhance or restrict a given
-                    ## boosting model to the specified boosting iteration i. Note that in both cases the
-                    ## original x will be changed to reduce the memory footprint. If the boosting model
-                    ## is enhanced by specifying an index that is larger than the initial mstop, only
-                    ## the missing i - mstop steps are fitted. If the model is restricted, the spare
-                    ## steps are not dropped, i.e., if we increase i again, these boosting steps are
-                    ## immediately available. Alternatively, the same operation can be done
-                    ## by mstop(x) <- i.
+    out <- do.call(mboost::gamboost, modelArgs)
+    ## from `?mstop`: The [.mboost function can be used to enhance or restrict a given
+    ## boosting model to the specified boosting iteration i. Note that in both cases the
+    ## original x will be changed to reduce the memory footprint. If the boosting model
+    ## is enhanced by specifying an index that is larger than the initial mstop, only
+    ## the missing i - mstop steps are fitted. If the model is restricted, the spare
+    ## steps are not dropped, i.e., if we increase i again, these boosting steps are
+    ## immediately available. Alternatively, the same operation can be done
+    ## by mstop(x) <- i.
 
-                    if(param$prune == "yes") {
-                      iters <- if(is.factor(y))
-                        mboost::mstop(AIC(out, "classical")) else
-                          mboost::mstop(AIC(out))
-                      if(iters < out$mstop()) out <- out[iters]
-                    }
-                    out$.org.mstop <- out$mstop()
+    if (param$prune == "yes") {
+      iters <- if (is.factor(y)) {
+        mboost::mstop(AIC(out, "classical"))
+      } else {
+        mboost::mstop(AIC(out))
+      }
+      if (iters < out$mstop()) out <- out[iters]
+    }
+    out$.org.mstop <- out$mstop()
 
-                    ## for easier printing (and tracebacks), we'll try to make the calls shorter
-                    ## by adding dummy object names instead of the long obkect definitions that
-                    ## currently exist
-                    out$call["x"] <- "xData"
-                    out$call["y"] <- "yData"
-                    out
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    predType <- ifelse(modelFit$problemType == "Classification", "class", "response")
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    out <- predict(modelFit, newdata, type = predType)
-                    if(!is.null(submodels)) {
+    ## for easier printing (and tracebacks), we'll try to make the calls shorter
+    ## by adding dummy object names instead of the long obkect definitions that
+    ## currently exist
+    out$call["x"] <- "xData"
+    out$call["y"] <- "yData"
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predType <- ifelse(
+      modelFit$problemType == "Classification",
+      "class",
+      "response"
+    )
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    out <- predict(modelFit, newdata, type = predType)
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- as.vector(out)
+      for (j in seq(along = submodels$mstop)) {
+        ## If the model has been pruned, make sure that the requested `mstop`
+        ## is not greater than the original value. If it is, use the orignal value.
+        ## This should only occur whenm the model was pruned .
+        this_mstop <- if (
+          submodels$prune[j] == "yes" &
+            submodels$mstop[j] > modelFit$.org.mstop
+        ) {
+          modelFit$.org.mstop
+        } else {
+          submodels$mstop[j]
+        }
+        tmp[[j + 1]] <- as.vector(predict(
+          modelFit[this_mstop],
+          newdata,
+          type = predType
+        ))
+      }
+      out <- tmp
+      mboost::mstop(modelFit) <- modelFit$.org.mstop
+    }
+    # cat(modelFit$mstop(), "!\n")
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    probs <- predict(modelFit, newdata, type = "response")
+    out <- cbind(1 - probs, probs)
+    colnames(out) <- modelFit$obsLevels
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
+      for (j in seq(along = submodels$mstop)) {
+        this_mstop <- if (
+          submodels$prune[j] == "yes" &
+            submodels$mstop[j] > modelFit$.org.mstop
+        ) {
+          modelFit$.org.mstop
+        } else {
+          submodels$mstop[j]
+        }
 
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- as.vector(out)
-                      for(j in seq(along = submodels$mstop)) {
-                        ## If the model has been pruned, make sure that the requested `mstop`
-                        ## is not greater than the original value. If it is, use the orignal value.
-                        ## This should only occur whenm the model was pruned .
-                        this_mstop <- if(submodels$prune[j] == "yes" &
-                                         submodels$mstop[j] > modelFit$.org.mstop)
-                          modelFit$.org.mstop else submodels$mstop[j]
-                        tmp[[j+1]]  <- as.vector(predict(modelFit[this_mstop],
-                                                         newdata,
-                                                         type = predType))
-                      }
-                      out <- tmp
-                      mboost::mstop(modelFit) <- modelFit$.org.mstop
-                    }
-                    # cat(modelFit$mstop(), "!\n")
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    probs <- predict(modelFit, newdata, type = "response")
-                    out <- cbind(1 - probs, probs)
-                    colnames(out) <- modelFit$obsLevels
-                    if(!is.null(submodels)) {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
-                      for(j in seq(along = submodels$mstop)) {
-                        this_mstop <- if(submodels$prune[j] == "yes" &
-                                         submodels$mstop[j] > modelFit$.org.mstop)
-                          modelFit$.org.mstop else submodels$mstop[j]
-
-                        tmpProb <- predict(modelFit[this_mstop], newdata, type = "response")
-                        tmpProb <- cbind(1 - tmpProb, tmpProb)
-                        colnames(tmpProb) <- modelFit$obsLevels
-                        tmp[[j+1]] <- as.data.frame(tmpProb[, modelFit$obsLevels, drop = FALSE], stringsAsFactors = TRUE)
-                      }
-                      out <- tmp
-                      mboost::mstop(modelFit) <- modelFit$.org.mstop
-                    }
-                    out
-                  },
-                  predictors = function(x, ...) {
-                    strsplit(variable.names(x), ", ")[[1]]
-                  },
-                  notes = "The `prune` option for this model enables the number of iterations to be determined by the optimal AIC value across all iterations. See the examples in `?mboost::mstop`. If pruning is not used, the ensemble makes predictions using the exact value of the `mstop` tuning parameter value.",
-                  tags = c("Generalized Additive Model", "Ensemble Model",
-                           "Boosting", "Implicit Feature Selection", "Two Class Only",
-                           "Accepts Case Weights"),
-                  levels = function(x) levels(x$response),
-                  sort = function(x) x[order(x$mstop, x$prune),])
+        tmpProb <- predict(modelFit[this_mstop], newdata, type = "response")
+        tmpProb <- cbind(1 - tmpProb, tmpProb)
+        colnames(tmpProb) <- modelFit$obsLevels
+        tmp[[j + 1]] <- as.data.frame(
+          tmpProb[, modelFit$obsLevels, drop = FALSE],
+          stringsAsFactors = TRUE
+        )
+      }
+      out <- tmp
+      mboost::mstop(modelFit) <- modelFit$.org.mstop
+    }
+    out
+  },
+  predictors = function(x, ...) {
+    strsplit(variable.names(x), ", ")[[1]]
+  },
+  notes = "The `prune` option for this model enables the number of iterations to be determined by the optimal AIC value across all iterations. See the examples in `?mboost::mstop`. If pruning is not used, the ensemble makes predictions using the exact value of the `mstop` tuning parameter value.",
+  tags = c(
+    "Generalized Additive Model",
+    "Ensemble Model",
+    "Boosting",
+    "Implicit Feature Selection",
+    "Two Class Only",
+    "Accepts Case Weights"
+  ),
+  levels = function(x) levels(x$response),
+  sort = function(x) x[order(x$mstop, x$prune), ]
+)

--- a/inst/model_sources/files/gamboost.R
+++ b/inst/model_sources/files/gamboost.R
@@ -44,10 +44,10 @@ modelInfo <- list(
     }
 
     if (!any(names(theDots) == "family")) {
-      theDots$family <- if (is.factor(y)) {
-        mboost::Binomial()
+      if (is.factor(y)) {
+        theDots$family <- mboost::Binomial()
       } else {
-        mboost::GaussReg()
+        theDots$family <- mboost::GaussReg()
       }
     }
 
@@ -56,10 +56,10 @@ modelInfo <- list(
       theDots$weights <- wts
     }
 
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     modelArgs <- c(
@@ -78,12 +78,14 @@ modelInfo <- list(
     ## by mstop(x) <- i.
 
     if (param$prune == "yes") {
-      iters <- if (is.factor(y)) {
-        mboost::mstop(AIC(out, "classical"))
+      if (is.factor(y)) {
+        iters <- mboost::mstop(AIC(out, "classical"))
       } else {
-        mboost::mstop(AIC(out))
+        iters <- mboost::mstop(AIC(out))
       }
-      if (iters < out$mstop()) out <- out[iters]
+      if (iters < out$mstop()) {
+        out <- out[iters]
+      }
     }
     out$.org.mstop <- out$mstop()
 
@@ -111,13 +113,13 @@ modelInfo <- list(
         ## If the model has been pruned, make sure that the requested `mstop`
         ## is not greater than the original value. If it is, use the orignal value.
         ## This should only occur whenm the model was pruned .
-        this_mstop <- if (
+        if (
           submodels$prune[j] == "yes" &
             submodels$mstop[j] > modelFit$.org.mstop
         ) {
-          modelFit$.org.mstop
+          this_mstop <- modelFit$.org.mstop
         } else {
-          submodels$mstop[j]
+          this_mstop <- submodels$mstop[j]
         }
         tmp[[j + 1]] <- as.vector(predict(
           modelFit[this_mstop],
@@ -142,13 +144,13 @@ modelInfo <- list(
       tmp <- vector(mode = "list", length = nrow(submodels) + 1)
       tmp[[1]] <- out
       for (j in seq(along = submodels$mstop)) {
-        this_mstop <- if (
+        if (
           submodels$prune[j] == "yes" &
             submodels$mstop[j] > modelFit$.org.mstop
         ) {
-          modelFit$.org.mstop
+          this_mstop <- modelFit$.org.mstop
         } else {
-          submodels$mstop[j]
+          this_mstop <- submodels$mstop[j]
         }
 
         tmpProb <- predict(modelFit[this_mstop], newdata, type = "response")

--- a/inst/model_sources/files/gaussprLinear.R
+++ b/inst/model_sources/files/gaussprLinear.R
@@ -1,35 +1,50 @@
-modelInfo <- list(label = "Gaussian Process",
-                  library = "kernlab",
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('parameter'),
-                                          class = c("character"),
-                                          label = c('Parameter')),
-                  grid = function(x, y, len = NULL, search = "grid") data.frame(parameter = "none"),
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    kernlab::gausspr(x = as.matrix(x), y = y,
-                                     kernel = "vanilladot",
-				     kpar = list(), ...)
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) {            
-                    out <- kernlab::predict(modelFit, as.matrix(newdata))
-                    if(is.matrix(out)) out <- out[,1]
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    kernlab::predict(modelFit, as.matrix(newdata), type = "probabilities")
-                  },
-                  predictors = function(x, ...) {
-                    if(hasTerms(x) & !is.null(x@terms))
-                    {
-                      out <- predictors.terms(x@terms)
-                    } else {
-                      out <- colnames(attr(x, "xmatrix"))
-                    }
-                    if(is.null(out)) out <- names(attr(x, "scaling")$x.scale$`scaled:center`)
-                    if(is.null(out)) out <-NA
-                    out
-                  },
-                  tags = c("Kernel Method", "Gaussian Process", "Linear Classifier"),
-                  levels = function(x) lev(x),
-                  sort = function(x) x)
+modelInfo <- list(
+  label = "Gaussian Process",
+  library = "kernlab",
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c('parameter'),
+    class = c("character"),
+    label = c('Parameter')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(parameter = "none")
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    kernlab::gausspr(
+      x = as.matrix(x),
+      y = y,
+      kernel = "vanilladot",
+      kpar = list(),
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- kernlab::predict(modelFit, as.matrix(newdata))
+    if (is.matrix(out)) {
+      out <- out[, 1]
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    kernlab::predict(modelFit, as.matrix(newdata), type = "probabilities")
+  },
+  predictors = function(x, ...) {
+    if (hasTerms(x) & !is.null(x@terms)) {
+      out <- predictors.terms(x@terms)
+    } else {
+      out <- colnames(attr(x, "xmatrix"))
+    }
+    if (is.null(out)) {
+      out <- names(attr(x, "scaling")$x.scale$`scaled:center`)
+    }
+    if (is.null(out)) {
+      out <- NA
+    }
+    out
+  },
+  tags = c("Kernel Method", "Gaussian Process", "Linear Classifier"),
+  levels = function(x) lev(x),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/gaussprPoly.R
+++ b/inst/model_sources/files/gaussprPoly.R
@@ -1,45 +1,61 @@
-modelInfo <- list(label = "Gaussian Process with Polynomial Kernel",
-                  library = "kernlab",
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('degree', 'scale'),
-                                          class = c("numeric", "numeric"),
-                                          label = c('Polynomial Degree', 'Scale')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(degree = seq(1, min(len, 3)),      
-                                         scale = 10 ^((1:len) - 4))
-                    } else {
-                      out <- data.frame(degree = sample(1:3, size = len, replace = TRUE),
-                                        scale = 10^runif(len, min = -5, 0))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    kernlab::gausspr(x = as.matrix(x), y = y,
-                                     kernel = kernlab::polydot(degree = param$degree,
-                                                       scale = param$scale,
-                                                       offset = 1), ...)         
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) {  
-                    out <- kernlab::predict(modelFit, as.matrix(newdata))
-                    if(is.matrix(out)) out <- out[,1]
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    kernlab::predict(modelFit, as.matrix(newdata), type = "probabilities")
-                  },
-                  predictors = function(x, ...) {
-                    if(hasTerms(x) & !is.null(x@terms))
-                    {
-                      out <- predictors.terms(x@terms)
-                    } else {
-                      out <- colnames(attr(x, "xmatrix"))
-                    }
-                    if(is.null(out)) out <- names(attr(x, "scaling")$xscale$`scaled:center`)
-                    if(is.null(out)) out <-NA
-                    out
-                  },
-                  tags = c("Kernel Method", "Gaussian Process", "Polynomial Model"),
-                  levels = function(x) lev(x),
-                  sort = function(x) x)
+modelInfo <- list(
+  label = "Gaussian Process with Polynomial Kernel",
+  library = "kernlab",
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c('degree', 'scale'),
+    class = c("numeric", "numeric"),
+    label = c('Polynomial Degree', 'Scale')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(degree = seq(1, min(len, 3)), scale = 10^((1:len) - 4))
+    } else {
+      out <- data.frame(
+        degree = sample(1:3, size = len, replace = TRUE),
+        scale = 10^runif(len, min = -5, 0)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    kernlab::gausspr(
+      x = as.matrix(x),
+      y = y,
+      kernel = kernlab::polydot(
+        degree = param$degree,
+        scale = param$scale,
+        offset = 1
+      ),
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- kernlab::predict(modelFit, as.matrix(newdata))
+    if (is.matrix(out)) {
+      out <- out[, 1]
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    kernlab::predict(modelFit, as.matrix(newdata), type = "probabilities")
+  },
+  predictors = function(x, ...) {
+    if (hasTerms(x) & !is.null(x@terms)) {
+      out <- predictors.terms(x@terms)
+    } else {
+      out <- colnames(attr(x, "xmatrix"))
+    }
+    if (is.null(out)) {
+      out <- names(attr(x, "scaling")$xscale$`scaled:center`)
+    }
+    if (is.null(out)) {
+      out <- NA
+    }
+    out
+  },
+  tags = c("Kernel Method", "Gaussian Process", "Polynomial Model"),
+  levels = function(x) lev(x),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/gaussprRadial.R
+++ b/inst/model_sources/files/gaussprRadial.R
@@ -1,44 +1,57 @@
-modelInfo <- list(label = "Gaussian Process with Radial Basis Function Kernel",
-                  library = "kernlab",
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('sigma'),
-                                          class = c("numeric"),
-                                          label = c('Sigma')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    sigmas <- kernlab::sigest(as.matrix(x), na.action = na.omit, scaled = TRUE)
-                    if(search == "grid") {
-                      out <- expand.grid(sigma = mean(as.vector(sigmas[-2])))
-                    } else {
-                      rng <- extendrange(log(sigmas), f = .75)
-                      out <- data.frame(sigma = exp(runif(len, min = rng[1], max = rng[2])))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    kernlab::gausspr(x = as.matrix(x), y = y,
-                                     kernel = "rbfdot",
-                                     kpar = list(sigma = param$sigma), ...)
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) {  
-                    out <- kernlab::predict(modelFit, as.matrix(newdata))
-                    if(is.matrix(out)) out <- out[,1]
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    kernlab::predict(modelFit, as.matrix(newdata), type = "probabilities")
-                  },
-                  predictors = function(x, ...) {
-                    if(hasTerms(x) & !is.null(x@terms))
-                    {
-                      out <- predictors.terms(x@terms)
-                    } else {
-                      out <- colnames(attr(x, "xmatrix"))
-                    }
-                    if(is.null(out)) out <- names(attr(x, "scaling")$x.scale$`scaled:center`)
-                    if(is.null(out)) out <-NA
-                    out
-                  },
-                  tags = c("Kernel Method", "Gaussian Process", "Radial Basis Function"),
-                  levels = function(x) lev(x),
-                  sort = function(x) x)
+modelInfo <- list(
+  label = "Gaussian Process with Radial Basis Function Kernel",
+  library = "kernlab",
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c('sigma'),
+    class = c("numeric"),
+    label = c('Sigma')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    sigmas <- kernlab::sigest(as.matrix(x), na.action = na.omit, scaled = TRUE)
+    if (search == "grid") {
+      out <- expand.grid(sigma = mean(as.vector(sigmas[-2])))
+    } else {
+      rng <- extendrange(log(sigmas), f = .75)
+      out <- data.frame(sigma = exp(runif(len, min = rng[1], max = rng[2])))
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    kernlab::gausspr(
+      x = as.matrix(x),
+      y = y,
+      kernel = "rbfdot",
+      kpar = list(sigma = param$sigma),
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- kernlab::predict(modelFit, as.matrix(newdata))
+    if (is.matrix(out)) {
+      out <- out[, 1]
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    kernlab::predict(modelFit, as.matrix(newdata), type = "probabilities")
+  },
+  predictors = function(x, ...) {
+    if (hasTerms(x) & !is.null(x@terms)) {
+      out <- predictors.terms(x@terms)
+    } else {
+      out <- colnames(attr(x, "xmatrix"))
+    }
+    if (is.null(out)) {
+      out <- names(attr(x, "scaling")$x.scale$`scaled:center`)
+    }
+    if (is.null(out)) {
+      out <- NA
+    }
+    out
+  },
+  tags = c("Kernel Method", "Gaussian Process", "Radial Basis Function"),
+  levels = function(x) lev(x),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/gbm.R
+++ b/inst/model_sources/files/gbm.R
@@ -1,193 +1,293 @@
-modelInfo <- list(label = "Stochastic Gradient Boosting",
-                  library = c("gbm", "plyr"),
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('n.trees', 'interaction.depth',
-                                                        'shrinkage', 'n.minobsinnode'),
-                                          class = rep("numeric", 4),
-                                          label = c('# Boosting Iterations', 'Max Tree Depth',
-                                                    'Shrinkage', 'Min. Terminal Node Size')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(interaction.depth = seq(1, len),
-                                         n.trees = floor((1:len) * 50),
-                                         shrinkage = .1,
-                                         n.minobsinnode = 10)
-                    } else {
-                      out <- data.frame(n.trees = floor(runif(len, min = 1, max = 5000)),
-                                        interaction.depth = sample(1:10, replace = TRUE, size = len),
-                                        shrinkage = runif(len, min = .001, max = .6),
-                                        n.minobsinnode = sample(5:25, replace = TRUE, size = len) )
-                    }
-                    out
-                  },
-                  loop = function(grid) {
-                    loop <- plyr::ddply(grid, c("shrinkage", "interaction.depth", "n.minobsinnode"),
-                                  function(x) c(n.trees = max(x$n.trees)))
-                    submodels <- vector(mode = "list", length = nrow(loop))
-                    for(i in seq(along = loop$n.trees)) {
-                      index <- which(grid$interaction.depth == loop$interaction.depth[i] &
-                                       grid$shrinkage == loop$shrinkage[i] &
-                                       grid$n.minobsinnode == loop$n.minobsinnode[i])
-                      trees <- grid[index, "n.trees"]
-                      submodels[[i]] <- data.frame(n.trees = trees[trees != loop$n.trees[i]])
-                    }
-                    list(loop = loop, submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    ## train will figure out whether we are doing classification or reggression
-                    ## from the class of the outcome and automatically specify the value of
-                    ## 'distribution' in the control file. If the user wants to over-ride this,
-                    ## this next bit will allow this.
-                    theDots <- list(...)
-                    if(any(names(theDots) == "distribution")) {
-                      modDist <- theDots$distribution
-                      theDots$distribution <- NULL
-                    } else {
-                      if(is.numeric(y)) {
-                        modDist <- "gaussian"
-                      } else modDist <- if(length(lev) == 2)  "bernoulli" else "multinomial"
-                    }
+modelInfo <- list(
+  label = "Stochastic Gradient Boosting",
+  library = c("gbm", "plyr"),
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c(
+      'n.trees',
+      'interaction.depth',
+      'shrinkage',
+      'n.minobsinnode'
+    ),
+    class = rep("numeric", 4),
+    label = c(
+      '# Boosting Iterations',
+      'Max Tree Depth',
+      'Shrinkage',
+      'Min. Terminal Node Size'
+    )
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        interaction.depth = seq(1, len),
+        n.trees = floor((1:len) * 50),
+        shrinkage = .1,
+        n.minobsinnode = 10
+      )
+    } else {
+      out <- data.frame(
+        n.trees = floor(runif(len, min = 1, max = 5000)),
+        interaction.depth = sample(1:10, replace = TRUE, size = len),
+        shrinkage = runif(len, min = .001, max = .6),
+        n.minobsinnode = sample(5:25, replace = TRUE, size = len)
+      )
+    }
+    out
+  },
+  loop = function(grid) {
+    loop <- plyr::ddply(
+      grid,
+      c("shrinkage", "interaction.depth", "n.minobsinnode"),
+      function(x) c(n.trees = max(x$n.trees))
+    )
+    submodels <- vector(mode = "list", length = nrow(loop))
+    for (i in seq(along = loop$n.trees)) {
+      index <- which(
+        grid$interaction.depth == loop$interaction.depth[i] &
+          grid$shrinkage == loop$shrinkage[i] &
+          grid$n.minobsinnode == loop$n.minobsinnode[i]
+      )
+      trees <- grid[index, "n.trees"]
+      submodels[[i]] <- data.frame(n.trees = trees[trees != loop$n.trees[i]])
+    }
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    ## train will figure out whether we are doing classification or reggression
+    ## from the class of the outcome and automatically specify the value of
+    ## 'distribution' in the control file. If the user wants to over-ride this,
+    ## this next bit will allow this.
+    theDots <- list(...)
+    if (any(names(theDots) == "distribution")) {
+      modDist <- theDots$distribution
+      theDots$distribution <- NULL
+    } else {
+      if (is.numeric(y)) {
+        modDist <- "gaussian"
+      } else {
+        modDist <- if (length(lev) == 2) "bernoulli" else "multinomial"
+      }
+    }
 
-                    ## check to see if weights were passed in (and availible)
-                    if(!is.null(wts)) theDots$w <- wts
-                    if(is.factor(y) && length(lev) == 2) y <- ifelse(y == lev[1], 1, 0)
-                    if(!is.data.frame(x) | inherits(x, "tbl_df"))
-                      x <- as.data.frame(x, stringsAsFactors = TRUE)
+    ## check to see if weights were passed in (and availible)
+    if (!is.null(wts)) {
+      theDots$w <- wts
+    }
+    if (is.factor(y) && length(lev) == 2) {
+      y <- ifelse(y == lev[1], 1, 0)
+    }
+    if (!is.data.frame(x) | inherits(x, "tbl_df")) {
+      x <- as.data.frame(x, stringsAsFactors = TRUE)
+    }
 
-                    modArgs <- list(x = x,
-                                    y = y,
-                                    interaction.depth = param$interaction.depth,
-                                    n.trees = param$n.trees,
-                                    shrinkage = param$shrinkage,
-                                    n.minobsinnode = param$n.minobsinnode,
-                                    distribution = modDist)
-                    if(any(names(theDots) == "family")) modArgs$distribution <- NULL
+    modArgs <- list(
+      x = x,
+      y = y,
+      interaction.depth = param$interaction.depth,
+      n.trees = param$n.trees,
+      shrinkage = param$shrinkage,
+      n.minobsinnode = param$n.minobsinnode,
+      distribution = modDist
+    )
+    if (any(names(theDots) == "family")) {
+      modArgs$distribution <- NULL
+    }
 
-                    if(length(theDots) > 0) modArgs <- c(modArgs, theDots)
+    if (length(theDots) > 0) {
+      modArgs <- c(modArgs, theDots)
+    }
 
-                    do.call(gbm::gbm.fit, modArgs)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata, type = "response",
-                                   n.trees = modelFit$tuneValue$n.trees)
-                    out[is.nan(out)] <- NA
-                    out <- switch(modelFit$distribution$name,
-                                  multinomial = {
-                                    ## The output is a 3D array that is
-                                    ## nxcx1
-                                    colnames(out[,,1,drop=FALSE])[apply(out[,,1,drop=FALSE], 1, which.max)]
-                                  },
-                                  bernoulli =, adaboost =, huberized = {
-                                    ## The data come back as an nx1 vector
-                                    ## of probabilities.
-                                    ifelse(out >= .5,
-                                           modelFit$obsLevels[1],
-                                           modelFit$obsLevels[2])
-                                  },
-                                  gaussian =, laplace =, tdist =, poisson =, quantile = {
-                                    out
-                                  })
+    do.call(gbm::gbm.fit, modArgs)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(
+      modelFit,
+      newdata,
+      type = "response",
+      n.trees = modelFit$tuneValue$n.trees
+    )
+    out[is.nan(out)] <- NA
+    out <- switch(
+      modelFit$distribution$name,
+      multinomial = {
+        ## The output is a 3D array that is
+        ## nxcx1
+        colnames(out[,, 1, drop = FALSE])[apply(
+          out[,, 1, drop = FALSE],
+          1,
+          which.max
+        )]
+      },
+      bernoulli = ,
+      adaboost = ,
+      huberized = {
+        ## The data come back as an nx1 vector
+        ## of probabilities.
+        ifelse(out >= .5, modelFit$obsLevels[1], modelFit$obsLevels[2])
+      },
+      gaussian = ,
+      laplace = ,
+      tdist = ,
+      poisson = ,
+      quantile = {
+        out
+      }
+    )
 
-                    if(!is.null(submodels)) {
-                      tmp <- predict(modelFit, newdata, type = "response", n.trees = submodels$n.trees)
-                      out <- switch(modelFit$distribution$name,
-                                    multinomial = {
-                                      ## The output is a 3D array that is
-                                      ## nxcx1
-                                      lvl <- colnames(tmp[,,1,drop=FALSE])
-                                      tmp <- apply(tmp, 3, function(x) apply(x, 1, which.max))
-                                      if(is.vector(tmp)) tmp <- matrix(tmp, nrow = 1)
-                                      tmp <- t(apply(tmp, 1, function(x, lvl) lvl[x], lvl = lvl))
-                                      if(nrow(tmp) == 1 & nrow(newdata) > 1) tmp <- t(tmp)
-                                      tmp <- as.list(as.data.frame(tmp, stringsAsFactors = FALSE))
-                                      c(list(out), tmp)
-                                    },
-                                    bernoulli =, adaboost =, huberized = {
-                                      ## Now we have a nxt matrix
-                                      tmp <- ifelse(tmp >= .5,
-                                                    modelFit$obsLevels[1],
-                                                    modelFit$obsLevels[2])
-                                      tmp <- as.list(as.data.frame(tmp, stringsAsFactors = FALSE))
-                                      c(list(out), tmp)
-                                    },
-                                    gaussian =, laplace =, tdist =,  poisson =, quantile=  {
-                                      ## an nxt matrix
-                                      tmp <- as.list(as.data.frame(tmp, stringsAsFactors = TRUE))
-                                      c(list(out), tmp)
-                                    })
-                    }
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata, type = "response",
-                                   n.trees = modelFit$tuneValue$n.trees)
+    if (!is.null(submodels)) {
+      tmp <- predict(
+        modelFit,
+        newdata,
+        type = "response",
+        n.trees = submodels$n.trees
+      )
+      out <- switch(
+        modelFit$distribution$name,
+        multinomial = {
+          ## The output is a 3D array that is
+          ## nxcx1
+          lvl <- colnames(tmp[,, 1, drop = FALSE])
+          tmp <- apply(tmp, 3, function(x) apply(x, 1, which.max))
+          if (is.vector(tmp)) {
+            tmp <- matrix(tmp, nrow = 1)
+          }
+          tmp <- t(apply(tmp, 1, function(x, lvl) lvl[x], lvl = lvl))
+          if (nrow(tmp) == 1 & nrow(newdata) > 1) {
+            tmp <- t(tmp)
+          }
+          tmp <- as.list(as.data.frame(tmp, stringsAsFactors = FALSE))
+          c(list(out), tmp)
+        },
+        bernoulli = ,
+        adaboost = ,
+        huberized = {
+          ## Now we have a nxt matrix
+          tmp <- ifelse(tmp >= .5, modelFit$obsLevels[1], modelFit$obsLevels[2])
+          tmp <- as.list(as.data.frame(tmp, stringsAsFactors = FALSE))
+          c(list(out), tmp)
+        },
+        gaussian = ,
+        laplace = ,
+        tdist = ,
+        poisson = ,
+        quantile = {
+          ## an nxt matrix
+          tmp <- as.list(as.data.frame(tmp, stringsAsFactors = TRUE))
+          c(list(out), tmp)
+        }
+      )
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(
+      modelFit,
+      newdata,
+      type = "response",
+      n.trees = modelFit$tuneValue$n.trees
+    )
 
-                    out[is.nan(out)] <- NA
+    out[is.nan(out)] <- NA
 
-                    out <- switch(modelFit$distribution$name,
-                                  multinomial = {
-                                    out <- if(dim(out)[3] == 1) as.data.frame(out, stringsAsFactors = TRUE) else out[,,1]
-                                    colnames(out) <- modelFit$obsLevels
-                                    out
-                                  },
-                                  bernoulli =, adaboost =, huberized = {
-                                    ## The data come back as an nx1 vector
-                                    ## of probabilities.
-                                    out <- cbind(out, 1 - out)
-                                    colnames(out) <- modelFit$obsLevels
-                                    out
-                                  },
-                                  gaussian =, laplace =, tdist =,  poisson = {
-                                    out
-                                  })
+    out <- switch(
+      modelFit$distribution$name,
+      multinomial = {
+        out <- if (dim(out)[3] == 1) {
+          as.data.frame(out, stringsAsFactors = TRUE)
+        } else {
+          out[,, 1]
+        }
+        colnames(out) <- modelFit$obsLevels
+        out
+      },
+      bernoulli = ,
+      adaboost = ,
+      huberized = {
+        ## The data come back as an nx1 vector
+        ## of probabilities.
+        out <- cbind(out, 1 - out)
+        colnames(out) <- modelFit$obsLevels
+        out
+      },
+      gaussian = ,
+      laplace = ,
+      tdist = ,
+      poisson = {
+        out
+      }
+    )
 
-                    if(!is.null(submodels)) {
-                      tmp <- predict(modelFit, newdata, type = "response", n.trees = submodels$n.trees)
-                      tmp <- switch(modelFit$distribution$name,
-                                    multinomial = {
-                                      ## The output is a 3D array that is
-                                      ## nxcxt
-                                      apply(tmp, 3, function(x) data.frame(x))
-                                    },
-                                    bernoulli =, adaboost =, huberized = {
-                                      ## The data come back as an nx1t matrix
-                                      ## of probabilities.
-                                      tmp <- as.list(as.data.frame(tmp, stringsAsFactors = TRUE))
-                                      lapply(tmp, function(x, lvl) {
-                                        x <- cbind(x, 1 - x)
-                                        colnames(x) <- lvl
-                                        x
-                                      }, lvl = modelFit$obsLevels)
-                                    })
-                      out <- c(list(out), tmp)
-                    }
-                    out
-                  },
-                  predictors = function(x, ...) {
-                    vi <- relative.influence(x, n.trees = x$tuneValue$n.trees)
-                    names(vi)[vi > 0]
-                  },
-                  varImp = function(object, numTrees = NULL, ...) {
-                    if(is.null(numTrees)) numTrees <- object$tuneValue$n.trees
-                    varImp <- relative.influence(object, n.trees = numTrees)
-                    out <- data.frame(varImp)
-                    colnames(out) <- "Overall"
-                    rownames(out) <- object$var.names
-                    out
-                  },
-                  levels = function(x) {
-                    if(x$distribution$name %in% c("gaussian", "laplace", "tdist"))
-                      return(NULL)
-                    if(is.null(x$classes)) {
-                      out <- if(any(names(x) == "obsLevels")) x$obsLevels else NULL
-                    } else {
-                      out <- x$classes
-                    }
-                    out
-                  },
-                  tags = c("Tree-Based Model", "Boosting", "Ensemble Model", "Implicit Feature Selection", "Accepts Case Weights"),
-                  sort = function(x) {
-                    # This is a toss-up, but the # trees probably adds
-                    # complexity faster than number of splits
-                    x[order(x$n.trees, x$interaction.depth, x$shrinkage),]
-                  })
+    if (!is.null(submodels)) {
+      tmp <- predict(
+        modelFit,
+        newdata,
+        type = "response",
+        n.trees = submodels$n.trees
+      )
+      tmp <- switch(
+        modelFit$distribution$name,
+        multinomial = {
+          ## The output is a 3D array that is
+          ## nxcxt
+          apply(tmp, 3, function(x) data.frame(x))
+        },
+        bernoulli = ,
+        adaboost = ,
+        huberized = {
+          ## The data come back as an nx1t matrix
+          ## of probabilities.
+          tmp <- as.list(as.data.frame(tmp, stringsAsFactors = TRUE))
+          lapply(
+            tmp,
+            function(x, lvl) {
+              x <- cbind(x, 1 - x)
+              colnames(x) <- lvl
+              x
+            },
+            lvl = modelFit$obsLevels
+          )
+        }
+      )
+      out <- c(list(out), tmp)
+    }
+    out
+  },
+  predictors = function(x, ...) {
+    vi <- relative.influence(x, n.trees = x$tuneValue$n.trees)
+    names(vi)[vi > 0]
+  },
+  varImp = function(object, numTrees = NULL, ...) {
+    if (is.null(numTrees)) {
+      numTrees <- object$tuneValue$n.trees
+    }
+    varImp <- relative.influence(object, n.trees = numTrees)
+    out <- data.frame(varImp)
+    colnames(out) <- "Overall"
+    rownames(out) <- object$var.names
+    out
+  },
+  levels = function(x) {
+    if (x$distribution$name %in% c("gaussian", "laplace", "tdist")) {
+      return(NULL)
+    }
+    if (is.null(x$classes)) {
+      out <- if (any(names(x) == "obsLevels")) x$obsLevels else NULL
+    } else {
+      out <- x$classes
+    }
+    out
+  },
+  tags = c(
+    "Tree-Based Model",
+    "Boosting",
+    "Ensemble Model",
+    "Implicit Feature Selection",
+    "Accepts Case Weights"
+  ),
+  sort = function(x) {
+    # This is a toss-up, but the # trees probably adds
+    # complexity faster than number of splits
+    x[order(x$n.trees, x$interaction.depth, x$shrinkage), ]
+  }
+)

--- a/inst/model_sources/files/gbm.R
+++ b/inst/model_sources/files/gbm.R
@@ -66,7 +66,11 @@ modelInfo <- list(
       if (is.numeric(y)) {
         modDist <- "gaussian"
       } else {
-        modDist <- if (length(lev) == 2) "bernoulli" else "multinomial"
+        if (length(lev) == 2) {
+          modDist <- "bernoulli"
+        } else {
+          modDist <- "multinomial"
+        }
       }
     }
 
@@ -193,10 +197,10 @@ modelInfo <- list(
     out <- switch(
       modelFit$distribution$name,
       multinomial = {
-        out <- if (dim(out)[3] == 1) {
-          as.data.frame(out, stringsAsFactors = TRUE)
+        if (dim(out)[3] == 1) {
+          out <- as.data.frame(out, stringsAsFactors = TRUE)
         } else {
-          out[,, 1]
+          out <- out[,, 1]
         }
         colnames(out) <- modelFit$obsLevels
         out
@@ -272,7 +276,11 @@ modelInfo <- list(
       return(NULL)
     }
     if (is.null(x$classes)) {
-      out <- if (any(names(x) == "obsLevels")) x$obsLevels else NULL
+      if (any(names(x) == "obsLevels")) {
+        out <- x$obsLevels
+      } else {
+        out <- NULL
+      }
     } else {
       out <- x$classes
     }

--- a/inst/model_sources/files/gbm_h2o.R
+++ b/inst/model_sources/files/gbm_h2o.R
@@ -1,72 +1,106 @@
-modelInfo <- list(label = "Gradient Boosting Machines",
-                  library = "h2o",
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('ntrees', 'max_depth', 'min_rows',
-                                                        'learn_rate', 'col_sample_rate'),
-                                          class = rep("numeric", 5),
-                                          label = c('# Boosting Iterations', 'Max Tree Depth',
-                                                    'Min. Terminal Node Size', 'Shrinkage',
-                                                    '#Randomly Selected Predictors')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(max_depth = seq(1, len),
-                                         ntrees = floor((1:len) * 50),
-                                         learn_rate = .1,
-                                         min_rows = 10,
-                                         col_sample_rate = 1)
-                    } else {
-                      out <- data.frame(ntrees = floor(runif(len, min = 1, max = 5000)),
-                                        max_depth = sample(1:10, replace = TRUE, size = len),
-                                        learn_rate = runif(len, min = .001, max = .6),
-                                        min_rows = sample(5:25, replace = TRUE, size = len),
-                                        col_sample_rate = runif(len))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    lvs <- length(levels(y))
-                    fam <- "gaussian"
-                    if(lvs == 2) fam <- "bernoulli"
-                    if(lvs >  2) fam <- "multinomial" ## intercept ... for family arg
+modelInfo <- list(
+  label = "Gradient Boosting Machines",
+  library = "h2o",
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c(
+      'ntrees',
+      'max_depth',
+      'min_rows',
+      'learn_rate',
+      'col_sample_rate'
+    ),
+    class = rep("numeric", 5),
+    label = c(
+      '# Boosting Iterations',
+      'Max Tree Depth',
+      'Min. Terminal Node Size',
+      'Shrinkage',
+      '#Randomly Selected Predictors'
+    )
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        max_depth = seq(1, len),
+        ntrees = floor((1:len) * 50),
+        learn_rate = .1,
+        min_rows = 10,
+        col_sample_rate = 1
+      )
+    } else {
+      out <- data.frame(
+        ntrees = floor(runif(len, min = 1, max = 5000)),
+        max_depth = sample(1:10, replace = TRUE, size = len),
+        learn_rate = runif(len, min = .001, max = .6),
+        min_rows = sample(5:25, replace = TRUE, size = len),
+        col_sample_rate = runif(len)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    lvs <- length(levels(y))
+    fam <- "gaussian"
+    if (lvs == 2) {
+      fam <- "bernoulli"
+    }
+    if (lvs > 2) {
+      fam <- "multinomial"
+    } ## intercept ... for family arg
 
-                    dat <- if(!is.data.frame(x)) as.data.frame(x, stringsAsFactors = TRUE) else x
-                    dat$.outcome <- y
-                    frame_name <- paste0("tmp_gbm_dat_",sample.int(100000, 1))
-                    tmp_train_dat = h2o::as.h2o(dat, destination_frame = frame_name)
+    dat <- if (!is.data.frame(x)) {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    } else {
+      x
+    }
+    dat$.outcome <- y
+    frame_name <- paste0("tmp_gbm_dat_", sample.int(100000, 1))
+    tmp_train_dat = h2o::as.h2o(dat, destination_frame = frame_name)
 
-                    out <- h2o::h2o.gbm(x = colnames(x), y = ".outcome",
-                                        training_frame = tmp_train_dat,
-                                        distribution = fam,
-                                        ntrees = param$ntrees, max_depth = param$max_depth,
-                                        learn_rate = param$learn_rate, min_rows = param$min_rows,
-                                        col_sample_rate = param$col_sample_rate,
-                                        ...)
-                    h2o::h2o.getModel(out@model_id)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    frame_name <- paste0("new_gbm_dat_",sample.int(100000, 1))
-                    newdata <- h2o::as.h2o(newdata, destination_frame = frame_name)
-                    as.data.frame(predict(modelFit, newdata), stringsAsFactors = TRUE)[,1]
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    frame_name <- paste0("new_gbm_dat_",sample.int(100000, 1))
-                    newdata <- h2o::as.h2o(newdata, destination_frame = frame_name)
-                    as.data.frame(predict(modelFit, newdata), stringsAsFactors = TRUE)[,-1]
-                  },
-                  predictors = function(x, ...) {
-                    out <- as.data.frame(h2o::h2o.varimp(x), stringsAsFactors = TRUE)
-                    out <- subset(out, relative_importance > 0)
-                    as.character(out$variable)
-                  },
-                  varImp = function(object, ...) {
-                    out <- as.data.frame(h2o::h2o.varimp(object), stringsAsFactors = TRUE)
-                    colnames(out)[colnames(out) == "relative_importance"] <- "Overall"
-                    rownames(out) <- out$variable
-                    out[, c("Overall"), drop = FALSE]
-                  },
-                  levels = function(x) x@model$training_metrics@metrics$domain,
-                  tags = c("Tree-Based Model", "Boosting",
-                           "Ensemble Model", "Implicit Feature Selection"),
-                  sort = function(x) x[order(x$ntrees, x$max_depth, x$learn_rate),],
-                  trim = NULL)
+    out <- h2o::h2o.gbm(
+      x = colnames(x),
+      y = ".outcome",
+      training_frame = tmp_train_dat,
+      distribution = fam,
+      ntrees = param$ntrees,
+      max_depth = param$max_depth,
+      learn_rate = param$learn_rate,
+      min_rows = param$min_rows,
+      col_sample_rate = param$col_sample_rate,
+      ...
+    )
+    h2o::h2o.getModel(out@model_id)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    frame_name <- paste0("new_gbm_dat_", sample.int(100000, 1))
+    newdata <- h2o::as.h2o(newdata, destination_frame = frame_name)
+    as.data.frame(predict(modelFit, newdata), stringsAsFactors = TRUE)[, 1]
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    frame_name <- paste0("new_gbm_dat_", sample.int(100000, 1))
+    newdata <- h2o::as.h2o(newdata, destination_frame = frame_name)
+    as.data.frame(predict(modelFit, newdata), stringsAsFactors = TRUE)[, -1]
+  },
+  predictors = function(x, ...) {
+    out <- as.data.frame(h2o::h2o.varimp(x), stringsAsFactors = TRUE)
+    out <- subset(out, relative_importance > 0)
+    as.character(out$variable)
+  },
+  varImp = function(object, ...) {
+    out <- as.data.frame(h2o::h2o.varimp(object), stringsAsFactors = TRUE)
+    colnames(out)[colnames(out) == "relative_importance"] <- "Overall"
+    rownames(out) <- out$variable
+    out[, c("Overall"), drop = FALSE]
+  },
+  levels = function(x) x@model$training_metrics@metrics$domain,
+  tags = c(
+    "Tree-Based Model",
+    "Boosting",
+    "Ensemble Model",
+    "Implicit Feature Selection"
+  ),
+  sort = function(x) x[order(x$ntrees, x$max_depth, x$learn_rate), ],
+  trim = NULL
+)

--- a/inst/model_sources/files/gbm_h2o.R
+++ b/inst/model_sources/files/gbm_h2o.R
@@ -50,10 +50,10 @@ modelInfo <- list(
       fam <- "multinomial"
     } ## intercept ... for family arg
 
-    dat <- if (!is.data.frame(x)) {
-      as.data.frame(x, stringsAsFactors = TRUE)
+    if (!is.data.frame(x)) {
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     } else {
-      x
+      dat <- x
     }
     dat$.outcome <- y
     frame_name <- paste0("tmp_gbm_dat_", sample.int(100000, 1))

--- a/inst/model_sources/files/gcvEarth.R
+++ b/inst/model_sources/files/gcvEarth.R
@@ -1,95 +1,106 @@
-modelInfo <- list(label = "Multivariate Adaptive Regression Splines",
-                  library = "earth",
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('degree'),
-                                          class = c("numeric"),
-                                          label = c('Product Degree')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    data.frame(degree = 1)
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    require(earth)
-                    theDots <- list(...)
-                    theDots$keepxy <- TRUE 
-                    
-                    ## pass in any model weights
-                    if (!is.null(wts)) theDots$weights <- wts
-                    
-                    modelArgs <- c(list(x = x, y = y, degree = param$degree), theDots)
-                    
-                    if (is.factor(y) & !any(names(theDots) == "glm")) {
-                      modelArgs$glm <- list(family = binomial, maxit = 100)
-                    }
-                    
-                    tmp <- do.call(earth::earth, modelArgs)
-                    
-                    tmp$call["degree"] <-  param$degree
-                    tmp 
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if (modelFit$problemType == "Classification") {
-                      out <- earth:::predict.earth(modelFit, newdata, type = "class")
-                    } else {
-                      out <- earth:::predict.earth(modelFit, newdata)
-                    }
-                    as.vector(out)            
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- earth:::predict.earth(modelFit, newdata, type = "response")
-                    if (ncol(out) > 1) {
-                      out <- t(apply(out, 1, function(x) x / sum(x)))
-                    } else {
-                      out <- cbind(1 - out[, 1], out[, 1])
-                      colnames(out) <- modelFit$obsLevels
-                    }
-                    as.data.frame(out, stringsAsFactors = TRUE)
-                  },
-                  predictors = function(x, ...) {
-                    vi <- varImp(x)
-                    notZero <- sort(unique(unlist(lapply(vi, function(x) which(x > 0)))))
-                    if (length(notZero) > 0) rownames(vi)[notZero] else NULL
-                  },
-                  varImp = function(object, value = "gcv", ...) {
-                    earthImp <- earth::evimp(object)
-                    if (!is.matrix(earthImp)) earthImp <- t(as.matrix(earthImp))
-                    
-                    # get other variable names and padd with zeros
-                    
-                    out <- earthImp
-                    perfCol <- which(colnames(out) == value)
-                    
-                    increaseInd <- out[,perfCol + 1]
-                    out <- as.data.frame(out[,perfCol, drop = FALSE], stringsAsFactors = TRUE)  
-                    colnames(out) <- "Overall"
-                    
-                    # At this point, we still may have some variables
-                    # that are not in the model but have non-zero
-                    # importance. We'll set those to zero
-                    if (any(earthImp[,"used"] == 0)) {
-                      dropList <- grep("-unused", rownames(earthImp), value = TRUE)
-                      out$Overall[rownames(out) %in% dropList] <- 0
-                    }
-                    rownames(out) <- gsub("-unused", "", rownames(out))                
-                    out <- as.data.frame(out, stringsAsFactors = TRUE)
-                    # fill in zeros for any variabels not  in out
-                    
-                    xNames <- object$namesx.org
-                    if (any(!(xNames %in% rownames(out)))) {
-                      xNames <- xNames[!(xNames %in% rownames(out))]
-                      others <- data.frame(
-                        Overall = rep(0, length(xNames)),
-                        row.names = xNames)
-                      out <- rbind(out, others)
-                    }
-                    out
-                  },
-                  levels = function(x) x$levels,
-                  tags = c("Multivariate Adaptive Regression Splines", 
-                           "Implicit Feature Selection", 
-                           "Accepts Case Weights"),
-                  notes = paste(
-                    "Unlike other packages used by `train`, the `earth`",
-                    "package is fully loaded when this model is used."
-                  ),                  
-                  sort = function(x) x[order(x$degree),])
+modelInfo <- list(
+  label = "Multivariate Adaptive Regression Splines",
+  library = "earth",
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c('degree'),
+    class = c("numeric"),
+    label = c('Product Degree')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(degree = 1)
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    require(earth)
+    theDots <- list(...)
+    theDots$keepxy <- TRUE
+
+    ## pass in any model weights
+    if (!is.null(wts)) {
+      theDots$weights <- wts
+    }
+
+    modelArgs <- c(list(x = x, y = y, degree = param$degree), theDots)
+
+    if (is.factor(y) & !any(names(theDots) == "glm")) {
+      modelArgs$glm <- list(family = binomial, maxit = 100)
+    }
+
+    tmp <- do.call(earth::earth, modelArgs)
+
+    tmp$call["degree"] <- param$degree
+    tmp
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (modelFit$problemType == "Classification") {
+      out <- earth:::predict.earth(modelFit, newdata, type = "class")
+    } else {
+      out <- earth:::predict.earth(modelFit, newdata)
+    }
+    as.vector(out)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- earth:::predict.earth(modelFit, newdata, type = "response")
+    if (ncol(out) > 1) {
+      out <- t(apply(out, 1, function(x) x / sum(x)))
+    } else {
+      out <- cbind(1 - out[, 1], out[, 1])
+      colnames(out) <- modelFit$obsLevels
+    }
+    as.data.frame(out, stringsAsFactors = TRUE)
+  },
+  predictors = function(x, ...) {
+    vi <- varImp(x)
+    notZero <- sort(unique(unlist(lapply(vi, function(x) which(x > 0)))))
+    if (length(notZero) > 0) rownames(vi)[notZero] else NULL
+  },
+  varImp = function(object, value = "gcv", ...) {
+    earthImp <- earth::evimp(object)
+    if (!is.matrix(earthImp)) {
+      earthImp <- t(as.matrix(earthImp))
+    }
+
+    # get other variable names and padd with zeros
+
+    out <- earthImp
+    perfCol <- which(colnames(out) == value)
+
+    increaseInd <- out[, perfCol + 1]
+    out <- as.data.frame(out[, perfCol, drop = FALSE], stringsAsFactors = TRUE)
+    colnames(out) <- "Overall"
+
+    # At this point, we still may have some variables
+    # that are not in the model but have non-zero
+    # importance. We'll set those to zero
+    if (any(earthImp[, "used"] == 0)) {
+      dropList <- grep("-unused", rownames(earthImp), value = TRUE)
+      out$Overall[rownames(out) %in% dropList] <- 0
+    }
+    rownames(out) <- gsub("-unused", "", rownames(out))
+    out <- as.data.frame(out, stringsAsFactors = TRUE)
+    # fill in zeros for any variabels not  in out
+
+    xNames <- object$namesx.org
+    if (any(!(xNames %in% rownames(out)))) {
+      xNames <- xNames[!(xNames %in% rownames(out))]
+      others <- data.frame(
+        Overall = rep(0, length(xNames)),
+        row.names = xNames
+      )
+      out <- rbind(out, others)
+    }
+    out
+  },
+  levels = function(x) x$levels,
+  tags = c(
+    "Multivariate Adaptive Regression Splines",
+    "Implicit Feature Selection",
+    "Accepts Case Weights"
+  ),
+  notes = paste(
+    "Unlike other packages used by `train`, the `earth`",
+    "package is fully loaded when this model is used."
+  ),
+  sort = function(x) x[order(x$degree), ]
+)

--- a/inst/model_sources/files/gcvEarth.R
+++ b/inst/model_sources/files/gcvEarth.R
@@ -53,7 +53,11 @@ modelInfo <- list(
   predictors = function(x, ...) {
     vi <- varImp(x)
     notZero <- sort(unique(unlist(lapply(vi, function(x) which(x > 0)))))
-    if (length(notZero) > 0) rownames(vi)[notZero] else NULL
+    if (length(notZero) > 0) {
+      rownames(vi)[notZero]
+    } else {
+      NULL
+    }
   },
   varImp = function(object, value = "gcv", ...) {
     earthImp <- earth::evimp(object)

--- a/inst/model_sources/files/glm.R
+++ b/inst/model_sources/files/glm.R
@@ -1,88 +1,112 @@
-modelInfo <- list(label = "Generalized Linear Model",
-                  library = NULL,
-                  loop = NULL,
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = "parameter",
-                                          class = "character",
-                                          label = "parameter"),
-                  grid = function(x, y, len = NULL, search = "grid") data.frame(parameter = "none"),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    if(length(levels(y)) > 2) stop("glm models can only use 2-class outcomes")
+modelInfo <- list(
+  label = "Generalized Linear Model",
+  library = NULL,
+  loop = NULL,
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = "parameter",
+    class = "character",
+    label = "parameter"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(parameter = "none")
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    if (length(levels(y)) > 2) {
+      stop("glm models can only use 2-class outcomes")
+    }
 
-                    theDots <- list(...)
-                    if(!any(names(theDots) == "family"))
-                    {
-                      theDots$family <- if(is.factor(y)) binomial() else gaussian()
-                    }
+    theDots <- list(...)
+    if (!any(names(theDots) == "family")) {
+      theDots$family <- if (is.factor(y)) binomial() else gaussian()
+    }
 
-                    ## pass in any model weights
-                    if(!is.null(wts)) theDots$weights <- wts
+    ## pass in any model weights
+    if (!is.null(wts)) {
+      theDots$weights <- wts
+    }
 
-                    modelArgs <- c(list(formula = as.formula(".outcome ~ ."), data = dat), theDots)
+    modelArgs <- c(
+      list(formula = as.formula(".outcome ~ ."), data = dat),
+      theDots
+    )
 
-                    out <- do.call("glm", modelArgs)
-                    ## When we use do.call(), the call infformation can contain a ton of
-                    ## information. Inlcuding the contenst of the data. We eliminate it.
-                    out$call <- NULL
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    if(modelFit$problemType == "Classification") {
-                      probs <-  predict(modelFit, newdata, type = "response")
-                      out <- ifelse(probs < .5,
-                                    modelFit$obsLevel[1],
-                                    modelFit$obsLevel[2])
-                    } else {
-                      out <- predict(modelFit, newdata, type = "response")
-                    }
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL){
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    out <- predict(modelFit, newdata, type = "response")
-                    out <- cbind(1-out, out)
-                    ## glm models the second factor level, we treat the first as the
-                    ## event of interest. See Details in ?glm
-                    dimnames(out)[[2]] <-  modelFit$obsLevels
-                    out
-                  },
-                  varImp = function(object, ...) {
-                    values <- summary(object)$coef
-                    varImps <-  abs(values[-1, grep("value$", colnames(values)), drop = FALSE])
-                    vimp <- data.frame(varImps)
-                    colnames(vimp) <- "Overall"
-                    if(!is.null(names(varImps))) rownames(vimp) <- names(varImps)
-                    vimp
-                  },
-                  predictors = function(x, ...) predictors(x$terms),
-                  levels = function(x) if(any(names(x) == "obsLevels")) x$obsLevels else NULL,
-                  trim = function(x) {
-                    #Based off: http://www.win-vector.com/blog/2014/05/trimming-the-fat-from-glm-models-in-r/
-                    x$y = c()
-                    x$model = c()
+    out <- do.call("glm", modelArgs)
+    ## When we use do.call(), the call infformation can contain a ton of
+    ## information. Inlcuding the contenst of the data. We eliminate it.
+    out$call <- NULL
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    if (modelFit$problemType == "Classification") {
+      probs <- predict(modelFit, newdata, type = "response")
+      out <- ifelse(probs < .5, modelFit$obsLevel[1], modelFit$obsLevel[2])
+    } else {
+      out <- predict(modelFit, newdata, type = "response")
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    out <- predict(modelFit, newdata, type = "response")
+    out <- cbind(1 - out, out)
+    ## glm models the second factor level, we treat the first as the
+    ## event of interest. See Details in ?glm
+    dimnames(out)[[2]] <- modelFit$obsLevels
+    out
+  },
+  varImp = function(object, ...) {
+    values <- summary(object)$coef
+    varImps <- abs(values[-1, grep("value$", colnames(values)), drop = FALSE])
+    vimp <- data.frame(varImps)
+    colnames(vimp) <- "Overall"
+    if (!is.null(names(varImps))) {
+      rownames(vimp) <- names(varImps)
+    }
+    vimp
+  },
+  predictors = function(x, ...) predictors(x$terms),
+  levels = function(x) if (any(names(x) == "obsLevels")) x$obsLevels else NULL,
+  trim = function(x) {
+    #Based off: http://www.win-vector.com/blog/2014/05/trimming-the-fat-from-glm-models-in-r/
+    x$y = c()
+    x$model = c()
 
-                    x$residuals = c()
-                    x$fitted.values = c()
-                    x$effects = c()
-                    x$qr$qr = c()
-                    x$linear.predictors = c()
-                    x$weights = c()
-                    x$prior.weights = c()
-                    x$data = c()
+    x$residuals = c()
+    x$fitted.values = c()
+    x$effects = c()
+    x$qr$qr = c()
+    x$linear.predictors = c()
+    x$weights = c()
+    x$prior.weights = c()
+    x$data = c()
 
-                    x$family$variance = c()
-                    x$family$dev.resids = c()
-                    x$family$aic = c()
-                    x$family$validmu = c()
-                    x$family$simulate = c()
-                    attr(x$terms,".Environment") = c()
-                    attr(x$formula,".Environment") = c()
+    x$family$variance = c()
+    x$family$dev.resids = c()
+    x$family$aic = c()
+    x$family$validmu = c()
+    x$family$simulate = c()
+    attr(x$terms, ".Environment") = c()
+    attr(x$formula, ".Environment") = c()
 
-                    x
-                  },
-                  tags = c("Generalized Linear Model", "Linear Classifier", 
-                           "Two Class Only", "Accepts Case Weights"),
-                  sort = function(x) x)
+    x
+  },
+  tags = c(
+    "Generalized Linear Model",
+    "Linear Classifier",
+    "Two Class Only",
+    "Accepts Case Weights"
+  ),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/glm.R
+++ b/inst/model_sources/files/glm.R
@@ -12,10 +12,10 @@ modelInfo <- list(
     data.frame(parameter = "none")
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     if (length(levels(y)) > 2) {
@@ -24,7 +24,11 @@ modelInfo <- list(
 
     theDots <- list(...)
     if (!any(names(theDots) == "family")) {
-      theDots$family <- if (is.factor(y)) binomial() else gaussian()
+      if (is.factor(y)) {
+        theDots$family <- binomial()
+      } else {
+        theDots$family <- gaussian()
+      }
     }
 
     ## pass in any model weights
@@ -77,7 +81,13 @@ modelInfo <- list(
     vimp
   },
   predictors = function(x, ...) predictors(x$terms),
-  levels = function(x) if (any(names(x) == "obsLevels")) x$obsLevels else NULL,
+  levels = function(x) {
+    if (any(names(x) == "obsLevels")) {
+      x$obsLevels
+    } else {
+      NULL
+    }
+  },
   trim = function(x) {
     #Based off: http://www.win-vector.com/blog/2014/05/trimming-the-fat-from-glm-models-in-r/
     x$y = c()

--- a/inst/model_sources/files/glm.nb.R
+++ b/inst/model_sources/files/glm.nb.R
@@ -16,10 +16,10 @@ modelInfo <- list(
     ]
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
 

--- a/inst/model_sources/files/glm.nb.R
+++ b/inst/model_sources/files/glm.nb.R
@@ -1,70 +1,93 @@
-modelInfo <- list(label = "Negative Binomial Generalized Linear Model",
-                  library = "MASS",
-                  loop = NULL,
-                  type = c("Regression"),
-                  parameters = data.frame(parameter = "link",
-                                          class = "character",
-                                          label = "Link Function"),
-                  grid = function(x, y, len = NULL, search = "grid") 
-                    data.frame(link = c("log", "sqrt", "identity"))[1:min(len, 3),,drop = FALSE],
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
+modelInfo <- list(
+  label = "Negative Binomial Generalized Linear Model",
+  library = "MASS",
+  loop = NULL,
+  type = c("Regression"),
+  parameters = data.frame(
+    parameter = "link",
+    class = "character",
+    label = "Link Function"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(link = c("log", "sqrt", "identity"))[
+      1:min(len, 3),
+      ,
+      drop = FALSE
+    ]
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
 
-                    theDots <- list(...)
+    theDots <- list(...)
 
-                    ## pass in any model weights
-                    if(!is.null(wts)) theDots$weights <- wts
+    ## pass in any model weights
+    if (!is.null(wts)) {
+      theDots$weights <- wts
+    }
 
-                    modelArgs <- c(list(formula = as.formula(".outcome ~ ."), 
-                                        data = dat,
-                                        link = as.character(param$link)), 
-                                   theDots)
+    modelArgs <- c(
+      list(
+        formula = as.formula(".outcome ~ ."),
+        data = dat,
+        link = as.character(param$link)
+      ),
+      theDots
+    )
 
-                    out <- do.call(getFromNamespace("glm.nb", "MASS"), modelArgs)
-                    ## When we use do.call(), the call infformation can contain a ton of
-                    ## information. Inlcuding the contenst of the data. We eliminate it.
-                    out$call <- NULL
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata, type = "response")
-                  },
-                  prob = NULL,
-                  varImp = function(object, ...) {
-                    values <- summary(object)$coef
-                    varImps <-  abs(values[-1, grep("value$", colnames(values)), drop = FALSE])
-                    out <- data.frame(varImps)
-                    colnames(out) <- "Overall"
-                    if(!is.null(names(varImps))) rownames(out) <- names(varImps)
-                    out
-                  },
-                  predictors = function(x, ...) predictors(x$terms),
-                  levels = NULL,
-                  trim = function(x) {
-                    #Based off: http://www.win-vector.com/blog/2014/05/trimming-the-fat-from-glm-models-in-r/
-                    x$y = c()
-                    x$model = c()
+    out <- do.call(getFromNamespace("glm.nb", "MASS"), modelArgs)
+    ## When we use do.call(), the call infformation can contain a ton of
+    ## information. Inlcuding the contenst of the data. We eliminate it.
+    out$call <- NULL
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata, type = "response")
+  },
+  prob = NULL,
+  varImp = function(object, ...) {
+    values <- summary(object)$coef
+    varImps <- abs(values[-1, grep("value$", colnames(values)), drop = FALSE])
+    out <- data.frame(varImps)
+    colnames(out) <- "Overall"
+    if (!is.null(names(varImps))) {
+      rownames(out) <- names(varImps)
+    }
+    out
+  },
+  predictors = function(x, ...) predictors(x$terms),
+  levels = NULL,
+  trim = function(x) {
+    #Based off: http://www.win-vector.com/blog/2014/05/trimming-the-fat-from-glm-models-in-r/
+    x$y = c()
+    x$model = c()
 
-                    x$residuals = c()
-                    x$fitted.values = c()
-                    x$effects = c()
-                    x$qr$qr = c()
-                    x$linear.predictors = c()
-                    x$weights = c()
-                    x$prior.weights = c()
-                    x$data = c()
+    x$residuals = c()
+    x$fitted.values = c()
+    x$effects = c()
+    x$qr$qr = c()
+    x$linear.predictors = c()
+    x$weights = c()
+    x$prior.weights = c()
+    x$data = c()
 
-                    x$family$variance = c()
-                    x$family$dev.resids = c()
-                    x$family$aic = c()
-                    x$family$validmu = c()
-                    x$family$simulate = c()
-                    attr(x$terms,".Environment") = c()
-                    attr(x$formula,".Environment") = c()
+    x$family$variance = c()
+    x$family$dev.resids = c()
+    x$family$aic = c()
+    x$family$validmu = c()
+    x$family$simulate = c()
+    attr(x$terms, ".Environment") = c()
+    attr(x$formula, ".Environment") = c()
 
-                    x
-                  },
-                  tags = c("Generalized Linear Model", "Accepts Case Weights"),
-                  sort = function(x) x)
+    x
+  },
+  tags = c("Generalized Linear Model", "Accepts Case Weights"),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/glmStepAIC.R
+++ b/inst/model_sources/files/glmStepAIC.R
@@ -1,81 +1,111 @@
-modelInfo <- list(label = "Generalized Linear Model with Stepwise Feature Selection",
-                  library = "MASS",
-                  loop = NULL,
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = "parameter",
-                                          class = "character",
-                                          label = "parameter"),
-                  grid = function(x, y, len = NULL, search = "grid") data.frame(parameter = "none"),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    if(length(levels(y)) > 2) stop("glm models can only use 2-class outcomes")
-                    
-                    ## The ... could pass to stepAIC or glm, so we'll try to
-                    ## parse them well
+modelInfo <- list(
+  label = "Generalized Linear Model with Stepwise Feature Selection",
+  library = "MASS",
+  loop = NULL,
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = "parameter",
+    class = "character",
+    label = "parameter"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(parameter = "none")
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    if (length(levels(y)) > 2) {
+      stop("glm models can only use 2-class outcomes")
+    }
 
-                    stepArgs <- names(formals(MASS::stepAIC))
-                    stepArgs <- stepArgs[!(stepArgs %in% c("object", "..."))]
-                    theDots <- list(...)
-                    glmArgs <- list()
+    ## The ... could pass to stepAIC or glm, so we'll try to
+    ## parse them well
 
-                    if(!any(names(theDots) == "family")) {
-                      glmArgs$family <- if(is.factor(y)) binomial() else gaussian()              
-                    } else glmArgs$family <- theDots$family
-                    if(any(!(names(theDots) %in% stepArgs))) 
-                      theDots <- theDots[names(theDots) %in% stepArgs]
-                    
-                    if(any(names(theDots) == "direction")) {
-                      ## Assume that if you go forward, you should start from nothing
-                      if(theDots$direction == "forward") {
-                        start_form <- as.formula(".outcome ~ 1")
-                        if(!any(names(theDots) == "scope")) {
-                          theDots$scope <- list(lower = as.formula(".outcome ~ 1"),
-                                                upper = as.formula(paste0(".outcome~", paste0(colnames(x), collapse = "+"))))
-                        }
-                      } else {
-                        ## For backwards or both, start from the current model
-                        start_form <- as.formula(".outcome ~ .")
-                      }           
-                    } else start_form <- as.formula(".outcome ~ .")
-                    ##  `If the scope argument is missing the default for direction is "backward".`
-                    
-                    ## pass in any model weights
-                    if(!is.null(wts)) glmArgs$weights <- wts
-                    
-                    modelArgs <- c(list(formula = start_form, data = dat),
-                                   glmArgs)
+    stepArgs <- names(formals(MASS::stepAIC))
+    stepArgs <- stepArgs[!(stepArgs %in% c("object", "..."))]
+    theDots <- list(...)
+    glmArgs <- list()
 
-                    mod <- do.call(glm, modelArgs)
+    if (!any(names(theDots) == "family")) {
+      glmArgs$family <- if (is.factor(y)) binomial() else gaussian()
+    } else {
+      glmArgs$family <- theDots$family
+    }
+    if (any(!(names(theDots) %in% stepArgs))) {
+      theDots <- theDots[names(theDots) %in% stepArgs]
+    }
 
-                    theDots$object <- mod
-                    out <- do.call(MASS::stepAIC, theDots)
-                    out$call <- NULL
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    if(modelFit$problemType == "Classification")
-                    {
-                      probs <-  predict(modelFit, newdata, type = "response")
-                      out <- ifelse(probs < .5,
-                                    modelFit$obsLevel[1],
-                                    modelFit$obsLevel[2])
-                    } else {
-                      out <- predict(modelFit, newdata, type = "response")
-                    }
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL){
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    out <- predict(modelFit, newdata, type = "response")
-                    out <- cbind(1-out, out)
-                    ## glm models the second factor level, we treat the first as the
-                    ## event of interest. See Details in ?glm
-                    dimnames(out)[[2]] <-  modelFit$obsLevels
-                    out
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("Generalized Linear Model", "Feature Selection Wrapper", "Linear Classifier",
-                           "Implicit Feature Selection", "Two Class Only", "Accepts Case Weights"),
-                  sort = function(x) x)
+    if (any(names(theDots) == "direction")) {
+      ## Assume that if you go forward, you should start from nothing
+      if (theDots$direction == "forward") {
+        start_form <- as.formula(".outcome ~ 1")
+        if (!any(names(theDots) == "scope")) {
+          theDots$scope <- list(
+            lower = as.formula(".outcome ~ 1"),
+            upper = as.formula(paste0(
+              ".outcome~",
+              paste0(colnames(x), collapse = "+")
+            ))
+          )
+        }
+      } else {
+        ## For backwards or both, start from the current model
+        start_form <- as.formula(".outcome ~ .")
+      }
+    } else {
+      start_form <- as.formula(".outcome ~ .")
+    }
+    ##  `If the scope argument is missing the default for direction is "backward".`
+
+    ## pass in any model weights
+    if (!is.null(wts)) {
+      glmArgs$weights <- wts
+    }
+
+    modelArgs <- c(list(formula = start_form, data = dat), glmArgs)
+
+    mod <- do.call(glm, modelArgs)
+
+    theDots$object <- mod
+    out <- do.call(MASS::stepAIC, theDots)
+    out$call <- NULL
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    if (modelFit$problemType == "Classification") {
+      probs <- predict(modelFit, newdata, type = "response")
+      out <- ifelse(probs < .5, modelFit$obsLevel[1], modelFit$obsLevel[2])
+    } else {
+      out <- predict(modelFit, newdata, type = "response")
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    out <- predict(modelFit, newdata, type = "response")
+    out <- cbind(1 - out, out)
+    ## glm models the second factor level, we treat the first as the
+    ## event of interest. See Details in ?glm
+    dimnames(out)[[2]] <- modelFit$obsLevels
+    out
+  },
+  levels = function(x) x$obsLevels,
+  tags = c(
+    "Generalized Linear Model",
+    "Feature Selection Wrapper",
+    "Linear Classifier",
+    "Implicit Feature Selection",
+    "Two Class Only",
+    "Accepts Case Weights"
+  ),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/glmStepAIC.R
+++ b/inst/model_sources/files/glmStepAIC.R
@@ -12,10 +12,10 @@ modelInfo <- list(
     data.frame(parameter = "none")
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     if (length(levels(y)) > 2) {
@@ -31,7 +31,11 @@ modelInfo <- list(
     glmArgs <- list()
 
     if (!any(names(theDots) == "family")) {
-      glmArgs$family <- if (is.factor(y)) binomial() else gaussian()
+      if (is.factor(y)) {
+        glmArgs$family <- binomial()
+      } else {
+        glmArgs$family <- gaussian()
+      }
     } else {
       glmArgs$family <- theDots$family
     }

--- a/inst/model_sources/files/glmboost.R
+++ b/inst/model_sources/files/glmboost.R
@@ -1,140 +1,195 @@
-modelInfo <- list(label = "Boosted Generalized Linear Model",
-                  library = c("plyr", "mboost"),
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('mstop', 'prune'),
-                                          class = c("numeric", "character"),
-                                          label = c('# Boosting Iterations', 'AIC Prune?')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- data.frame(mstop = floor((1:len) * 50), prune = "no")
-                    } else {
-                      out <- data.frame(mstop = sample(1:1000, size = len, replace = TRUE),
-                                        prune = sample(c("yes", "no"), size = len, replace = TRUE))
-                    }
-                  },
-                  loop = function(grid) {
-                    grid <- grid[order(-grid$mstop, grid$prune),]
-                    loop <- plyr::ddply(grid, plyr::`.`(prune), function(x) data.frame(mstop = max(x$mstop)))
-                    submodels <- vector(mode = "list", length = nrow(loop))
-                    for(i in seq(along = loop$mstop)) {
-                      submodels[[i]] <- subset(grid, prune == loop$prune[i] & mstop < loop$mstop[i])
-                    }
-                    list(loop = loop[, c("mstop", "prune")], submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    ##check for control list and over-write mstop
-                    theDots <- list(...)
-                    if(any(names(theDots) == "control")) {
-                      theDots$control$mstop <- param$mstop
-                      ctl <- theDots$control
-                      theDots$control <- NULL
-                    } else ctl <- mboost::boost_control(mstop = param$mstop)
+modelInfo <- list(
+  label = "Boosted Generalized Linear Model",
+  library = c("plyr", "mboost"),
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c('mstop', 'prune'),
+    class = c("numeric", "character"),
+    label = c('# Boosting Iterations', 'AIC Prune?')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(mstop = floor((1:len) * 50), prune = "no")
+    } else {
+      out <- data.frame(
+        mstop = sample(1:1000, size = len, replace = TRUE),
+        prune = sample(c("yes", "no"), size = len, replace = TRUE)
+      )
+    }
+  },
+  loop = function(grid) {
+    grid <- grid[order(-grid$mstop, grid$prune), ]
+    loop <- plyr::ddply(grid, plyr::`.`(prune), function(x) {
+      data.frame(mstop = max(x$mstop))
+    })
+    submodels <- vector(mode = "list", length = nrow(loop))
+    for (i in seq(along = loop$mstop)) {
+      submodels[[i]] <- subset(
+        grid,
+        prune == loop$prune[i] & mstop < loop$mstop[i]
+      )
+    }
+    list(loop = loop[, c("mstop", "prune")], submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    ##check for control list and over-write mstop
+    theDots <- list(...)
+    if (any(names(theDots) == "control")) {
+      theDots$control$mstop <- param$mstop
+      ctl <- theDots$control
+      theDots$control <- NULL
+    } else {
+      ctl <- mboost::boost_control(mstop = param$mstop)
+    }
 
-                    if(!any(names(theDots) == "family"))
-                      theDots$family <- if(is.factor(y)) mboost::Binomial() else mboost::GaussReg()
+    if (!any(names(theDots) == "family")) {
+      theDots$family <- if (is.factor(y)) {
+        mboost::Binomial()
+      } else {
+        mboost::GaussReg()
+      }
+    }
 
-                    ## pass in any model weights
-                    if(!is.null(wts)) theDots$weights <- wts
+    ## pass in any model weights
+    if (!is.null(wts)) {
+      theDots$weights <- wts
+    }
 
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    modelArgs <- c(list(formula = as.formula(".outcome ~ ."),
-                                        data = dat, control = ctl),
-                                   theDots)
-                    out <- do.call(mboost:::glmboost.formula, modelArgs)
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    modelArgs <- c(
+      list(formula = as.formula(".outcome ~ ."), data = dat, control = ctl),
+      theDots
+    )
+    out <- do.call(mboost:::glmboost.formula, modelArgs)
 
-                    ## from `?mstop`: The [.mboost function can be used to enhance or restrict a given
-                    ## boosting model to the specified boosting iteration i. Note that in both cases the
-                    ## original x will be changed to reduce the memory footprint. If the boosting model
-                    ## is enhanced by specifying an index that is larger than the initial mstop, only
-                    ## the missing i - mstop steps are fitted. If the model is restricted, the spare
-                    ## steps are not dropped, i.e., if we increase i again, these boosting steps are
-                    ## immediately available. Alternatively, the same operation can be done
-                    ## by mstop(x) <- i.
+    ## from `?mstop`: The [.mboost function can be used to enhance or restrict a given
+    ## boosting model to the specified boosting iteration i. Note that in both cases the
+    ## original x will be changed to reduce the memory footprint. If the boosting model
+    ## is enhanced by specifying an index that is larger than the initial mstop, only
+    ## the missing i - mstop steps are fitted. If the model is restricted, the spare
+    ## steps are not dropped, i.e., if we increase i again, these boosting steps are
+    ## immediately available. Alternatively, the same operation can be done
+    ## by mstop(x) <- i.
 
-                    if(param$prune == "yes") {
-                      iters <- if(is.factor(y))
-                        mboost::mstop(AIC(out, "classical")) else
-                          mboost::mstop(AIC(out))
-                      if(iters < out$mstop()) out <- out[iters]
-                    }
-                    out$.org.mstop <- out$mstop()
+    if (param$prune == "yes") {
+      iters <- if (is.factor(y)) {
+        mboost::mstop(AIC(out, "classical"))
+      } else {
+        mboost::mstop(AIC(out))
+      }
+      if (iters < out$mstop()) out <- out[iters]
+    }
+    out$.org.mstop <- out$mstop()
 
-                    ## for easier printing (and tracebacks), we'll try to make the calls shorter
-                    ## by adding dummy object names instead of the long object definitions that
-                    ## currently exist
-                    out$call["x"] <- "xData"
-                    out$call["y"] <- "yData"
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    predType <- ifelse(modelFit$problemType == "Classification", "class", "response")
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    out <- predict(modelFit, newdata, type = predType)
-                    if(!is.null(submodels)) {
+    ## for easier printing (and tracebacks), we'll try to make the calls shorter
+    ## by adding dummy object names instead of the long object definitions that
+    ## currently exist
+    out$call["x"] <- "xData"
+    out$call["y"] <- "yData"
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predType <- ifelse(
+      modelFit$problemType == "Classification",
+      "class",
+      "response"
+    )
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    out <- predict(modelFit, newdata, type = predType)
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- as.vector(out)
+      for (j in seq(along = submodels$mstop)) {
+        ## If the model has been pruned, make sure that the requested `mstop`
+        ## is not greater than the original value. If it is, use the orignal value.
+        ## This should only occur whenm the model was pruned .
+        this_mstop <- if (
+          submodels$prune[j] == "yes" &
+            submodels$mstop[j] > modelFit$.org.mstop
+        ) {
+          modelFit$.org.mstop
+        } else {
+          submodels$mstop[j]
+        }
+        tmp[[j + 1]] <- as.vector(predict(
+          modelFit[this_mstop],
+          newdata,
+          type = predType
+        ))
+      }
+      out <- tmp
+      mboost::mstop(modelFit) <- modelFit$.org.mstop
+    }
+    # cat(modelFit$mstop(), "!\n")
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    probs <- predict(modelFit, newdata, type = "response")
+    out <- cbind(1 - probs, probs)
+    colnames(out) <- modelFit$obsLevels
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
+      for (j in seq(along = submodels$mstop)) {
+        this_mstop <- if (
+          submodels$prune[j] == "yes" &
+            submodels$mstop[j] > modelFit$.org.mstop
+        ) {
+          modelFit$.org.mstop
+        } else {
+          submodels$mstop[j]
+        }
 
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- as.vector(out)
-                      for(j in seq(along = submodels$mstop)) {
-                        ## If the model has been pruned, make sure that the requested `mstop`
-                        ## is not greater than the original value. If it is, use the orignal value.
-                        ## This should only occur whenm the model was pruned .
-                        this_mstop <- if(submodels$prune[j] == "yes" &
-                                         submodels$mstop[j] > modelFit$.org.mstop)
-                          modelFit$.org.mstop else submodels$mstop[j]
-                        tmp[[j+1]]  <- as.vector(predict(modelFit[this_mstop],
-                                                         newdata,
-                                                         type = predType))
-                      }
-                      out <- tmp
-                      mboost::mstop(modelFit) <- modelFit$.org.mstop
-                    }
-                    # cat(modelFit$mstop(), "!\n")
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    probs <- predict(modelFit, newdata, type = "response")
-                    out <- cbind(1 - probs, probs)
-                    colnames(out) <- modelFit$obsLevels
-                    if(!is.null(submodels)) {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
-                      for(j in seq(along = submodels$mstop)) {
-                        this_mstop <- if(submodels$prune[j] == "yes" &
-                                         submodels$mstop[j] > modelFit$.org.mstop)
-                          modelFit$.org.mstop else submodels$mstop[j]
-
-                        tmpProb <- predict(modelFit[this_mstop], newdata, type = "response")
-                        tmpProb <- cbind(1 - tmpProb, tmpProb)
-                        colnames(tmpProb) <- modelFit$obsLevels
-                        tmp[[j+1]] <- as.data.frame(tmpProb[, modelFit$obsLevels, drop = FALSE], stringsAsFactors = TRUE)
-                      }
-                      out <- tmp
-                      mboost::mstop(modelFit) <- modelFit$.org.mstop
-                    }
-                    out
-                  },
-                  predictors = function(x, ...) {
-                    strsplit(variable.names(x), ", ")[[1]]
-                  },
-                  varImp = function(object, ...) {
-                    betas <- abs(coef(object))
-                    betas <- betas[names(betas) != "(Intercept)"]
-                    bnames <- names(betas)
-                    name_check <- object$xName %in% bnames
-                    if(any(!(name_check))) {
-                      missing <- object$xName[!name_check]
-                      beta_miss <- rep(0, length(missing))
-                      names(beta_miss) <- missing
-                      betas <- c(betas, beta_miss)
-                    }
-                    out <- data.frame(Overall = betas)
-                    rownames(out) <- names(betas)
-                    out
-                  },
-                  levels = function(x) levels(x$response),
-                  notes = "The `prune` option for this model enables the number of iterations to be determined by the optimal AIC value across all iterations. See the examples in `?mboost::mstop`. If pruning is not used, the ensemble makes predictions using the exact value of the `mstop` tuning parameter value.",
-                  tags = c("Generalized Linear Model", "Ensemble Model", "Boosting",
-                           "Linear Classifier", "Two Class Only", "Accepts Case Weights"),
-                  sort = function(x) x[order(x$mstop, x$prune),])
+        tmpProb <- predict(modelFit[this_mstop], newdata, type = "response")
+        tmpProb <- cbind(1 - tmpProb, tmpProb)
+        colnames(tmpProb) <- modelFit$obsLevels
+        tmp[[j + 1]] <- as.data.frame(
+          tmpProb[, modelFit$obsLevels, drop = FALSE],
+          stringsAsFactors = TRUE
+        )
+      }
+      out <- tmp
+      mboost::mstop(modelFit) <- modelFit$.org.mstop
+    }
+    out
+  },
+  predictors = function(x, ...) {
+    strsplit(variable.names(x), ", ")[[1]]
+  },
+  varImp = function(object, ...) {
+    betas <- abs(coef(object))
+    betas <- betas[names(betas) != "(Intercept)"]
+    bnames <- names(betas)
+    name_check <- object$xName %in% bnames
+    if (any(!(name_check))) {
+      missing <- object$xName[!name_check]
+      beta_miss <- rep(0, length(missing))
+      names(beta_miss) <- missing
+      betas <- c(betas, beta_miss)
+    }
+    out <- data.frame(Overall = betas)
+    rownames(out) <- names(betas)
+    out
+  },
+  levels = function(x) levels(x$response),
+  notes = "The `prune` option for this model enables the number of iterations to be determined by the optimal AIC value across all iterations. See the examples in `?mboost::mstop`. If pruning is not used, the ensemble makes predictions using the exact value of the `mstop` tuning parameter value.",
+  tags = c(
+    "Generalized Linear Model",
+    "Ensemble Model",
+    "Boosting",
+    "Linear Classifier",
+    "Two Class Only",
+    "Accepts Case Weights"
+  ),
+  sort = function(x) x[order(x$mstop, x$prune), ]
+)

--- a/inst/model_sources/files/glmboost.R
+++ b/inst/model_sources/files/glmboost.R
@@ -43,10 +43,10 @@ modelInfo <- list(
     }
 
     if (!any(names(theDots) == "family")) {
-      theDots$family <- if (is.factor(y)) {
-        mboost::Binomial()
+      if (is.factor(y)) {
+        theDots$family <- mboost::Binomial()
       } else {
-        mboost::GaussReg()
+        theDots$family <- mboost::GaussReg()
       }
     }
 
@@ -55,10 +55,10 @@ modelInfo <- list(
       theDots$weights <- wts
     }
 
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     modelArgs <- c(
@@ -77,12 +77,14 @@ modelInfo <- list(
     ## by mstop(x) <- i.
 
     if (param$prune == "yes") {
-      iters <- if (is.factor(y)) {
-        mboost::mstop(AIC(out, "classical"))
+      if (is.factor(y)) {
+        iters <- mboost::mstop(AIC(out, "classical"))
       } else {
-        mboost::mstop(AIC(out))
+        iters <- mboost::mstop(AIC(out))
       }
-      if (iters < out$mstop()) out <- out[iters]
+      if (iters < out$mstop()) {
+        out <- out[iters]
+      }
     }
     out$.org.mstop <- out$mstop()
 
@@ -110,13 +112,13 @@ modelInfo <- list(
         ## If the model has been pruned, make sure that the requested `mstop`
         ## is not greater than the original value. If it is, use the orignal value.
         ## This should only occur whenm the model was pruned .
-        this_mstop <- if (
+        if (
           submodels$prune[j] == "yes" &
             submodels$mstop[j] > modelFit$.org.mstop
         ) {
-          modelFit$.org.mstop
+          this_mstop <- modelFit$.org.mstop
         } else {
-          submodels$mstop[j]
+          this_mstop <- submodels$mstop[j]
         }
         tmp[[j + 1]] <- as.vector(predict(
           modelFit[this_mstop],
@@ -141,13 +143,13 @@ modelInfo <- list(
       tmp <- vector(mode = "list", length = nrow(submodels) + 1)
       tmp[[1]] <- out
       for (j in seq(along = submodels$mstop)) {
-        this_mstop <- if (
+        if (
           submodels$prune[j] == "yes" &
             submodels$mstop[j] > modelFit$.org.mstop
         ) {
-          modelFit$.org.mstop
+          this_mstop <- modelFit$.org.mstop
         } else {
-          submodels$mstop[j]
+          this_mstop <- submodels$mstop[j]
         }
 
         tmpProb <- predict(modelFit[this_mstop], newdata, type = "response")

--- a/inst/model_sources/files/glmnet.R
+++ b/inst/model_sources/files/glmnet.R
@@ -9,7 +9,11 @@ modelInfo <- list(
   ),
   grid = function(x, y, len = NULL, search = "grid") {
     if (search == "grid") {
-      numLev <- if (is.character(y) | is.factor(y)) length(levels(y)) else NA
+      if (is.character(y) | is.factor(y)) {
+        numLev <- length(levels(y))
+      } else {
+        numLev <- NA
+      }
       if (!is.na(numLev)) {
         fam <- ifelse(numLev > 2, "multinomial", "binomial")
       } else {
@@ -44,7 +48,11 @@ modelInfo <- list(
     list(loop = loop, submodels = submodels)
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    numLev <- if (is.character(y) | is.factor(y)) length(levels(y)) else NA
+    if (is.character(y) | is.factor(y)) {
+      numLev <- length(levels(y))
+    } else {
+      numLev <- NA
+    }
 
     theDots <- list(...)
 
@@ -99,10 +107,10 @@ modelInfo <- list(
         ))
       } else {
         tmp <- predict(modelFit, newdata, s = submodels$lambda, type = "class")
-        tmp <- if (is.matrix(tmp)) {
-          as.data.frame(tmp, stringsAsFactors = FALSE)
+        if (is.matrix(tmp)) {
+          tmp <- as.data.frame(tmp, stringsAsFactors = FALSE)
         } else {
-          as.character(tmp)
+          tmp <- as.character(tmp)
         }
         tmp <- as.list(tmp)
       }
@@ -111,10 +119,10 @@ modelInfo <- list(
     out
   },
   prob = function(modelFit, newdata, submodels = NULL) {
-    obsLevels <- if ("classnames" %in% names(modelFit)) {
-      modelFit$classnames
+    if ("classnames" %in% names(modelFit)) {
+      obsLevels <- modelFit$classnames
     } else {
-      NULL
+      obsLevels <- NULL
     }
     if (!is.matrix(newdata) && !inherits(newdata, "sparseMatrix")) {
       newdata <- Matrix::as.matrix(newdata)
@@ -153,7 +161,11 @@ modelInfo <- list(
       } else {
         tmp <- apply(tmp, 3, function(x) data.frame(x))
       }
-      probs <- if (is.list(tmp)) c(list(probs), tmp) else list(probs, tmp)
+      if (is.list(tmp)) {
+        probs <- c(list(probs), tmp)
+      } else {
+        probs <- list(probs, tmp)
+      }
     }
     probs
   },
@@ -168,7 +180,11 @@ modelInfo <- list(
         stop("must supply a value of lambda")
       }
     }
-    allVar <- if (is.list(x$beta)) rownames(x$beta[[1]]) else rownames(x$beta)
+    if (is.list(x$beta)) {
+      allVar <- rownames(x$beta[[1]])
+    } else {
+      allVar <- rownames(x$beta)
+    }
     out <- unlist(predict(x, s = lambda, type = "nonzero"))
     out <- unique(out)
     if (length(out) > 0) {
@@ -198,7 +214,13 @@ modelInfo <- list(
     out <- abs(out[rownames(out) != "(Intercept)", , drop = FALSE])
     out
   },
-  levels = function(x) if (any(names(x) == "obsLevels")) x$obsLevels else NULL,
+  levels = function(x) {
+    if (any(names(x) == "obsLevels")) {
+      x$obsLevels
+    } else {
+      NULL
+    }
+  },
   tags = c(
     "Generalized Linear Model",
     "Implicit Feature Selection",

--- a/inst/model_sources/files/glmnet.R
+++ b/inst/model_sources/files/glmnet.R
@@ -1,167 +1,217 @@
-modelInfo <- list(label = "glmnet",
-                  library = c("glmnet", "Matrix"),
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('alpha', 'lambda'),
-                                          class = c("numeric", "numeric"),
-                                          label = c('Mixing Percentage', 'Regularization Parameter')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      numLev <- if(is.character(y) | is.factor(y)) length(levels(y)) else NA
-                      if(!is.na(numLev)) {
-                        fam <- ifelse(numLev > 2, "multinomial", "binomial")
-                      } else fam <- "gaussian"
-                      if(!is.matrix(x) && !inherits(x, "sparseMatrix"))
-                        x <- Matrix::as.matrix(x)
-                      init <- glmnet::glmnet(x, y,
-                                     family = fam,
-                                     nlambda = len+2,
-                                     alpha = .5)
-                      lambda <- unique(init$lambda)
-                      lambda <- lambda[-c(1, length(lambda))]
-                      lambda <- lambda[1:min(length(lambda), len)]
-                      out <- expand.grid(alpha = seq(0.1, 1, length = len),
-                                         lambda = lambda)
-                    } else {
-                      out <- data.frame(alpha = runif(len, min = 0, 1),
-                                        lambda = 2^runif(len, min = -10, 3))
-                    }
-                    out
-                  },
-                  loop = function(grid) {
-                    alph <- unique(grid$alpha)
-                    loop <- data.frame(alpha = alph)
-                    loop$lambda <- NA
-                    submodels <- vector(mode = "list", length = length(alph))
-                    for(i in seq(along = alph)) {
-                      np <- grid[grid$alpha == alph[i],"lambda"]
-                      loop$lambda[loop$alpha == alph[i]] <- np[which.max(np)]
-                      submodels[[i]] <- data.frame(lambda = np[-which.max(np)])
-                    }
-                    list(loop = loop, submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    numLev <- if(is.character(y) | is.factor(y)) length(levels(y)) else NA
+modelInfo <- list(
+  label = "glmnet",
+  library = c("glmnet", "Matrix"),
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c('alpha', 'lambda'),
+    class = c("numeric", "numeric"),
+    label = c('Mixing Percentage', 'Regularization Parameter')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      numLev <- if (is.character(y) | is.factor(y)) length(levels(y)) else NA
+      if (!is.na(numLev)) {
+        fam <- ifelse(numLev > 2, "multinomial", "binomial")
+      } else {
+        fam <- "gaussian"
+      }
+      if (!is.matrix(x) && !inherits(x, "sparseMatrix")) {
+        x <- Matrix::as.matrix(x)
+      }
+      init <- glmnet::glmnet(x, y, family = fam, nlambda = len + 2, alpha = .5)
+      lambda <- unique(init$lambda)
+      lambda <- lambda[-c(1, length(lambda))]
+      lambda <- lambda[1:min(length(lambda), len)]
+      out <- expand.grid(alpha = seq(0.1, 1, length = len), lambda = lambda)
+    } else {
+      out <- data.frame(
+        alpha = runif(len, min = 0, 1),
+        lambda = 2^runif(len, min = -10, 3)
+      )
+    }
+    out
+  },
+  loop = function(grid) {
+    alph <- unique(grid$alpha)
+    loop <- data.frame(alpha = alph)
+    loop$lambda <- NA
+    submodels <- vector(mode = "list", length = length(alph))
+    for (i in seq(along = alph)) {
+      np <- grid[grid$alpha == alph[i], "lambda"]
+      loop$lambda[loop$alpha == alph[i]] <- np[which.max(np)]
+      submodels[[i]] <- data.frame(lambda = np[-which.max(np)])
+    }
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    numLev <- if (is.character(y) | is.factor(y)) length(levels(y)) else NA
 
-                    theDots <- list(...)
+    theDots <- list(...)
 
-                    if(all(names(theDots) != "family")) {
-                      if(!is.na(numLev)) {
-                        fam <- ifelse(numLev > 2, "multinomial", "binomial")
-                      } else fam <- "gaussian"
-                      theDots$family <- fam
-                    }
+    if (all(names(theDots) != "family")) {
+      if (!is.na(numLev)) {
+        fam <- ifelse(numLev > 2, "multinomial", "binomial")
+      } else {
+        fam <- "gaussian"
+      }
+      theDots$family <- fam
+    }
 
-                    ## pass in any model weights
-                    if(!is.null(wts)) theDots$weights <- wts
+    ## pass in any model weights
+    if (!is.null(wts)) {
+      theDots$weights <- wts
+    }
 
-                    if(!is.matrix(x) && !inherits(x, "sparseMatrix"))
-                      x <- Matrix::as.matrix(x)
+    if (!is.matrix(x) && !inherits(x, "sparseMatrix")) {
+      x <- Matrix::as.matrix(x)
+    }
 
-                    modelArgs <- c(list(x = x,
-                                        y = y,
-                                        alpha = param$alpha),
-                                   theDots)
-                    out <- do.call(glmnet::glmnet, modelArgs)
-                    if(!is.na(param$lambda[1])) out$lambdaOpt <- param$lambda[1]
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata) && !inherits(newdata, "sparseMatrix")) 
-                      newdata <- Matrix::as.matrix(newdata)
-                    if(length(modelFit$obsLevels) < 2) {
-                      out <- predict(modelFit, newdata, s = modelFit$lambdaOpt, type = "response")
-                    } else {
-                      out <- predict(modelFit, newdata, s = modelFit$lambdaOpt, type = "class")
-                    }
-                    if(is.matrix(out)) out <- out[,1]
+    modelArgs <- c(list(x = x, y = y, alpha = param$alpha), theDots)
+    out <- do.call(glmnet::glmnet, modelArgs)
+    if (!is.na(param$lambda[1])) {
+      out$lambdaOpt <- param$lambda[1]
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata) && !inherits(newdata, "sparseMatrix")) {
+      newdata <- Matrix::as.matrix(newdata)
+    }
+    if (length(modelFit$obsLevels) < 2) {
+      out <- predict(
+        modelFit,
+        newdata,
+        s = modelFit$lambdaOpt,
+        type = "response"
+      )
+    } else {
+      out <- predict(modelFit, newdata, s = modelFit$lambdaOpt, type = "class")
+    }
+    if (is.matrix(out)) {
+      out <- out[, 1]
+    }
 
-                    if(!is.null(submodels)) {
-                      if(length(modelFit$obsLevels) < 2) {
-                        tmp <- as.list(as.data.frame(predict(modelFit, newdata, s = submodels$lambda),
-                                                     stringsAsFactors = TRUE))
-                      } else {
-                        tmp <- predict(modelFit, newdata, s = submodels$lambda, type = "class")
-                        tmp <- if(is.matrix(tmp)) as.data.frame(tmp, stringsAsFactors = FALSE) else as.character(tmp)
-                        tmp <- as.list(tmp)
-                      }
-                      out <- c(list(out), tmp)
-                    }
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    obsLevels <- if("classnames" %in% names(modelFit)) modelFit$classnames else NULL
-                    if(!is.matrix(newdata) && !inherits(newdata, "sparseMatrix"))
-                      newdata <- Matrix::as.matrix(newdata)
-                    probs <- predict(modelFit, newdata,
-                                     s = modelFit$lambdaOpt,
-                                     type = "response")
-                    if(length(obsLevels) == 2) {
-                      probs <- as.vector(probs)
-                      probs <- as.data.frame(cbind(1-probs, probs), stringsAsFactors = FALSE)
-                      colnames(probs) <- modelFit$obsLevels
-                    } else {
-                      probs <- as.data.frame(probs[,,1,drop = FALSE], stringsAsFactors = FALSE)
-                      names(probs) <- modelFit$obsLevels
-                    }
-                    if(!is.null(submodels)) {
-                      tmp <- predict(modelFit, newdata,
-                                     s = submodels$lambda,
-                                     type = "response")
-                      if(length(obsLevels) == 2) {
-                        tmp <- as.list(as.data.frame(tmp, stringsAsFactors = TRUE))
-                        tmp <- lapply(tmp,
-                                      function(x, lev) {
-                                        x <- as.vector(x)
-                                        tmp <- data.frame(1-x, x)
-                                        names(tmp) <- lev
-                                        tmp
-                                      },
-                                      lev = modelFit$obsLevels)
-                      } else tmp <- apply(tmp, 3, function(x) data.frame(x))
-                      probs <- if(is.list(tmp)) c(list(probs), tmp) else list(probs, tmp)
-                    }
-                    probs
-                  },
-                  predictors = function(x, lambda = NULL, ...) {
-                    if(is.null(lambda))
-                    {
-                      if(length(lambda) > 1) stop("Only one value of lambda is allowed right now")
-                      if(!is.null(x$lambdaOpt)) {
-                        lambda <- x$lambdaOpt
-                      } else stop("must supply a value of lambda")
-                    }
-                    allVar <- if(is.list(x$beta)) rownames(x$beta[[1]]) else rownames(x$beta)
-                    out <- unlist(predict(x, s = lambda, type = "nonzero"))
-                    out <- unique(out)
-                    if(length(out) > 0) {
-                      out <- out[!is.na(out)]
-                      out <- allVar[out]
-                    }
-                    out
-                  },
-                  varImp = function(object, lambda = NULL, ...) {
-                    if(is.null(lambda)) {
-                      if(length(lambda) > 1) stop("Only one value of lambda is allowed right now")
-                      if(!is.null(object$lambdaOpt)) {
-                        lambda <- object$lambdaOpt
-                      } else stop("must supply a value of lambda")
-                    }
-                    beta <- predict(object, s = lambda, type = "coef")
-                    if(is.list(beta)) {
-                      out <- do.call("cbind", lapply(beta, function(x) x[,1]))
-                      out <- as.data.frame(out, stringsAsFactors = TRUE)
-                    } else out <- data.frame(Overall = beta[,1])
-                    out <- abs(out[rownames(out) != "(Intercept)",,drop = FALSE])
-                    out
-                  },
-                  levels = function(x) if(any(names(x) == "obsLevels")) x$obsLevels else NULL,
-                  tags = c("Generalized Linear Model", "Implicit Feature Selection",
-                           "L1 Regularization", "L2 Regularization", "Linear Classifier",
-                           "Linear Regression"),
-                  sort = function(x) x[order(-x$lambda, x$alpha),],
-                  trim = function(x) {
-                    x$call <- NULL
-                    x$df <- NULL
-                    x$dev.ratio <- NULL
-                    x
-                  })
+    if (!is.null(submodels)) {
+      if (length(modelFit$obsLevels) < 2) {
+        tmp <- as.list(as.data.frame(
+          predict(modelFit, newdata, s = submodels$lambda),
+          stringsAsFactors = TRUE
+        ))
+      } else {
+        tmp <- predict(modelFit, newdata, s = submodels$lambda, type = "class")
+        tmp <- if (is.matrix(tmp)) {
+          as.data.frame(tmp, stringsAsFactors = FALSE)
+        } else {
+          as.character(tmp)
+        }
+        tmp <- as.list(tmp)
+      }
+      out <- c(list(out), tmp)
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    obsLevels <- if ("classnames" %in% names(modelFit)) {
+      modelFit$classnames
+    } else {
+      NULL
+    }
+    if (!is.matrix(newdata) && !inherits(newdata, "sparseMatrix")) {
+      newdata <- Matrix::as.matrix(newdata)
+    }
+    probs <- predict(
+      modelFit,
+      newdata,
+      s = modelFit$lambdaOpt,
+      type = "response"
+    )
+    if (length(obsLevels) == 2) {
+      probs <- as.vector(probs)
+      probs <- as.data.frame(cbind(1 - probs, probs), stringsAsFactors = FALSE)
+      colnames(probs) <- modelFit$obsLevels
+    } else {
+      probs <- as.data.frame(
+        probs[,, 1, drop = FALSE],
+        stringsAsFactors = FALSE
+      )
+      names(probs) <- modelFit$obsLevels
+    }
+    if (!is.null(submodels)) {
+      tmp <- predict(modelFit, newdata, s = submodels$lambda, type = "response")
+      if (length(obsLevels) == 2) {
+        tmp <- as.list(as.data.frame(tmp, stringsAsFactors = TRUE))
+        tmp <- lapply(
+          tmp,
+          function(x, lev) {
+            x <- as.vector(x)
+            tmp <- data.frame(1 - x, x)
+            names(tmp) <- lev
+            tmp
+          },
+          lev = modelFit$obsLevels
+        )
+      } else {
+        tmp <- apply(tmp, 3, function(x) data.frame(x))
+      }
+      probs <- if (is.list(tmp)) c(list(probs), tmp) else list(probs, tmp)
+    }
+    probs
+  },
+  predictors = function(x, lambda = NULL, ...) {
+    if (is.null(lambda)) {
+      if (length(lambda) > 1) {
+        stop("Only one value of lambda is allowed right now")
+      }
+      if (!is.null(x$lambdaOpt)) {
+        lambda <- x$lambdaOpt
+      } else {
+        stop("must supply a value of lambda")
+      }
+    }
+    allVar <- if (is.list(x$beta)) rownames(x$beta[[1]]) else rownames(x$beta)
+    out <- unlist(predict(x, s = lambda, type = "nonzero"))
+    out <- unique(out)
+    if (length(out) > 0) {
+      out <- out[!is.na(out)]
+      out <- allVar[out]
+    }
+    out
+  },
+  varImp = function(object, lambda = NULL, ...) {
+    if (is.null(lambda)) {
+      if (length(lambda) > 1) {
+        stop("Only one value of lambda is allowed right now")
+      }
+      if (!is.null(object$lambdaOpt)) {
+        lambda <- object$lambdaOpt
+      } else {
+        stop("must supply a value of lambda")
+      }
+    }
+    beta <- predict(object, s = lambda, type = "coef")
+    if (is.list(beta)) {
+      out <- do.call("cbind", lapply(beta, function(x) x[, 1]))
+      out <- as.data.frame(out, stringsAsFactors = TRUE)
+    } else {
+      out <- data.frame(Overall = beta[, 1])
+    }
+    out <- abs(out[rownames(out) != "(Intercept)", , drop = FALSE])
+    out
+  },
+  levels = function(x) if (any(names(x) == "obsLevels")) x$obsLevels else NULL,
+  tags = c(
+    "Generalized Linear Model",
+    "Implicit Feature Selection",
+    "L1 Regularization",
+    "L2 Regularization",
+    "Linear Classifier",
+    "Linear Regression"
+  ),
+  sort = function(x) x[order(-x$lambda, x$alpha), ],
+  trim = function(x) {
+    x$call <- NULL
+    x$df <- NULL
+    x$dev.ratio <- NULL
+    x
+  }
+)

--- a/inst/model_sources/files/glmnet_h2o.R
+++ b/inst/model_sources/files/glmnet_h2o.R
@@ -23,10 +23,10 @@ modelInfo <- list(
   },
   loop = NULL,
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (!is.data.frame(x)) {
-      as.data.frame(x, stringsAsFactors = TRUE)
+    if (!is.data.frame(x)) {
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     } else {
-      x
+      dat <- x
     }
     dat$.outcome <- y
     p <- ncol(dat)

--- a/inst/model_sources/files/glmnet_h2o.R
+++ b/inst/model_sources/files/glmnet_h2o.R
@@ -1,65 +1,88 @@
-modelInfo <- list(label = "glmnet",
-                  library = "h2o",
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('alpha', 'lambda'),
-                                          class = c("numeric", "numeric"),
-                                          label = c('Mixing Percentage', 'Regularization Parameter')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(alpha = seq(0, 1, length = len),
-                                        lambda = c(0, 10 ^ seq(-1, -4, length = len - 1)))
-                    } else {
-                      out <- data.frame(alpha = runif(len, min = 0, 1),
-                                        lambda = 2^runif(len, min = -10, 3))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    dat <- if(!is.data.frame(x)) as.data.frame(x, stringsAsFactors = TRUE) else x
-                    dat$.outcome <- y
-                    p <- ncol(dat)
-                    frame_name <- paste0("tmp_glmnet_dat_",sample.int(100000, 1))
-                    tmp_train_dat = h2o::as.h2o(dat, destination_frame = frame_name)
-                    out <- h2o::h2o.glm(x = colnames(x), y = ".outcome",
-                                       training_frame = tmp_train_dat,
-                                       family = if(is.factor(y)) "binomial" else "gaussian",
-                                       alpha = param$alpha, lambda = param$lambda, ...)
-                    h2o::h2o.getModel(out@model_id)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    frame_name <- paste0("new_glmnet_dat_",sample.int(100000, 1))
-                    newdata <- h2o::as.h2o(newdata, destination_frame = frame_name)
-                    as.data.frame(predict(modelFit, newdata), stringsAsFactors = TRUE)[,1]
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    frame_name <- paste0("new_glmnet_dat_",sample.int(100000, 1))
-                    newdata <- h2o::as.h2o(newdata, destination_frame = frame_name)
-                    as.data.frame(predict(modelFit, newdata), stringsAsFactors = TRUE)[,-1]
-                  },
-                  predictors = function(object, ...) {
-                    out <- as.data.frame(h2o::h2o.varimp(object), stringsAsFactors = TRUE)
-                    colnames(out)[colnames(out) == "coefficients"] <- "Overall"
-                    out <- out[!is.na(out$Overall),]   
-                    out$names
-                  },
-                  varImp = function(object, ...) {
-                    out <- as.data.frame(h2o::h2o.varimp(object), stringsAsFactors = TRUE)
-                    colnames(out)[colnames(out) == "coefficients"] <- "Overall"
-                    rownames(out) <- out$names
-                    out <- out[!is.na(out$Overall), c("Overall"), drop = FALSE]   
-                    all_var <- object@allparameters$x
-                    if(any(!(all_var %in% rownames(out)))) {
-                      missing <- all_var[!(all_var %in% rownames(out))]
-                      tmp <- data.frame(OVerall = rep(0, length(missing)))
-                      rownames(tmp) <- missing
-                      out <- rbind(out, tmp)
-                    }
-                    out
-                  },
-                  levels = NULL,
-                  tags = c("Generalized Linear Model", "Implicit Feature Selection", 
-                           "L1 Regularization", "L2 Regularization", "Linear Classifier",
-                           "Linear Regression", "Two Class Only"),
-                  sort = function(x) x[order(-x$lambda, x$alpha),],
-                  trim = NULL)
+modelInfo <- list(
+  label = "glmnet",
+  library = "h2o",
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c('alpha', 'lambda'),
+    class = c("numeric", "numeric"),
+    label = c('Mixing Percentage', 'Regularization Parameter')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        alpha = seq(0, 1, length = len),
+        lambda = c(0, 10^seq(-1, -4, length = len - 1))
+      )
+    } else {
+      out <- data.frame(
+        alpha = runif(len, min = 0, 1),
+        lambda = 2^runif(len, min = -10, 3)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (!is.data.frame(x)) {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    } else {
+      x
+    }
+    dat$.outcome <- y
+    p <- ncol(dat)
+    frame_name <- paste0("tmp_glmnet_dat_", sample.int(100000, 1))
+    tmp_train_dat = h2o::as.h2o(dat, destination_frame = frame_name)
+    out <- h2o::h2o.glm(
+      x = colnames(x),
+      y = ".outcome",
+      training_frame = tmp_train_dat,
+      family = if (is.factor(y)) "binomial" else "gaussian",
+      alpha = param$alpha,
+      lambda = param$lambda,
+      ...
+    )
+    h2o::h2o.getModel(out@model_id)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    frame_name <- paste0("new_glmnet_dat_", sample.int(100000, 1))
+    newdata <- h2o::as.h2o(newdata, destination_frame = frame_name)
+    as.data.frame(predict(modelFit, newdata), stringsAsFactors = TRUE)[, 1]
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    frame_name <- paste0("new_glmnet_dat_", sample.int(100000, 1))
+    newdata <- h2o::as.h2o(newdata, destination_frame = frame_name)
+    as.data.frame(predict(modelFit, newdata), stringsAsFactors = TRUE)[, -1]
+  },
+  predictors = function(object, ...) {
+    out <- as.data.frame(h2o::h2o.varimp(object), stringsAsFactors = TRUE)
+    colnames(out)[colnames(out) == "coefficients"] <- "Overall"
+    out <- out[!is.na(out$Overall), ]
+    out$names
+  },
+  varImp = function(object, ...) {
+    out <- as.data.frame(h2o::h2o.varimp(object), stringsAsFactors = TRUE)
+    colnames(out)[colnames(out) == "coefficients"] <- "Overall"
+    rownames(out) <- out$names
+    out <- out[!is.na(out$Overall), c("Overall"), drop = FALSE]
+    all_var <- object@allparameters$x
+    if (any(!(all_var %in% rownames(out)))) {
+      missing <- all_var[!(all_var %in% rownames(out))]
+      tmp <- data.frame(OVerall = rep(0, length(missing)))
+      rownames(tmp) <- missing
+      out <- rbind(out, tmp)
+    }
+    out
+  },
+  levels = NULL,
+  tags = c(
+    "Generalized Linear Model",
+    "Implicit Feature Selection",
+    "L1 Regularization",
+    "L2 Regularization",
+    "Linear Classifier",
+    "Linear Regression",
+    "Two Class Only"
+  ),
+  sort = function(x) x[order(-x$lambda, x$alpha), ],
+  trim = NULL
+)

--- a/inst/model_sources/files/gpls.R
+++ b/inst/model_sources/files/gpls.R
@@ -1,32 +1,40 @@
-modelInfo <- list(label = "Generalized Partial Least Squares",
-                  library = "gpls",
-                  loop = NULL,
-                  type = c('Classification'),
-                  parameters = data.frame(parameter = c('K.prov'),
-                                          class = c('numeric'),
-                                          label = c('#Components')),
-                  grid = function(x, y, len = NULL, search = "grid")  {
-                    if(search == "grid") {
-                      out <- data.frame(K.prov =seq(1, len))
-                    } else {
-                      out <- data.frame(K.prov = unique(sample(1:ncol(x), size = len, replace = TRUE)))
-                    }
-                    out
-                    },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...)
-                    gpls::gpls(x, y, K.prov = param$K.prov, ...),
-                  predict = function(modelFit, newdata, submodels = NULL)
-                    predict(modelFit, newdata)$class,
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata)$predicted
-                    out <- cbind(out, 1-out)
-                    colnames(out) <-  modelFit$obsLevels
-                    out
-                  },
-                  predictors = function(x, ...) {
-                    out <- if(hasTerms(x)) predictors(x$terms) else colnames(x$data$x.order)
-                    out[!(out %in% "Intercept")]
-                  },
-                  tags = c("Logistic Regression", "Partial Least Squares", "Linear Classifier"),
-                  sort = function(x) x[order(x[,1]),],
-                  levels = function(x) x$obsLevels)
+modelInfo <- list(
+  label = "Generalized Partial Least Squares",
+  library = "gpls",
+  loop = NULL,
+  type = c('Classification'),
+  parameters = data.frame(
+    parameter = c('K.prov'),
+    class = c('numeric'),
+    label = c('#Components')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(K.prov = seq(1, len))
+    } else {
+      out <- data.frame(
+        K.prov = unique(sample(1:ncol(x), size = len, replace = TRUE))
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    gpls::gpls(x, y, K.prov = param$K.prov, ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)$class
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata)$predicted
+    out <- cbind(out, 1 - out)
+    colnames(out) <- modelFit$obsLevels
+    out
+  },
+  predictors = function(x, ...) {
+    out <- if (hasTerms(x)) predictors(x$terms) else colnames(x$data$x.order)
+    out[!(out %in% "Intercept")]
+  },
+  tags = c("Logistic Regression", "Partial Least Squares", "Linear Classifier"),
+  sort = function(x) x[order(x[, 1]), ],
+  levels = function(x) x$obsLevels
+)

--- a/inst/model_sources/files/gpls.R
+++ b/inst/model_sources/files/gpls.R
@@ -31,7 +31,11 @@ modelInfo <- list(
     out
   },
   predictors = function(x, ...) {
-    out <- if (hasTerms(x)) predictors(x$terms) else colnames(x$data$x.order)
+    if (hasTerms(x)) {
+      out <- predictors(x$terms)
+    } else {
+      out <- colnames(x$data$x.order)
+    }
     out[!(out %in% "Intercept")]
   },
   tags = c("Logistic Regression", "Partial Least Squares", "Linear Classifier"),

--- a/inst/model_sources/files/hda.R
+++ b/inst/model_sources/files/hda.R
@@ -1,39 +1,58 @@
-modelInfo <- list(label = "Heteroscedastic Discriminant Analysis",
-                  library = "hda",
-                  loop = NULL,
-                  type = c('Classification'),
-                  parameters = data.frame(parameter = c('gamma', 'lambda', 'newdim'),
-                                          class = c('numeric', 'numeric', 'numeric'),
-                                          label = c('Gamma', 'Lambda', 'Dimension of the Discriminative Subspace')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(gamma = seq(0.1, 1, length = len),
-                                         lambda =  seq(0, 1, length = len),
-                                         newdim = 2:(min(len, ncol(x))))
-                    } else {
-                      out <- data.frame(gamma = runif(len, min = 0, max = 1),
-                                        lambda = runif(len, min = 0, max = 1),
-                                        newdim = sample(2:ncol(x), size = len, replace = TRUE))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...)
-                    hda::hda(x, y,
-                        newdim = param$newdim,
-                        reg.lamb = param$lambda,
-                        reg.gamm = param$gamma,
-                        crule = TRUE, ...),
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    tmp <- predict(modelFit, as.matrix(newdata))
-                    if(is.vector(tmp)) tmp <- matrix(tmp, ncol = 1)
-                    as.character(predict(modelFit$naivebayes, tmp))
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    tmp <- predict(modelFit, as.matrix(newdata))
-                    if(is.vector(tmp)) tmp <- matrix(tmp, ncol = 1)
-                    as.data.frame(predict(modelFit$naivebayes, tmp, type = "raw"),
-                                  stringsAsFactors = FALSE)
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("Discriminant Analysis", "Linear Classifier", "Regularization"),
-                  sort = function(x) x[order(x$newdim, -x$lambda, x$gamma),])
+modelInfo <- list(
+  label = "Heteroscedastic Discriminant Analysis",
+  library = "hda",
+  loop = NULL,
+  type = c('Classification'),
+  parameters = data.frame(
+    parameter = c('gamma', 'lambda', 'newdim'),
+    class = c('numeric', 'numeric', 'numeric'),
+    label = c('Gamma', 'Lambda', 'Dimension of the Discriminative Subspace')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        gamma = seq(0.1, 1, length = len),
+        lambda = seq(0, 1, length = len),
+        newdim = 2:(min(len, ncol(x)))
+      )
+    } else {
+      out <- data.frame(
+        gamma = runif(len, min = 0, max = 1),
+        lambda = runif(len, min = 0, max = 1),
+        newdim = sample(2:ncol(x), size = len, replace = TRUE)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    hda::hda(
+      x,
+      y,
+      newdim = param$newdim,
+      reg.lamb = param$lambda,
+      reg.gamm = param$gamma,
+      crule = TRUE,
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    tmp <- predict(modelFit, as.matrix(newdata))
+    if (is.vector(tmp)) {
+      tmp <- matrix(tmp, ncol = 1)
+    }
+    as.character(predict(modelFit$naivebayes, tmp))
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    tmp <- predict(modelFit, as.matrix(newdata))
+    if (is.vector(tmp)) {
+      tmp <- matrix(tmp, ncol = 1)
+    }
+    as.data.frame(
+      predict(modelFit$naivebayes, tmp, type = "raw"),
+      stringsAsFactors = FALSE
+    )
+  },
+  levels = function(x) x$obsLevels,
+  tags = c("Discriminant Analysis", "Linear Classifier", "Regularization"),
+  sort = function(x) x[order(x$newdim, -x$lambda, x$gamma), ]
+)

--- a/inst/model_sources/files/hdda.R
+++ b/inst/model_sources/files/hdda.R
@@ -1,32 +1,59 @@
-modelInfo <- list(label = "High Dimensional Discriminant Analysis",
-                  library = "HDclassif",
-                  loop = NULL,
-                  type = c('Classification'),
-                  parameters = data.frame(parameter = c('threshold', 'model'),
-                                          class = c('character', 'numeric'),
-                                          label = c('Threshold', 'Model Type')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    mods <- c("AkjBkQkDk", "AkBkQkDk", "ABkQkDk", "AkjBQkDk", "AkBQkDk", 
-                              "ABQkDk", "AkjBkQkD", "AkBkQkD", "ABkQkD", "AkjBQkD", 
-                              "AkBQkD", "ABQkD", "AjBQD", "ABQD")
-                    if(search == "grid") {
-                      out <- expand.grid(model = c("all"), 
-                                         threshold = seq(0.05, .3, length = len))
-                    } else {
-                      out <- data.frame(model = sample(mods, size = len, replace = TRUE),
-                                        threshold = runif(len, min = 0, max = 1))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    HDclassif::hdda(x, y, model = as.character(param$model), threshold = param$threshold, ...)
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    as.character(predict(modelFit, newdata)$class)
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    data.frame(unclass(predict(modelFit, newdata)$posterior))
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("Discriminant Analysis", "Linear Classifier"),
-                  sort = function(x) x[order(-x$threshold),])
+modelInfo <- list(
+  label = "High Dimensional Discriminant Analysis",
+  library = "HDclassif",
+  loop = NULL,
+  type = c('Classification'),
+  parameters = data.frame(
+    parameter = c('threshold', 'model'),
+    class = c('character', 'numeric'),
+    label = c('Threshold', 'Model Type')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    mods <- c(
+      "AkjBkQkDk",
+      "AkBkQkDk",
+      "ABkQkDk",
+      "AkjBQkDk",
+      "AkBQkDk",
+      "ABQkDk",
+      "AkjBkQkD",
+      "AkBkQkD",
+      "ABkQkD",
+      "AkjBQkD",
+      "AkBQkD",
+      "ABQkD",
+      "AjBQD",
+      "ABQD"
+    )
+    if (search == "grid") {
+      out <- expand.grid(
+        model = c("all"),
+        threshold = seq(0.05, .3, length = len)
+      )
+    } else {
+      out <- data.frame(
+        model = sample(mods, size = len, replace = TRUE),
+        threshold = runif(len, min = 0, max = 1)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    HDclassif::hdda(
+      x,
+      y,
+      model = as.character(param$model),
+      threshold = param$threshold,
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    as.character(predict(modelFit, newdata)$class)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    data.frame(unclass(predict(modelFit, newdata)$posterior))
+  },
+  levels = function(x) x$obsLevels,
+  tags = c("Discriminant Analysis", "Linear Classifier"),
+  sort = function(x) x[order(-x$threshold), ]
+)

--- a/inst/model_sources/files/hdrda.R
+++ b/inst/model_sources/files/hdrda.R
@@ -1,37 +1,60 @@
-modelInfo <- list(label = "High-Dimensional Regularized Discriminant Analysis",
-                  library = "sparsediscrim",
-                  loop = NULL,
-                  type = "Classification",
-                  parameters = data.frame(parameter = c("gamma", "lambda", "shrinkage_type"),
-                                          class = c(rep("numeric", 2), "character"),
-                                          label = c("Gamma", "Lambda", "Shrinkage Type")),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- expand.grid(gamma = seq(0, 1, length = len), 
-                                         lambda =  seq(0, 1, length = len),
-                                         shrinkage_type = c("ridge", "convex"))
-                    } else {
-                      out <- data.frame(gamma = runif(len, min = 0, max = 1), 
-                                        lambda = runif(len, min = 0, max = 1),
-                                        shrinkage_type = sample(c("ridge", "convex"), size = len, replace = TRUE))
-                    }
-                    out
-                  }, 
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    sparsediscrim::hdrda(x, y, gamma = param$gamma, lambda = param$lambda,
-                          shrinkage_type = as.character(param$shrinkage_type),
-                          ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) 
-                    predict(modelFit, newdata)$class,
-                  prob = function(modelFit, newdata, submodels = NULL)
-                    predict(modelFit, newdata)$posterior,
-                  predictors = function(x, ...) x$varnames,
-                  tags = c("Discriminant Analysis", "Polynomial Model", "Regularization",
-                           "Linear Classifier"),
-                  levels = function(x) names(x$prior),
-                  sort = function(x) {
-                    # since lds is less complex than qda, we
-                    # sort on lambda (larger are least complex)
-                    x[order(-x$lambda, x$gamma),] 
-                  })
+modelInfo <- list(
+  label = "High-Dimensional Regularized Discriminant Analysis",
+  library = "sparsediscrim",
+  loop = NULL,
+  type = "Classification",
+  parameters = data.frame(
+    parameter = c("gamma", "lambda", "shrinkage_type"),
+    class = c(rep("numeric", 2), "character"),
+    label = c("Gamma", "Lambda", "Shrinkage Type")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        gamma = seq(0, 1, length = len),
+        lambda = seq(0, 1, length = len),
+        shrinkage_type = c("ridge", "convex")
+      )
+    } else {
+      out <- data.frame(
+        gamma = runif(len, min = 0, max = 1),
+        lambda = runif(len, min = 0, max = 1),
+        shrinkage_type = sample(
+          c("ridge", "convex"),
+          size = len,
+          replace = TRUE
+        )
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    sparsediscrim::hdrda(
+      x,
+      y,
+      gamma = param$gamma,
+      lambda = param$lambda,
+      shrinkage_type = as.character(param$shrinkage_type),
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)$class
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)$posterior
+  },
+  predictors = function(x, ...) x$varnames,
+  tags = c(
+    "Discriminant Analysis",
+    "Polynomial Model",
+    "Regularization",
+    "Linear Classifier"
+  ),
+  levels = function(x) names(x$prior),
+  sort = function(x) {
+    # since lds is less complex than qda, we
+    # sort on lambda (larger are least complex)
+    x[order(-x$lambda, x$gamma), ]
+  }
+)

--- a/inst/model_sources/files/icr.R
+++ b/inst/model_sources/files/icr.R
@@ -1,22 +1,30 @@
-modelInfo <- list(label = "Independent Component Regression",
-                  library = "fastICA",
-                  loop = NULL,
-                  type = c('Regression'),
-                  parameters = data.frame(parameter = c('n.comp'),
-                                          class = c('numeric'),
-                                          label = c('#Components')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- data.frame(n.comp = 1:len)
-                    } else {
-                      out <- data.frame(n.comp = unique(sample(1:ncol(x), size = len, replace = TRUE)))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    caret::icr(x, y, n.comp = param$n.comp, ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) predict(modelFit, newdata),
-                  prob = NULL,
-                  tags = c("Linear Regression", "Feature Extraction"),
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Independent Component Regression",
+  library = "fastICA",
+  loop = NULL,
+  type = c('Regression'),
+  parameters = data.frame(
+    parameter = c('n.comp'),
+    class = c('numeric'),
+    label = c('#Components')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(n.comp = 1:len)
+    } else {
+      out <- data.frame(
+        n.comp = unique(sample(1:ncol(x), size = len, replace = TRUE))
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    caret::icr(x, y, n.comp = param$n.comp, ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)
+  },
+  prob = NULL,
+  tags = c("Linear Regression", "Feature Extraction"),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/kernelpls.R
+++ b/inst/model_sources/files/kernelpls.R
@@ -25,16 +25,16 @@ modelInfo <- list(
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
     ncomp <- min(ncol(x), param$ncomp)
-    out <- if (is.factor(y)) {
-      caret::plsda(x, y, method = "kernelpls", ncomp = ncomp, ...)
+    if (is.factor(y)) {
+      out <- caret::plsda(x, y, method = "kernelpls", ncomp = ncomp, ...)
     } else {
-      dat <- if (is.data.frame(x)) {
-        x
+      if (is.data.frame(x)) {
+        dat <- x
       } else {
-        as.data.frame(x, stringsAsFactors = TRUE)
+        dat <- as.data.frame(x, stringsAsFactors = TRUE)
       }
       dat$.outcome <- y
-      pls::plsr(
+      out <- pls::plsr(
         .outcome ~ .,
         data = dat,
         method = "kernelpls",
@@ -45,13 +45,13 @@ modelInfo <- list(
     out
   },
   predict = function(modelFit, newdata, submodels = NULL) {
-    out <- if (modelFit$problemType == "Classification") {
+    if (modelFit$problemType == "Classification") {
       if (!is.matrix(newdata)) {
         newdata <- as.matrix(newdata)
       }
       out <- predict(modelFit, newdata, type = "class")
     } else {
-      as.vector(pls:::predict.mvr(
+      out <- as.vector(pls:::predict.mvr(
         modelFit,
         newdata,
         ncomp = max(modelFit$ncomp)
@@ -137,7 +137,11 @@ modelInfo <- list(
 
     nms <- dimnames(perf)
     if (length(nms$estimate) > 1) {
-      pIndex <- if (is.null(estimate)) 1 else which(nms$estimate == estimate)
+      if (is.null(estimate)) {
+        pIndex <- 1
+      } else {
+        pIndex <- which(nms$estimate == estimate)
+      }
       perf <- perf[pIndex, , , drop = FALSE]
     }
     numResp <- dim(modelCoef)[2]

--- a/inst/model_sources/files/kernelpls.R
+++ b/inst/model_sources/files/kernelpls.R
@@ -1,134 +1,177 @@
-modelInfo <- list(label = "Partial Least Squares",
-                  library = "pls",
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = 'ncomp',
-                                          class = "numeric",
-                                          label = '#Components'),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- data.frame(ncomp = seq(1, min(ncol(x) - 1, len), by = 1))
-                    } else {
-                      out <- data.frame(ncomp = unique(sample(1:ncol(x), size = len, replace = TRUE)))
-                    }
-                    out
-                  },
-                  loop = function(grid) {
-                    grid <- grid[order(grid$ncomp, decreasing = TRUE),, drop = FALSE]
-                    loop <- grid[1,,drop = FALSE]
-                    submodels <- list(grid[-1,,drop = FALSE])
-                    list(loop = loop, submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    ncomp <- min(ncol(x), param$ncomp)
-                    out <- if(is.factor(y))
-                    {
-                      caret::plsda(x, y, method = "kernelpls", ncomp = ncomp, ...)
-                    } else {
-                      dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                      dat$.outcome <- y
-                      pls::plsr(.outcome ~ ., data = dat, method = "kernelpls", ncomp = ncomp, ...)
-                    }
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- if(modelFit$problemType == "Classification")
-                    {
-                      if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                      out <- predict(modelFit, newdata, type="class")
+modelInfo <- list(
+  label = "Partial Least Squares",
+  library = "pls",
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = 'ncomp',
+    class = "numeric",
+    label = '#Components'
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(ncomp = seq(1, min(ncol(x) - 1, len), by = 1))
+    } else {
+      out <- data.frame(
+        ncomp = unique(sample(1:ncol(x), size = len, replace = TRUE))
+      )
+    }
+    out
+  },
+  loop = function(grid) {
+    grid <- grid[order(grid$ncomp, decreasing = TRUE), , drop = FALSE]
+    loop <- grid[1, , drop = FALSE]
+    submodels <- list(grid[-1, , drop = FALSE])
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    ncomp <- min(ncol(x), param$ncomp)
+    out <- if (is.factor(y)) {
+      caret::plsda(x, y, method = "kernelpls", ncomp = ncomp, ...)
+    } else {
+      dat <- if (is.data.frame(x)) {
+        x
+      } else {
+        as.data.frame(x, stringsAsFactors = TRUE)
+      }
+      dat$.outcome <- y
+      pls::plsr(
+        .outcome ~ .,
+        data = dat,
+        method = "kernelpls",
+        ncomp = ncomp,
+        ...
+      )
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- if (modelFit$problemType == "Classification") {
+      if (!is.matrix(newdata)) {
+        newdata <- as.matrix(newdata)
+      }
+      out <- predict(modelFit, newdata, type = "class")
+    } else {
+      as.vector(pls:::predict.mvr(
+        modelFit,
+        newdata,
+        ncomp = max(modelFit$ncomp)
+      ))
+    }
 
-                    } else as.vector(pls:::predict.mvr(modelFit, newdata, ncomp = max(modelFit$ncomp)))
+    if (!is.null(submodels)) {
+      ## We'll merge the first set of predictions below
+      tmp <- vector(mode = "list", length = nrow(submodels))
 
-                    if(!is.null(submodels))
-                    {
-                      ## We'll merge the first set of predictions below
-                      tmp <- vector(mode = "list", length = nrow(submodels))
+      if (modelFit$problemType == "Classification") {
+        if (length(submodels$ncomp) > 1) {
+          tmp <- as.list(predict(modelFit, newdata, ncomp = submodels$ncomp))
+        } else {
+          tmp <- list(predict(modelFit, newdata, ncomp = submodels$ncomp))
+        }
+      } else {
+        tmp <- as.list(
+          as.data.frame(
+            apply(
+              predict(modelFit, newdata, ncomp = submodels$ncomp),
+              3,
+              function(x) list(x)
+            ),
+            stringsAsFActors = FALSE
+          )
+        )
+      }
 
-                      if(modelFit$problemType == "Classification")
-                      {
-                        if(length(submodels$ncomp) > 1)
-                        {
-                          tmp <- as.list(predict(modelFit, newdata, ncomp = submodels$ncomp))
-                        } else tmp <- list(predict(modelFit, newdata, ncomp = submodels$ncomp))
+      out <- c(list(out), tmp)
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- predict(
+      modelFit,
+      newdata,
+      type = "prob",
+      ncomp = modelFit$tuneValue$ncomp
+    )
+    if (length(dim(out)) == 3) {
+      if (dim(out)[1] > 1) {
+        out <- out[,, 1]
+      } else {
+        out <- as.data.frame(t(out[,, 1]), stringsAsFactors = TRUE)
+      }
+    }
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
 
-                      } else {
-                        tmp <- as.list(
-                          as.data.frame(
-                            apply(predict(modelFit, newdata, ncomp = submodels$ncomp), 3, function(x) list(x)),
-                            stringsAsFActors = FALSE
-                          )
-                        )
-                      }
+      for (j in seq(along = submodels$ncomp)) {
+        tmpProb <- predict(
+          modelFit,
+          newdata,
+          type = "prob",
+          ncomp = submodels$ncomp[j]
+        )
+        if (length(dim(tmpProb)) == 3) {
+          if (dim(tmpProb)[1] > 1) {
+            tmpProb <- tmpProb[,, 1]
+          } else {
+            tmpProb <- as.data.frame(t(tmpProb[,, 1]), stringsAsFactors = TRUE)
+          }
+        }
 
-                      out <- c(list(out), tmp)
-                    }
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    out <- predict(modelFit, newdata, type = "prob",  ncomp = modelFit$tuneValue$ncomp)
-                    if(length(dim(out)) == 3){
-                      if(dim(out)[1] > 1) {
-                        out <- out[,,1]
-                      } else {
-                        out <- as.data.frame(t(out[,,1]), stringsAsFactors = TRUE)
-                      }
-                    }
-                    if(!is.null(submodels))
-                    {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
+        tmp[[j + 1]] <- as.data.frame(
+          tmpProb[, modelFit$obsLevels, drop = FALSE],
+          stringsAsFactors = TRUE
+        )
+      }
+      out <- tmp
+    }
+    out
+  },
+  varImp = function(object, estimate = NULL, ...) {
+    library(pls)
+    modelCoef <- coef(object, intercept = FALSE, comps = 1:object$ncomp)
+    perf <- MSEP(object)$val
 
-                      for(j in seq(along = submodels$ncomp))
-                      {
-                        tmpProb <- predict(modelFit, newdata, type = "prob",  ncomp = submodels$ncomp[j])
-                        if(length(dim(tmpProb)) == 3){
-                          if(dim(tmpProb)[1] > 1) {
-                            tmpProb <- tmpProb[,,1]
-                          } else {
-                            tmpProb <- as.data.frame(t(tmpProb[,,1]), stringsAsFactors = TRUE)
-                          }
-                        }
+    nms <- dimnames(perf)
+    if (length(nms$estimate) > 1) {
+      pIndex <- if (is.null(estimate)) 1 else which(nms$estimate == estimate)
+      perf <- perf[pIndex, , , drop = FALSE]
+    }
+    numResp <- dim(modelCoef)[2]
 
-                        tmp[[j+1]] <- as.data.frame(tmpProb[, modelFit$obsLevels, drop = FALSE], stringsAsFactors = TRUE)
-                      }
-                      out <- tmp
-                    }
-                    out
-                  },
-                  varImp = function(object, estimate = NULL, ...) {
-                  	library(pls)
-                    modelCoef <- coef(object, intercept = FALSE, comps = 1:object$ncomp)
-                    perf <- MSEP(object)$val
+    if (numResp <= 2) {
+      modelCoef <- modelCoef[, 1, , drop = FALSE]
+      perf <- perf[, 1, ]
+      delta <- -diff(perf)
+      delta <- delta / sum(delta)
+      out <- data.frame(
+        Overall = apply(abs(modelCoef), 1, weighted.mean, w = delta)
+      )
+    } else {
+      perf <- -t(apply(perf[1, , ], 1, diff))
+      perf <- t(apply(perf, 1, function(u) u / sum(u)))
+      out <- matrix(NA, ncol = numResp, nrow = dim(modelCoef)[1])
 
-                    nms <- dimnames(perf)
-                    if(length(nms$estimate) > 1) {
-                      pIndex <- if(is.null(estimate)) 1 else which(nms$estimate == estimate)
-                      perf <- perf[pIndex,,,drop = FALSE]
-                    }
-                    numResp <- dim(modelCoef)[2]
-
-                    if(numResp <= 2) {
-                      modelCoef <- modelCoef[,1,,drop = FALSE]
-                      perf <- perf[,1,]
-                      delta <- -diff(perf)
-                      delta <- delta/sum(delta)
-                      out <- data.frame(Overall = apply(abs(modelCoef), 1,
-                                                        weighted.mean, w = delta))
-                    } else {
-                      perf <- -t(apply(perf[1,,], 1, diff))
-                      perf <- t(apply(perf, 1, function(u) u/sum(u)))
-                      out <- matrix(NA, ncol = numResp, nrow = dim(modelCoef)[1])
-
-                      for(i in 1:numResp) {
-                        tmp <- abs(modelCoef[,i,, drop = FALSE])
-                        out[,i] <- apply(tmp, 1,  weighted.mean, w = perf[i,])
-                      }
-                      colnames(out) <- dimnames(modelCoef)[[2]]
-                      rownames(out) <- dimnames(modelCoef)[[1]]
-                    }
-                    as.data.frame(out, stringsAsFactors = TRUE)
-                  },
-                  predictors = function(x, ...) rownames(x$projection),
-                  levels = function(x) x$obsLevels,
-                  tags = c("Partial Least Squares", "Feature Extraction", "Kernel Method", "Linear Classifier", "Linear Regression"),
-                  sort = function(x) x[order(x[,1]),])
+      for (i in 1:numResp) {
+        tmp <- abs(modelCoef[, i, , drop = FALSE])
+        out[, i] <- apply(tmp, 1, weighted.mean, w = perf[i, ])
+      }
+      colnames(out) <- dimnames(modelCoef)[[2]]
+      rownames(out) <- dimnames(modelCoef)[[1]]
+    }
+    as.data.frame(out, stringsAsFactors = TRUE)
+  },
+  predictors = function(x, ...) rownames(x$projection),
+  levels = function(x) x$obsLevels,
+  tags = c(
+    "Partial Least Squares",
+    "Feature Extraction",
+    "Kernel Method",
+    "Linear Classifier",
+    "Linear Regression"
+  ),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/kknn.R
+++ b/inst/model_sources/files/kknn.R
@@ -1,41 +1,73 @@
-modelInfo <- list(label = "k-Nearest Neighbors",
-                  library = "kknn",
-                  loop = NULL,
-                  type = c('Regression', 'Classification'),
-                  parameters = data.frame(parameter = c('kmax', 'distance', 'kernel'),
-                                          class = c('numeric', 'numeric', 'character'),
-                                          label = c('Max. #Neighbors', 'Distance', 'Kernel')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- data.frame(kmax = (5:((2 * len)+4))[(5:((2 * len)+4))%%2 > 0], 
-                                        distance = 2, 
-                                        kernel = "optimal")
-                    } else {
-                      by_val <- if(is.factor(y)) length(levels(y)) else 1
-                      kerns <- c("rectangular", "triangular", "epanechnikov", "biweight", "triweight", 
-                                 "cos", "inv", "gaussian")
-                      out <- data.frame(kmax = sample(seq(1, floor(nrow(x)/3), by = by_val), size = len, replace = TRUE),
-                                        distance = runif(len, min = 0, max = 3),
-                                        kernel = sample(kerns, size = len, replace = TRUE))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    kknn::train.kknn(.outcome ~ ., data = dat,
-                               kmax = param$kmax,
-                               distance = param$distance,
-                               kernel = as.character(param$kernel), ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata)
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = "Prototype Models",
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata, type = "prob")
-                  },
-                  sort = function(x) x[order(-x[,1]),])
+modelInfo <- list(
+  label = "k-Nearest Neighbors",
+  library = "kknn",
+  loop = NULL,
+  type = c('Regression', 'Classification'),
+  parameters = data.frame(
+    parameter = c('kmax', 'distance', 'kernel'),
+    class = c('numeric', 'numeric', 'character'),
+    label = c('Max. #Neighbors', 'Distance', 'Kernel')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(
+        kmax = (5:((2 * len) + 4))[(5:((2 * len) + 4)) %% 2 > 0],
+        distance = 2,
+        kernel = "optimal"
+      )
+    } else {
+      by_val <- if (is.factor(y)) length(levels(y)) else 1
+      kerns <- c(
+        "rectangular",
+        "triangular",
+        "epanechnikov",
+        "biweight",
+        "triweight",
+        "cos",
+        "inv",
+        "gaussian"
+      )
+      out <- data.frame(
+        kmax = sample(
+          seq(1, floor(nrow(x) / 3), by = by_val),
+          size = len,
+          replace = TRUE
+        ),
+        distance = runif(len, min = 0, max = 3),
+        kernel = sample(kerns, size = len, replace = TRUE)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    kknn::train.kknn(
+      .outcome ~ .,
+      data = dat,
+      kmax = param$kmax,
+      distance = param$distance,
+      kernel = as.character(param$kernel),
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata)
+  },
+  levels = function(x) x$obsLevels,
+  tags = "Prototype Models",
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata, type = "prob")
+  },
+  sort = function(x) x[order(-x[, 1]), ]
+)

--- a/inst/model_sources/files/kknn.R
+++ b/inst/model_sources/files/kknn.R
@@ -16,7 +16,11 @@ modelInfo <- list(
         kernel = "optimal"
       )
     } else {
-      by_val <- if (is.factor(y)) length(levels(y)) else 1
+      if (is.factor(y)) {
+        by_val <- length(levels(y))
+      } else {
+        by_val <- 1
+      }
       kerns <- c(
         "rectangular",
         "triangular",
@@ -40,10 +44,10 @@ modelInfo <- list(
     out
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     kknn::train.kknn(

--- a/inst/model_sources/files/knn.R
+++ b/inst/model_sources/files/knn.R
@@ -12,7 +12,11 @@ modelInfo <- list(
     if (search == "grid") {
       out <- data.frame(k = (5:((2 * len) + 4))[(5:((2 * len) + 4)) %% 2 > 0])
     } else {
-      by_val <- if (is.factor(y)) length(levels(y)) else 1
+      if (is.factor(y)) {
+        by_val <- length(levels(y))
+      } else {
+        by_val <- 1
+      }
       out <- data.frame(
         k = sample(
           seq(1, floor(nrow(x) / 3), by = by_val),

--- a/inst/model_sources/files/knn.R
+++ b/inst/model_sources/files/knn.R
@@ -1,38 +1,47 @@
-modelInfo <- list(label = "k-Nearest Neighbors",
-                  library = NULL,
-                  loop = NULL,
-                  type = c("Classification", "Regression"),
-                  parameters = data.frame(parameter = "k",
-                                          class = "numeric",
-                                          label = "#Neighbors"),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- data.frame(k = (5:((2 * len)+4))[(5:((2 * len)+4))%%2 > 0])
-                    } else {
-                      by_val <- if(is.factor(y)) length(levels(y)) else 1
-                      out <- data.frame(k = sample(seq(1, floor(nrow(x)/3), by = by_val), size = len, replace = TRUE))
-                    }
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    if(is.factor(y))
-                    {
-                      knn3(as.matrix(x), y, k = param$k, ...)
-                    } else {
-                      knnreg(as.matrix(x), y, k = param$k, ...)
-                    }
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(modelFit$problemType == "Classification")
-                    {
-                      out <- predict(modelFit, newdata,  type = "class")
-                    } else {
-                      out <- predict(modelFit, newdata)
-                    }
-                    out
-                  },
-                  predictors = function(x, ...) colnames(x$learn$X),
-                  tags = "Prototype Models",
-                  prob = function(modelFit, newdata, submodels = NULL)
-                    predict(modelFit, newdata, type = "prob"),
-                  levels = function(x) levels(x$learn$y),
-                  sort = function(x) x[order(-x[,1]),])
+modelInfo <- list(
+  label = "k-Nearest Neighbors",
+  library = NULL,
+  loop = NULL,
+  type = c("Classification", "Regression"),
+  parameters = data.frame(
+    parameter = "k",
+    class = "numeric",
+    label = "#Neighbors"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(k = (5:((2 * len) + 4))[(5:((2 * len) + 4)) %% 2 > 0])
+    } else {
+      by_val <- if (is.factor(y)) length(levels(y)) else 1
+      out <- data.frame(
+        k = sample(
+          seq(1, floor(nrow(x) / 3), by = by_val),
+          size = len,
+          replace = TRUE
+        )
+      )
+    }
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (is.factor(y)) {
+      knn3(as.matrix(x), y, k = param$k, ...)
+    } else {
+      knnreg(as.matrix(x), y, k = param$k, ...)
+    }
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (modelFit$problemType == "Classification") {
+      out <- predict(modelFit, newdata, type = "class")
+    } else {
+      out <- predict(modelFit, newdata)
+    }
+    out
+  },
+  predictors = function(x, ...) colnames(x$learn$X),
+  tags = "Prototype Models",
+  prob = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata, type = "prob")
+  },
+  levels = function(x) levels(x$learn$y),
+  sort = function(x) x[order(-x[, 1]), ]
+)

--- a/inst/model_sources/files/krlsPoly.R
+++ b/inst/model_sources/files/krlsPoly.R
@@ -1,33 +1,48 @@
-modelInfo <- list(label ="Polynomial Kernel Regularized Least Squares",
-                  library = c("KRLS"),
-                  loop = NULL,
-                  type = c('Regression'),
-                  parameters = data.frame(parameter = c('lambda', 'degree'),
-                                          class = c('numeric', 'numeric'),
-                                          label = c('Regularization Parameter', 'Polynomial Degree')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(lambda = NA, degree = 1:3)
-                    } else {
-                      out <- data.frame(lambda = 10^runif(len, min = -5, 0),
-                                        degree = sample(1:3, size = len, replace = TRUE))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    if(!(param$degree %in% 1:4)) stop("Degree should be either 1, 2, 3 or 4")
-                    krn <- switch(param$degree,
-                                  '1' = "linear",
-                                  '2' = "poly2",
-                                  '3' = "poly3",
-                                  '4' = "poly4")
-                    KRLS::krls(x, y, lambda = if(is.na(param$lambda)) NULL else param$lambda,
-                               derivative = FALSE,
-                               whichkernel = krn, ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    KRLS:::predict.krls(modelFit, newdata)$fit[,1]
-                  },
-                  tags = c("Kernel Method", "L2 Regularization", "Polynomial Model"),
-                  prob = NULL,
-                  sort = function(x) x[order(x$degree, x$lambda),])
+modelInfo <- list(
+  label = "Polynomial Kernel Regularized Least Squares",
+  library = c("KRLS"),
+  loop = NULL,
+  type = c('Regression'),
+  parameters = data.frame(
+    parameter = c('lambda', 'degree'),
+    class = c('numeric', 'numeric'),
+    label = c('Regularization Parameter', 'Polynomial Degree')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(lambda = NA, degree = 1:3)
+    } else {
+      out <- data.frame(
+        lambda = 10^runif(len, min = -5, 0),
+        degree = sample(1:3, size = len, replace = TRUE)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (!(param$degree %in% 1:4)) {
+      stop("Degree should be either 1, 2, 3 or 4")
+    }
+    krn <- switch(
+      param$degree,
+      '1' = "linear",
+      '2' = "poly2",
+      '3' = "poly3",
+      '4' = "poly4"
+    )
+    KRLS::krls(
+      x,
+      y,
+      lambda = if (is.na(param$lambda)) NULL else param$lambda,
+      derivative = FALSE,
+      whichkernel = krn,
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    KRLS:::predict.krls(modelFit, newdata)$fit[, 1]
+  },
+  tags = c("Kernel Method", "L2 Regularization", "Polynomial Model"),
+  prob = NULL,
+  sort = function(x) x[order(x$degree, x$lambda), ]
+)

--- a/inst/model_sources/files/krlsRadial.R
+++ b/inst/model_sources/files/krlsRadial.R
@@ -1,43 +1,57 @@
-modelInfo <- list(label = "Radial Basis Function Kernel Regularized Least Squares",
-                  library = c("KRLS", "kernlab"),
-                  loop = NULL,
-                  type = c('Regression'),
-                  parameters = data.frame(parameter = c('lambda', 'sigma'),
-                                          class = c('numeric', 'numeric'),
-                                          label = c('Regularization Parameter', 'Sigma')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    ## this was changed to follow what kernlab does inside of ksvm and rvm:
-                    sigmaEstimate <- try(kernlab::sigest(x, na.action = na.omit, scaled = TRUE),
-                                         silent = TRUE)
-                    if(!(class(sigmaEstimate) == "try-error")) {
-                      if(search == "grid") {
-                        out <- expand.grid(lambda = NA, 
-                                           sigma = 1/seq(sigmaEstimate[1], sigmaEstimate[3], length = len))
-                      } else {
-                        rng <- extendrange(log(sigmaEstimate), f = .75)
-                        out <- data.frame(lambda = 10^runif(len, min = -5, 0),
-                                          sigma = 1/exp(runif(len, min = rng[1], max = rng[2])))
-                      }
-                      
-                    } else {
-                      if(search == "grid") {
-                        out <- expand.grid(lambda = NA, 
-                                           sigma = 1/(10 ^((1:len) - 3))) 
-                      } else {
-                        out <- data.frame(lambda = 10^runif(len, min = -5, 0),
-                                          sigma = 1/(10^runif(len, min = -4, max = 0)))
-                      }
-                    }
-                    out
-                  }
-                  ,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    KRLS::krls(x, y, lambda = if(is.na(param$lambda)) NULL else param$lambda,
-                               sigma = param$sigma, ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    KRLS:::predict.krls(modelFit, newdata)$fit[,1]
-                  },
-                  tags = c("Kernel Method", "L2 Regularization", "Radial Basis Function"),
-                  prob = NULL,
-                  sort = function(x) x[order(x$lambda),])
+modelInfo <- list(
+  label = "Radial Basis Function Kernel Regularized Least Squares",
+  library = c("KRLS", "kernlab"),
+  loop = NULL,
+  type = c('Regression'),
+  parameters = data.frame(
+    parameter = c('lambda', 'sigma'),
+    class = c('numeric', 'numeric'),
+    label = c('Regularization Parameter', 'Sigma')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    ## this was changed to follow what kernlab does inside of ksvm and rvm:
+    sigmaEstimate <- try(
+      kernlab::sigest(x, na.action = na.omit, scaled = TRUE),
+      silent = TRUE
+    )
+    if (!(class(sigmaEstimate) == "try-error")) {
+      if (search == "grid") {
+        out <- expand.grid(
+          lambda = NA,
+          sigma = 1 / seq(sigmaEstimate[1], sigmaEstimate[3], length = len)
+        )
+      } else {
+        rng <- extendrange(log(sigmaEstimate), f = .75)
+        out <- data.frame(
+          lambda = 10^runif(len, min = -5, 0),
+          sigma = 1 / exp(runif(len, min = rng[1], max = rng[2]))
+        )
+      }
+    } else {
+      if (search == "grid") {
+        out <- expand.grid(lambda = NA, sigma = 1 / (10^((1:len) - 3)))
+      } else {
+        out <- data.frame(
+          lambda = 10^runif(len, min = -5, 0),
+          sigma = 1 / (10^runif(len, min = -4, max = 0))
+        )
+      }
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    KRLS::krls(
+      x,
+      y,
+      lambda = if (is.na(param$lambda)) NULL else param$lambda,
+      sigma = param$sigma,
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    KRLS:::predict.krls(modelFit, newdata)$fit[, 1]
+  },
+  tags = c("Kernel Method", "L2 Regularization", "Radial Basis Function"),
+  prob = NULL,
+  sort = function(x) x[order(x$lambda), ]
+)

--- a/inst/model_sources/files/lars.R
+++ b/inst/model_sources/files/lars.R
@@ -1,66 +1,78 @@
-modelInfo <- list(label = "Least Angle Regression",
-                  library = "lars",
-                  type = "Regression",
-                  parameters = data.frame(parameter = 'fraction',
-                                          class = "numeric",
-                                          label = 'Fraction'),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <-  expand.grid(fraction = seq(0.05, 1, length = len))
-                    } else {
-                      out <- data.frame(fraction = runif(len, min = 0, max = 1))
-                    }
-                    out
-                  },
-                  loop = function(grid) {   
-                    grid <- grid[order(grid$fraction, decreasing = TRUE),, drop = FALSE]
-                    loop <- grid[1,,drop = FALSE]
-                    submodels <- list(grid[-1,,drop = FALSE])     
-                    list(loop = loop, submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...)
-                    lars::lars(as.matrix(x), y, ...),
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit,
-                                   as.matrix(newdata),
-                                   type = "fit",
-                                   mode = "fraction",
-                                   s = modelFit$tuneValue$fraction)$fit
-                    
-                    if(!is.null(submodels))
-                    {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
-                      
-                      for(j in seq(along = submodels$fraction))
-                      {
-                        tmp[[j+1]] <- predict(modelFit,
-                                              as.matrix(newdata),
-                                              type = "fit",
-                                              mode = "fraction",
-                                              s = submodels$fraction[j])$fit
-                      }
-                      out <- tmp
-                    }
-                    out        
-                  },
-                  predictors = function(x, s = NULL, ...) {
-                    if(is.null(s))
-                    {
-                      if(!is.null(x$tuneValue))
-                      {
-                        s <- x$tuneValue$fraction
-                      } else stop("must supply a vaue of s")
-                      out <- predict(x, s = s,
-                                     type = "coefficients",
-                                     mode = "fraction")$coefficients
-                      
-                    } else {
-                      out <- predict(x, s = s, ...)$coefficients
-                      
-                    }
-                    names(out)[out != 0]
-                  },
-                  tags = c("Linear Regression", "Implicit Feature Selection", "L1 Regularization"),
-                  prob = NULL,
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Least Angle Regression",
+  library = "lars",
+  type = "Regression",
+  parameters = data.frame(
+    parameter = 'fraction',
+    class = "numeric",
+    label = 'Fraction'
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(fraction = seq(0.05, 1, length = len))
+    } else {
+      out <- data.frame(fraction = runif(len, min = 0, max = 1))
+    }
+    out
+  },
+  loop = function(grid) {
+    grid <- grid[order(grid$fraction, decreasing = TRUE), , drop = FALSE]
+    loop <- grid[1, , drop = FALSE]
+    submodels <- list(grid[-1, , drop = FALSE])
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    lars::lars(as.matrix(x), y, ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(
+      modelFit,
+      as.matrix(newdata),
+      type = "fit",
+      mode = "fraction",
+      s = modelFit$tuneValue$fraction
+    )$fit
+
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
+
+      for (j in seq(along = submodels$fraction)) {
+        tmp[[j + 1]] <- predict(
+          modelFit,
+          as.matrix(newdata),
+          type = "fit",
+          mode = "fraction",
+          s = submodels$fraction[j]
+        )$fit
+      }
+      out <- tmp
+    }
+    out
+  },
+  predictors = function(x, s = NULL, ...) {
+    if (is.null(s)) {
+      if (!is.null(x$tuneValue)) {
+        s <- x$tuneValue$fraction
+      } else {
+        stop("must supply a vaue of s")
+      }
+      out <- predict(
+        x,
+        s = s,
+        type = "coefficients",
+        mode = "fraction"
+      )$coefficients
+    } else {
+      out <- predict(x, s = s, ...)$coefficients
+    }
+    names(out)[out != 0]
+  },
+  tags = c(
+    "Linear Regression",
+    "Implicit Feature Selection",
+    "L1 Regularization"
+  ),
+  prob = NULL,
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/lars2.R
+++ b/inst/model_sources/files/lars2.R
@@ -1,68 +1,84 @@
-modelInfo <- list(label = "Least Angle Regression",
-                  library = "lars",
-                  type = "Regression",
-                  parameters = data.frame(parameter = 'step',
-                                          class = "numeric",
-                                          label = '#Steps'),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- data.frame(step = caret::var_seq(p = ncol(x), 
-                                                              classification = is.factor(y), 
-                                                              len = len))
-                    } else {
-                      out <- data.frame(step = sample(1:ncol(x), size = len, replace = TRUE))
-                    }
-                    out
-                  },
-                  loop = function(grid) {   
-                    grid <- grid[order(grid$step, decreasing = TRUE),, drop = FALSE]
-                    loop <- grid[1,,drop = FALSE]
-                    submodels <- list(grid[-1,,drop = FALSE])     
-                    list(loop = loop, submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...)
-                    lars::lars(as.matrix(x), y, ...),
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit,
-                                   as.matrix(newdata),
-                                   type = "fit",
-                                   mode = "step",
-                                   s = modelFit$tuneValue$step)$fit
-                    
-                    if(!is.null(submodels))
-                    {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
-                      
-                      for(j in seq(along = submodels$step))
-                      {
-                        tmp[[j+1]] <- predict(modelFit,
-                                              as.matrix(newdata),
-                                              type = "fit",
-                                              mode = "step",
-                                              s = submodels$step[j])$fit
-                      }
-                      out <- tmp
-                    }
-                    out       
-                  },
-                  predictors = function(x, s = NULL, ...) {
-                    if(is.null(s))
-                    {
-                      if(!is.null(x$tuneValue))
-                      {
-                        s <- x$tuneValue$.fraction
-                      } else stop("must supply a vaue of s")
-                      out <- predict(x, s = s,
-                                     type = "coefficients",
-                                     mode = "fraction")$coefficients
-                      
-                    } else {
-                      out <- predict(x, s = s, ...)$coefficients
-                      
-                    }
-                    names(out)[out != 0]
-                  },
-                  tags = c("Linear Regression", "Implicit Feature Selection", "L1 Regularization"),
-                  prob = NULL,
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Least Angle Regression",
+  library = "lars",
+  type = "Regression",
+  parameters = data.frame(
+    parameter = 'step',
+    class = "numeric",
+    label = '#Steps'
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(
+        step = caret::var_seq(
+          p = ncol(x),
+          classification = is.factor(y),
+          len = len
+        )
+      )
+    } else {
+      out <- data.frame(step = sample(1:ncol(x), size = len, replace = TRUE))
+    }
+    out
+  },
+  loop = function(grid) {
+    grid <- grid[order(grid$step, decreasing = TRUE), , drop = FALSE]
+    loop <- grid[1, , drop = FALSE]
+    submodels <- list(grid[-1, , drop = FALSE])
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    lars::lars(as.matrix(x), y, ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(
+      modelFit,
+      as.matrix(newdata),
+      type = "fit",
+      mode = "step",
+      s = modelFit$tuneValue$step
+    )$fit
+
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
+
+      for (j in seq(along = submodels$step)) {
+        tmp[[j + 1]] <- predict(
+          modelFit,
+          as.matrix(newdata),
+          type = "fit",
+          mode = "step",
+          s = submodels$step[j]
+        )$fit
+      }
+      out <- tmp
+    }
+    out
+  },
+  predictors = function(x, s = NULL, ...) {
+    if (is.null(s)) {
+      if (!is.null(x$tuneValue)) {
+        s <- x$tuneValue$.fraction
+      } else {
+        stop("must supply a vaue of s")
+      }
+      out <- predict(
+        x,
+        s = s,
+        type = "coefficients",
+        mode = "fraction"
+      )$coefficients
+    } else {
+      out <- predict(x, s = s, ...)$coefficients
+    }
+    names(out)[out != 0]
+  },
+  tags = c(
+    "Linear Regression",
+    "Implicit Feature Selection",
+    "L1 Regularization"
+  ),
+  prob = NULL,
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/lasso.R
+++ b/inst/model_sources/files/lasso.R
@@ -1,69 +1,87 @@
-modelInfo <- list(label = "The lasso",
-                  library = "elasticnet",
-                  type = "Regression",
-                  parameters = data.frame(parameter = 'fraction',
-                                          class = "numeric",
-                                          label = 'Fraction of Full Solution'),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <-  expand.grid(fraction = seq(.1, .9, length = len))
-                    } else {
-                      out <- data.frame(fraction = runif(len, min = 0, max = 1))
-                    }
-                    out
-                  },
-                  loop = function(grid) {   
-                    grid <- grid[order(grid$fraction, decreasing = TRUE),, drop = FALSE]
-                    loop <- grid[1,,drop = FALSE]
-                    submodels <- list(grid[-1,,drop = FALSE])     
-                    list(loop = loop, submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    elasticnet::enet(as.matrix(x), y, lambda = 0, ...)
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- elasticnet::predict.enet(modelFit, 
-                                   newdata, 
-                                   s = modelFit$tuneValue$fraction, 
-                                   mode = "fraction")$fit
+modelInfo <- list(
+  label = "The lasso",
+  library = "elasticnet",
+  type = "Regression",
+  parameters = data.frame(
+    parameter = 'fraction',
+    class = "numeric",
+    label = 'Fraction of Full Solution'
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(fraction = seq(.1, .9, length = len))
+    } else {
+      out <- data.frame(fraction = runif(len, min = 0, max = 1))
+    }
+    out
+  },
+  loop = function(grid) {
+    grid <- grid[order(grid$fraction, decreasing = TRUE), , drop = FALSE]
+    loop <- grid[1, , drop = FALSE]
+    submodels <- list(grid[-1, , drop = FALSE])
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    elasticnet::enet(as.matrix(x), y, lambda = 0, ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- elasticnet::predict.enet(
+      modelFit,
+      newdata,
+      s = modelFit$tuneValue$fraction,
+      mode = "fraction"
+    )$fit
 
-                    if(!is.null(submodels)) {
-                      if(nrow(submodels) > 1) {
-                        out <- c(
-                          list(if(is.matrix(out)) out[,1]  else out),
-                          as.list(
-                            as.data.frame(
-                              elasticnet::predict.enet(modelFit,
-                                      newx = newdata,
-                                      s = submodels$fraction,
-                                      mode = "fraction")$fit)))
-                        
-                      } else {
-                        tmp <- elasticnet::predict.enet(
-                          modelFit,
-                          newx = newdata,
-                          s = submodels$fraction,
-                          mode = "fraction")$fit
-                        out <- c(list(if(is.matrix(out)) out[,1]  else out),  list(tmp))
-                      }
-                    }
-                    out        
-                  },
-                  predictors = function(x, s = NULL, ...) {
-                    if(is.null(s)) {
-                      if(!is.null(x$tuneValue))  {
-                        s <- x$tuneValue$fraction
-                      } else stop("must supply a vaue of s")
-                      out <- elasticnet::predict.enet(
-                        x, s = s,
-                        type = "coefficients",
-                        mode = "fraction")$coefficients
-                      
-                    } else {
-                      out <- elasticnet::predict.enet(x, s = s)$coefficients
-                    }
-                    names(out)[out != 0]
-                  },
-                  tags = c("Linear Regression", "Implicit Feature Selection", "L1 Regularization"),
-                  prob = NULL,
-                  sort = function(x) x[order(x$fraction),])
+    if (!is.null(submodels)) {
+      if (nrow(submodels) > 1) {
+        out <- c(
+          list(if (is.matrix(out)) out[, 1] else out),
+          as.list(
+            as.data.frame(
+              elasticnet::predict.enet(
+                modelFit,
+                newx = newdata,
+                s = submodels$fraction,
+                mode = "fraction"
+              )$fit
+            )
+          )
+        )
+      } else {
+        tmp <- elasticnet::predict.enet(
+          modelFit,
+          newx = newdata,
+          s = submodels$fraction,
+          mode = "fraction"
+        )$fit
+        out <- c(list(if (is.matrix(out)) out[, 1] else out), list(tmp))
+      }
+    }
+    out
+  },
+  predictors = function(x, s = NULL, ...) {
+    if (is.null(s)) {
+      if (!is.null(x$tuneValue)) {
+        s <- x$tuneValue$fraction
+      } else {
+        stop("must supply a vaue of s")
+      }
+      out <- elasticnet::predict.enet(
+        x,
+        s = s,
+        type = "coefficients",
+        mode = "fraction"
+      )$coefficients
+    } else {
+      out <- elasticnet::predict.enet(x, s = s)$coefficients
+    }
+    names(out)[out != 0]
+  },
+  tags = c(
+    "Linear Regression",
+    "Implicit Feature Selection",
+    "L1 Regularization"
+  ),
+  prob = NULL,
+  sort = function(x) x[order(x$fraction), ]
+)

--- a/inst/model_sources/files/lda.R
+++ b/inst/model_sources/files/lda.R
@@ -1,17 +1,29 @@
-modelInfo <- list(label = "Linear Discriminant Analysis",
-                  library = "MASS",
-                  loop = NULL,
-                  type = "Classification",
-                  parameters = data.frame(parameter = "parameter",
-                                          class = "character",
-                                          label = "parameter"),
-                  grid = function(x, y, len = NULL, search = "grid") data.frame(parameter = "none"),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) MASS::lda(x, y, ...)  ,
-                  predict = function(modelFit, newdata, submodels = NULL)
-                    predict(modelFit, newdata)$class,
-                  prob = function(modelFit, newdata, submodels = NULL) 
-                    predict(modelFit, newdata)$posterior,
-                  predictors = function(x, ...) if(hasTerms(x)) predictors(x$terms) else colnames(x$means),
-                  tags = c("Discriminant Analysis", "Linear Classifier"),
-                  levels = function(x) names(x$prior),
-                  sort = function(x) x)
+modelInfo <- list(
+  label = "Linear Discriminant Analysis",
+  library = "MASS",
+  loop = NULL,
+  type = "Classification",
+  parameters = data.frame(
+    parameter = "parameter",
+    class = "character",
+    label = "parameter"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(parameter = "none")
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    MASS::lda(x, y, ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)$class
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)$posterior
+  },
+  predictors = function(x, ...) {
+    if (hasTerms(x)) predictors(x$terms) else colnames(x$means)
+  },
+  tags = c("Discriminant Analysis", "Linear Classifier"),
+  levels = function(x) names(x$prior),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/lda.R
+++ b/inst/model_sources/files/lda.R
@@ -21,7 +21,11 @@ modelInfo <- list(
     predict(modelFit, newdata)$posterior
   },
   predictors = function(x, ...) {
-    if (hasTerms(x)) predictors(x$terms) else colnames(x$means)
+    if (hasTerms(x)) {
+      predictors(x$terms)
+    } else {
+      colnames(x$means)
+    }
   },
   tags = c("Discriminant Analysis", "Linear Classifier"),
   levels = function(x) names(x$prior),

--- a/inst/model_sources/files/lda2.R
+++ b/inst/model_sources/files/lda2.R
@@ -1,48 +1,69 @@
-modelInfo <- list(label = "Linear Discriminant Analysis",
-                  library = "MASS",
-                  loop = function(grid) {
-                    grid <- grid[order(grid$dimen, decreasing = TRUE),, drop = FALSE]
-                    loop <- grid[1,,drop = FALSE]
-                    submodels <- list(grid[-1,,drop = FALSE])
-                    list(loop = loop, submodels = submodels)
-                  },
-                  type = c('Classification'),
-                  parameters = data.frame(parameter = c('dimen'),
-                                          class = c('numeric'),
-                                          label = c('#Discriminant Functions')),
-                  grid = function(x, y, len = NULL, search = "grid") data.frame(dimen = 1:min(ncol(x), length(levels(y)) - 1)),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) MASS::lda(x, y, ...)  ,
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- as.character(predict(modelFit, newdata, dimen = modelFit$tuneValue$dimen)$class)
-                    if(!is.null(submodels))
-                    {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
-                      for(j in seq(along = submodels$dimen))
-                      {
-                        tmp[[j+1]] <- as.character(predict(modelFit, newdata, dimen = submodels$dimen[j])$class)
-                      }
-                      out <- tmp
-                    }                        
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata, dimen = modelFit$tuneValue$dimen)$posterior
-                    if(!is.null(submodels))
-                    {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
-                      
-                      for(j in seq(along = submodels$dimen))
-                      {
-                        tmpProb <- predict(modelFit, newdata, dimen = submodels$dimen[j])$posterior
-                        tmp[[j+1]] <- as.data.frame(tmpProb[, modelFit$obsLevels, drop = FALSE], stringsAsFactors = TRUE)
-                      }
-                      out <- tmp
-                    }                        
-                    out
-                  },
-                  predictors = function(x, ...) if(hasTerms(x)) predictors(x$terms) else colnames(x$means),
-                  tags = c("Discriminant Analysis", "Linear Classifier"),
-                  levels = function(x) names(x$prior),
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Linear Discriminant Analysis",
+  library = "MASS",
+  loop = function(grid) {
+    grid <- grid[order(grid$dimen, decreasing = TRUE), , drop = FALSE]
+    loop <- grid[1, , drop = FALSE]
+    submodels <- list(grid[-1, , drop = FALSE])
+    list(loop = loop, submodels = submodels)
+  },
+  type = c('Classification'),
+  parameters = data.frame(
+    parameter = c('dimen'),
+    class = c('numeric'),
+    label = c('#Discriminant Functions')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(dimen = 1:min(ncol(x), length(levels(y)) - 1))
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    MASS::lda(x, y, ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- as.character(
+      predict(modelFit, newdata, dimen = modelFit$tuneValue$dimen)$class
+    )
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
+      for (j in seq(along = submodels$dimen)) {
+        tmp[[j + 1]] <- as.character(
+          predict(modelFit, newdata, dimen = submodels$dimen[j])$class
+        )
+      }
+      out <- tmp
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(
+      modelFit,
+      newdata,
+      dimen = modelFit$tuneValue$dimen
+    )$posterior
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
+
+      for (j in seq(along = submodels$dimen)) {
+        tmpProb <- predict(
+          modelFit,
+          newdata,
+          dimen = submodels$dimen[j]
+        )$posterior
+        tmp[[j + 1]] <- as.data.frame(
+          tmpProb[, modelFit$obsLevels, drop = FALSE],
+          stringsAsFactors = TRUE
+        )
+      }
+      out <- tmp
+    }
+    out
+  },
+  predictors = function(x, ...) {
+    if (hasTerms(x)) predictors(x$terms) else colnames(x$means)
+  },
+  tags = c("Discriminant Analysis", "Linear Classifier"),
+  levels = function(x) names(x$prior),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/lda2.R
+++ b/inst/model_sources/files/lda2.R
@@ -61,7 +61,11 @@ modelInfo <- list(
     out
   },
   predictors = function(x, ...) {
-    if (hasTerms(x)) predictors(x$terms) else colnames(x$means)
+    if (hasTerms(x)) {
+      predictors(x$terms)
+    } else {
+      colnames(x$means)
+    }
   },
   tags = c("Discriminant Analysis", "Linear Classifier"),
   levels = function(x) names(x$prior),

--- a/inst/model_sources/files/leapBackward.R
+++ b/inst/model_sources/files/leapBackward.R
@@ -1,67 +1,91 @@
-modelInfo <- list(label = "Linear Regression with Backwards Selection",
-                  library = "leaps",
-                  type = "Regression",
-                  parameters = data.frame(parameter = 'nvmax',
-                                          class = "numeric",
-                                          label = 'Maximum Number of Predictors'),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- data.frame(nvmax = 2:(len+1))
-                    } else {
-                      out <- data.frame(nvmax = sort(unique(sample(2:(ncol(x) - 1), size = len, replace = TRUE))))
-                    }
-                    out
-                    },
-                  loop = function(grid) {   
-                    grid <- grid[order(grid$nvmax, decreasing = TRUE),, drop = FALSE]
-                    loop <- grid[1,,drop = FALSE]
-                    submodels <- list(grid[-1,,drop = FALSE])
-                    list(loop = loop, submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {   
-                    theDots <- list(...)
-                    if(any(names(theDots) == "nbest")) stop("'nbest' should not be specified")
-                    if(any(names(theDots) == "method")) stop("'method' should not be specified")
-                    if(any(names(theDots) == "nvmax")) stop("'nvmax' should not be specified")
+modelInfo <- list(
+  label = "Linear Regression with Backwards Selection",
+  library = "leaps",
+  type = "Regression",
+  parameters = data.frame(
+    parameter = 'nvmax',
+    class = "numeric",
+    label = 'Maximum Number of Predictors'
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(nvmax = 2:(len + 1))
+    } else {
+      out <- data.frame(
+        nvmax = sort(unique(sample(
+          2:(ncol(x) - 1),
+          size = len,
+          replace = TRUE
+        )))
+      )
+    }
+    out
+  },
+  loop = function(grid) {
+    grid <- grid[order(grid$nvmax, decreasing = TRUE), , drop = FALSE]
+    loop <- grid[1, , drop = FALSE]
+    submodels <- list(grid[-1, , drop = FALSE])
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    theDots <- list(...)
+    if (any(names(theDots) == "nbest")) {
+      stop("'nbest' should not be specified")
+    }
+    if (any(names(theDots) == "method")) {
+      stop("'method' should not be specified")
+    }
+    if (any(names(theDots) == "nvmax")) {
+      stop("'nvmax' should not be specified")
+    }
 
-                    leaps::regsubsets(as.matrix(x), y,
-                               weights = if(!is.null(wts)) wts else rep(1, length(y)),
-                               nbest = 1, nvmax = param$nvmax, method = "backward", ...)
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    newdata <- as.matrix(newdata)
-                    foo <- function(b, x) x[,names(b),drop = FALSE] %*% b
-                    path <- 1:(modelFit$nvmax - 1)
-                    betas <- coef(modelFit, id = 1:(modelFit$nvmax - 1))
-                    
-                    newdata <- cbind(rep(1, nrow(newdata)), newdata)
-                    colnames(newdata)[1] <- "(Intercept)"
-                    
-                    out <- foo(betas[[length(betas)]], newdata)[,1]
-                    
-                    if(!is.null(submodels)) {
-                      numTerms <- unlist(lapply(betas, length))
-                      if(any(names(betas[[length(betas)]]) == "(Intercept)")) 
-                        numTerms <- numTerms - 1
-                      ## Need to find the elements of betas that 
-                      ## correspond to the values of submodels$nvmax
-                      
-                      keepers <- which(numTerms %in% submodels$nvmax)
-                      if(length(keepers) != length(submodels$nvmax))
-                        stop("Some values of 'nvmax' are not in the model sequence.")
-                      
-                      ## The grid code sorted from largest to smallest, so 
-                      ## to match them, reverse the order
-                      keepers <- rev(keepers)
-                      preds <- lapply(betas[keepers], foo, x= newdata)
-                      preds <- do.call("cbind", preds)
-                      
-                      out <- as.data.frame(cbind(out, preds), stringsAsFactors = TRUE)
-                      out <- as.list(out)
-                    }
-                    
-                    out
-                  },
-                  tags = c("Linear Regression", "Feature Selection Wrapper"),
-                  prob = NULL,
-                  sort = function(x) x[order(x[,1]),])
+    leaps::regsubsets(
+      as.matrix(x),
+      y,
+      weights = if (!is.null(wts)) wts else rep(1, length(y)),
+      nbest = 1,
+      nvmax = param$nvmax,
+      method = "backward",
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    newdata <- as.matrix(newdata)
+    foo <- function(b, x) x[, names(b), drop = FALSE] %*% b
+    path <- 1:(modelFit$nvmax - 1)
+    betas <- coef(modelFit, id = 1:(modelFit$nvmax - 1))
+
+    newdata <- cbind(rep(1, nrow(newdata)), newdata)
+    colnames(newdata)[1] <- "(Intercept)"
+
+    out <- foo(betas[[length(betas)]], newdata)[, 1]
+
+    if (!is.null(submodels)) {
+      numTerms <- unlist(lapply(betas, length))
+      if (any(names(betas[[length(betas)]]) == "(Intercept)")) {
+        numTerms <- numTerms - 1
+      }
+      ## Need to find the elements of betas that
+      ## correspond to the values of submodels$nvmax
+
+      keepers <- which(numTerms %in% submodels$nvmax)
+      if (length(keepers) != length(submodels$nvmax)) {
+        stop("Some values of 'nvmax' are not in the model sequence.")
+      }
+
+      ## The grid code sorted from largest to smallest, so
+      ## to match them, reverse the order
+      keepers <- rev(keepers)
+      preds <- lapply(betas[keepers], foo, x = newdata)
+      preds <- do.call("cbind", preds)
+
+      out <- as.data.frame(cbind(out, preds), stringsAsFactors = TRUE)
+      out <- as.list(out)
+    }
+
+    out
+  },
+  tags = c("Linear Regression", "Feature Selection Wrapper"),
+  prob = NULL,
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/leapForward.R
+++ b/inst/model_sources/files/leapForward.R
@@ -1,68 +1,92 @@
-modelInfo <- list(label = "Linear Regression with Forward Selection",
-                  library = "leaps",
-                  type = "Regression",
-                  parameters = data.frame(parameter = 'nvmax',
-                                          class = "numeric",
-                                          label = 'Maximum Number of Predictors'),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- data.frame(nvmax = 2:(len+1))
-                    } else {
-                      out <- data.frame(nvmax = sort(unique(sample(2:(ncol(x) - 1), size = len, replace = TRUE))))
-                    }
-                    out
-                  },
-                  loop = function(grid) {   
-                    grid <- grid[order(grid$nvmax, decreasing = TRUE),, drop = FALSE]
-                    loop <- grid[1,,drop = FALSE]
-                    submodels <- list(grid[-1,,drop = FALSE])
-                    list(loop = loop, submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {   
-                    theDots <- list(...)
-                    if(any(names(theDots) == "nbest")) stop("'nbest' should not be specified")
-                    if(any(names(theDots) == "method")) stop("'method' should not be specified")
-                    if(any(names(theDots) == "nvmax")) stop("'nvmax' should not be specified")
-                  
-                    leaps::regsubsets(as.matrix(x), y,
-                               weights = if(!is.null(wts)) wts else rep(1, length(y)),
-                               nbest = 1, nvmax = param$nvmax, method = "forward", ...)
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    newdata <- as.matrix(newdata)
-                    foo <- function(b, x) x[,names(b),drop = FALSE] %*% b
-                    
-                    path <- 1:(modelFit$nvmax - 1)
-                    betas <- coef(modelFit, id = 1:(modelFit$nvmax - 1))
-                    
-                    newdata <- cbind(rep(1, nrow(newdata)), as.matrix(newdata))
-                    colnames(newdata)[1] <- "(Intercept)"
-                    
-                    out <- foo(betas[[length(betas)]], newdata)[,1]
-                    
-                    if(!is.null(submodels))
-                    {
-                      numTerms <- unlist(lapply(betas, length))
-                      if(any(names(betas[[length(betas)]]) == "(Intercept)")) numTerms <- numTerms - 1
-                      ## Need to find the elements of betas that 
-                      ## correspond to the values of submodels$nvmax
-                      
-                      keepers <- which(numTerms %in% submodels$nvmax)
-                      if(length(keepers) != length(submodels$nvmax))
-                        stop("Some values of 'nvmax' are not in the model sequence.")
-                      
-                      ## The grid code sorted from largest to smallest, so 
-                      ## to match them, reverse the order
-                      keepers <- rev(keepers)
-                      preds <- lapply(betas[keepers], foo, x= newdata)
-                      preds <- do.call("cbind", preds)
-                      
-                      out <- as.data.frame(cbind(out, preds), stringsAsFactors = TRUE)
-                      out <- as.list(out)
-                    }
-                    
-                    out
-                  },
-                  tags = c("Linear Regression", "Feature Selection Wrapper"),
-                  prob = NULL,
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Linear Regression with Forward Selection",
+  library = "leaps",
+  type = "Regression",
+  parameters = data.frame(
+    parameter = 'nvmax',
+    class = "numeric",
+    label = 'Maximum Number of Predictors'
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(nvmax = 2:(len + 1))
+    } else {
+      out <- data.frame(
+        nvmax = sort(unique(sample(
+          2:(ncol(x) - 1),
+          size = len,
+          replace = TRUE
+        )))
+      )
+    }
+    out
+  },
+  loop = function(grid) {
+    grid <- grid[order(grid$nvmax, decreasing = TRUE), , drop = FALSE]
+    loop <- grid[1, , drop = FALSE]
+    submodels <- list(grid[-1, , drop = FALSE])
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    theDots <- list(...)
+    if (any(names(theDots) == "nbest")) {
+      stop("'nbest' should not be specified")
+    }
+    if (any(names(theDots) == "method")) {
+      stop("'method' should not be specified")
+    }
+    if (any(names(theDots) == "nvmax")) {
+      stop("'nvmax' should not be specified")
+    }
+
+    leaps::regsubsets(
+      as.matrix(x),
+      y,
+      weights = if (!is.null(wts)) wts else rep(1, length(y)),
+      nbest = 1,
+      nvmax = param$nvmax,
+      method = "forward",
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    newdata <- as.matrix(newdata)
+    foo <- function(b, x) x[, names(b), drop = FALSE] %*% b
+
+    path <- 1:(modelFit$nvmax - 1)
+    betas <- coef(modelFit, id = 1:(modelFit$nvmax - 1))
+
+    newdata <- cbind(rep(1, nrow(newdata)), as.matrix(newdata))
+    colnames(newdata)[1] <- "(Intercept)"
+
+    out <- foo(betas[[length(betas)]], newdata)[, 1]
+
+    if (!is.null(submodels)) {
+      numTerms <- unlist(lapply(betas, length))
+      if (any(names(betas[[length(betas)]]) == "(Intercept)")) {
+        numTerms <- numTerms - 1
+      }
+      ## Need to find the elements of betas that
+      ## correspond to the values of submodels$nvmax
+
+      keepers <- which(numTerms %in% submodels$nvmax)
+      if (length(keepers) != length(submodels$nvmax)) {
+        stop("Some values of 'nvmax' are not in the model sequence.")
+      }
+
+      ## The grid code sorted from largest to smallest, so
+      ## to match them, reverse the order
+      keepers <- rev(keepers)
+      preds <- lapply(betas[keepers], foo, x = newdata)
+      preds <- do.call("cbind", preds)
+
+      out <- as.data.frame(cbind(out, preds), stringsAsFactors = TRUE)
+      out <- as.list(out)
+    }
+
+    out
+  },
+  tags = c("Linear Regression", "Feature Selection Wrapper"),
+  prob = NULL,
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/leapSeq.R
+++ b/inst/model_sources/files/leapSeq.R
@@ -1,68 +1,92 @@
-modelInfo <- list(label = "Linear Regression with Stepwise Selection",
-                  library = "leaps",
-                  type = "Regression",
-                  parameters = data.frame(parameter = 'nvmax',
-                                          class = "numeric",
-                                          label = 'Maximum Number of Predictors'),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- data.frame(nvmax = 2:(len+1))
-                    } else {
-                      out <- data.frame(nvmax = sort(unique(sample(2:(ncol(x) - 1), size = len, replace = TRUE))))
-                    }
-                    out
-                  },
-                  loop = function(grid) {   
-                    grid <- grid[order(grid$nvmax, decreasing = TRUE),, drop = FALSE]
-                    loop <- grid[1,,drop = FALSE]
-                    submodels <- list(grid[-1,,drop = FALSE])
-                    list(loop = loop, submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {   
-                    theDots <- list(...)
-                    if(any(names(theDots) == "nbest")) stop("'nbest' should not be specified")
-                    if(any(names(theDots) == "method")) stop("'method' should not be specified")
-                    if(any(names(theDots) == "nvmax")) stop("'nvmax' should not be specified")
-                  
-                    leaps::regsubsets(as.matrix(x), y,
-                               weights = if(!is.null(wts)) wts else rep(1, length(y)),
-                               nbest = 1, nvmax = param$nvmax, method = "seqrep", ...)
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    newdata <- as.matrix(newdata)
-                    foo <- function(b, x) x[,names(b),drop = FALSE] %*% b
-                    
-                    path <- 1:(modelFit$nvmax - 1)
-                    betas <- coef(modelFit, id = 1:(modelFit$nvmax - 1))
-                    
-                    newdata <- cbind(rep(1, nrow(newdata)), as.matrix(newdata))
-                    colnames(newdata)[1] <- "(Intercept)"
-                    
-                    out <- foo(betas[[length(betas)]], newdata)[,1]
-                    
-                    if(!is.null(submodels))
-                    {
-                      numTerms <- unlist(lapply(betas, length))
-                      if(any(names(betas[[length(betas)]]) == "(Intercept)")) numTerms <- numTerms - 1
-                      ## Need to find the elements of betas that 
-                      ## correspond to the values of submodels$nvmax
-                      
-                      keepers <- which(numTerms %in% submodels$nvmax)
-                      if(length(keepers) != length(submodels$nvmax))
-                        stop("Some values of 'nvmax' are not in the model sequence.")
-                      
-                      ## The grid code sorted from largest to smallest, so 
-                      ## to match them, reverse the order
-                      keepers <- rev(keepers)
-                      preds <- lapply(betas[keepers], foo, x= newdata)
-                      preds <- do.call("cbind", preds)
-                      
-                      out <- as.data.frame(cbind(out, preds), stringsAsFactors = TRUE)
-                      out <- as.list(out)
-                    }
-                    
-                    out
-                  },
-                  tags = c("Linear Regression", "Feature Selection Wrapper"),
-                  prob = NULL,
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Linear Regression with Stepwise Selection",
+  library = "leaps",
+  type = "Regression",
+  parameters = data.frame(
+    parameter = 'nvmax',
+    class = "numeric",
+    label = 'Maximum Number of Predictors'
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(nvmax = 2:(len + 1))
+    } else {
+      out <- data.frame(
+        nvmax = sort(unique(sample(
+          2:(ncol(x) - 1),
+          size = len,
+          replace = TRUE
+        )))
+      )
+    }
+    out
+  },
+  loop = function(grid) {
+    grid <- grid[order(grid$nvmax, decreasing = TRUE), , drop = FALSE]
+    loop <- grid[1, , drop = FALSE]
+    submodels <- list(grid[-1, , drop = FALSE])
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    theDots <- list(...)
+    if (any(names(theDots) == "nbest")) {
+      stop("'nbest' should not be specified")
+    }
+    if (any(names(theDots) == "method")) {
+      stop("'method' should not be specified")
+    }
+    if (any(names(theDots) == "nvmax")) {
+      stop("'nvmax' should not be specified")
+    }
+
+    leaps::regsubsets(
+      as.matrix(x),
+      y,
+      weights = if (!is.null(wts)) wts else rep(1, length(y)),
+      nbest = 1,
+      nvmax = param$nvmax,
+      method = "seqrep",
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    newdata <- as.matrix(newdata)
+    foo <- function(b, x) x[, names(b), drop = FALSE] %*% b
+
+    path <- 1:(modelFit$nvmax - 1)
+    betas <- coef(modelFit, id = 1:(modelFit$nvmax - 1))
+
+    newdata <- cbind(rep(1, nrow(newdata)), as.matrix(newdata))
+    colnames(newdata)[1] <- "(Intercept)"
+
+    out <- foo(betas[[length(betas)]], newdata)[, 1]
+
+    if (!is.null(submodels)) {
+      numTerms <- unlist(lapply(betas, length))
+      if (any(names(betas[[length(betas)]]) == "(Intercept)")) {
+        numTerms <- numTerms - 1
+      }
+      ## Need to find the elements of betas that
+      ## correspond to the values of submodels$nvmax
+
+      keepers <- which(numTerms %in% submodels$nvmax)
+      if (length(keepers) != length(submodels$nvmax)) {
+        stop("Some values of 'nvmax' are not in the model sequence.")
+      }
+
+      ## The grid code sorted from largest to smallest, so
+      ## to match them, reverse the order
+      keepers <- rev(keepers)
+      preds <- lapply(betas[keepers], foo, x = newdata)
+      preds <- do.call("cbind", preds)
+
+      out <- as.data.frame(cbind(out, preds), stringsAsFactors = TRUE)
+      out <- as.list(out)
+    }
+
+    out
+  },
+  tags = c("Linear Regression", "Feature Selection Wrapper"),
+  prob = NULL,
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/lm.R
+++ b/inst/model_sources/files/lm.R
@@ -1,44 +1,60 @@
-modelInfo <- list(label = "Linear Regression",
-                  library = NULL,
-                  loop = NULL,
-                  type = "Regression",
-                  parameters = data.frame(parameter = "intercept",
-                                          class = "logical",
-                                          label = "intercept"),
-                  grid = function(x, y, len = NULL, search = "grid") 
-                    data.frame(intercept = TRUE),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    if(!is.null(wts))
-                    {
-                      if (param$intercept)
-                        out <- lm(.outcome ~ ., data = dat, weights = wts, ...)
-                      else
-                        out <- lm(.outcome ~ 0 + ., data = dat, weights = wts, ...)
-                    } else 
-                    {
-                      if (param$intercept)
-                        out <- lm(.outcome ~ ., data = dat, ...)
-                      else
-                        out <- lm(.outcome ~ 0 + ., data = dat, ...)
-                    }
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata)
-                  },
-                  prob = NULL,
-                  predictors = function(x, ...) predictors(x$terms),
-                  tags = c("Linear Regression", "Accepts Case Weights"),
-                  varImp = function(object, ...) {
-                    values <- summary(object)$coef
-                    varImps <-  abs(values[ !grepl( rownames(values), pattern = 'Intercept' ), 
-                                            grep("value$", colnames(values)), drop = FALSE]) 
-                    out <- data.frame(varImps)
-                    colnames(out) <- "Overall"
-                    if(!is.null(names(varImps))) rownames(out) <- names(varImps)
-                    out   
-                  },
-                  sort = function(x) x)
+modelInfo <- list(
+  label = "Linear Regression",
+  library = NULL,
+  loop = NULL,
+  type = "Regression",
+  parameters = data.frame(
+    parameter = "intercept",
+    class = "logical",
+    label = "intercept"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(intercept = TRUE)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    if (!is.null(wts)) {
+      if (param$intercept) {
+        out <- lm(.outcome ~ ., data = dat, weights = wts, ...)
+      } else {
+        out <- lm(.outcome ~ 0 + ., data = dat, weights = wts, ...)
+      }
+    } else {
+      if (param$intercept) {
+        out <- lm(.outcome ~ ., data = dat, ...)
+      } else {
+        out <- lm(.outcome ~ 0 + ., data = dat, ...)
+      }
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata)
+  },
+  prob = NULL,
+  predictors = function(x, ...) predictors(x$terms),
+  tags = c("Linear Regression", "Accepts Case Weights"),
+  varImp = function(object, ...) {
+    values <- summary(object)$coef
+    varImps <- abs(values[
+      !grepl(rownames(values), pattern = 'Intercept'),
+      grep("value$", colnames(values)),
+      drop = FALSE
+    ])
+    out <- data.frame(varImps)
+    colnames(out) <- "Overall"
+    if (!is.null(names(varImps))) {
+      rownames(out) <- names(varImps)
+    }
+    out
+  },
+  sort = function(x) x
+)

--- a/inst/model_sources/files/lm.R
+++ b/inst/model_sources/files/lm.R
@@ -12,10 +12,10 @@ modelInfo <- list(
     data.frame(intercept = TRUE)
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     if (!is.null(wts)) {

--- a/inst/model_sources/files/lmStepAIC.R
+++ b/inst/model_sources/files/lmStepAIC.R
@@ -12,10 +12,10 @@ modelInfo <- list(
     data.frame(parameter = "none")
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     if (!is.null(wts)) {

--- a/inst/model_sources/files/lmStepAIC.R
+++ b/inst/model_sources/files/lmStepAIC.R
@@ -1,24 +1,41 @@
-modelInfo <- list(label = "Linear Regression with Stepwise Selection",
-                  library = "MASS",
-                  loop = NULL,
-                  type = "Regression",
-                  parameters = data.frame(parameter = "parameter",
-                                          class = "character",
-                                          label = "parameter"),
-                  grid = function(x, y, len = NULL, search = "grid") data.frame(parameter = "none"),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    if(!is.null(wts))
-                    {
-                      out <- MASS::stepAIC(lm(.outcome ~ ., data = dat, weights = wts), ...)
-                    } else out <- MASS::stepAIC(lm(.outcome ~ ., data = dat), ...)
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata)
-                    },
-                  prob = NULL,
-                  tags = c("Linear Regression", "Feature Selection Wrapper", "Accepts Case Weights"),
-                  sort = function(x) x)
+modelInfo <- list(
+  label = "Linear Regression with Stepwise Selection",
+  library = "MASS",
+  loop = NULL,
+  type = "Regression",
+  parameters = data.frame(
+    parameter = "parameter",
+    class = "character",
+    label = "parameter"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(parameter = "none")
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    if (!is.null(wts)) {
+      out <- MASS::stepAIC(lm(.outcome ~ ., data = dat, weights = wts), ...)
+    } else {
+      out <- MASS::stepAIC(lm(.outcome ~ ., data = dat), ...)
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata)
+  },
+  prob = NULL,
+  tags = c(
+    "Linear Regression",
+    "Feature Selection Wrapper",
+    "Accepts Case Weights"
+  ),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/loclda.R
+++ b/inst/model_sources/files/loclda.R
@@ -14,7 +14,11 @@ modelInfo <- list(
     if (search == "grid") {
       out <- data.frame(k = floor(p_seq * nrow(x)))
     } else {
-      by_val <- if (is.factor(y)) length(levels(y)) else 1
+      if (is.factor(y)) {
+        by_val <- length(levels(y))
+      } else {
+        by_val <- 1
+      }
       out <- data.frame(
         k = floor(runif(
           len,
@@ -35,7 +39,11 @@ modelInfo <- list(
     predict(modelFit, newdata)$posterior
   },
   predictors = function(x, ...) {
-    if (hasTerms(x)) predictors(x$terms) else colnames(x$means)
+    if (hasTerms(x)) {
+      predictors(x$terms)
+    } else {
+      colnames(x$means)
+    }
   },
   tags = c("Discriminant Analysis", "Linear Classifier"),
   levels = function(x) names(x$prior),

--- a/inst/model_sources/files/loclda.R
+++ b/inst/model_sources/files/loclda.R
@@ -1,28 +1,43 @@
-modelInfo <- list(label = "Localized Linear Discriminant Analysis",
-                  library = "klaR",
-                  loop = NULL,
-                  type = "Classification",
-                  parameters = data.frame(parameter = "k",
-                                          class = "numeric",
-                                          label = "#Nearest Neighbors"),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    min_p <- ncol(x)/nrow(x) + .05
-                    p_seq <- seq(min_p , min(.9, min_p + 1/3), length = len)
-                    if(search == "grid") {
-                      out <- data.frame(k = floor(p_seq*nrow(x)))
-                    } else {
-                      by_val <- if(is.factor(y)) length(levels(y)) else 1
-                      out <- data.frame(k = floor(runif(len, min = nrow(x)*min_p, max = nrow(x)*min(.9, min_p + 1/3))))
-                    }
-                    out
-                    },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...)
-                    klaR::loclda(x, y, k = floor(param$k), ...)  ,
-                  predict = function(modelFit, newdata, submodels = NULL)
-                    predict(modelFit, newdata)$class,
-                  prob = function(modelFit, newdata, submodels = NULL) 
-                    predict(modelFit, newdata)$posterior,
-                  predictors = function(x, ...) if(hasTerms(x)) predictors(x$terms) else colnames(x$means),
-                  tags = c("Discriminant Analysis", "Linear Classifier"),
-                  levels = function(x) names(x$prior),
-                  sort = function(x) x)
+modelInfo <- list(
+  label = "Localized Linear Discriminant Analysis",
+  library = "klaR",
+  loop = NULL,
+  type = "Classification",
+  parameters = data.frame(
+    parameter = "k",
+    class = "numeric",
+    label = "#Nearest Neighbors"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    min_p <- ncol(x) / nrow(x) + .05
+    p_seq <- seq(min_p, min(.9, min_p + 1 / 3), length = len)
+    if (search == "grid") {
+      out <- data.frame(k = floor(p_seq * nrow(x)))
+    } else {
+      by_val <- if (is.factor(y)) length(levels(y)) else 1
+      out <- data.frame(
+        k = floor(runif(
+          len,
+          min = nrow(x) * min_p,
+          max = nrow(x) * min(.9, min_p + 1 / 3)
+        ))
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    klaR::loclda(x, y, k = floor(param$k), ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)$class
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)$posterior
+  },
+  predictors = function(x, ...) {
+    if (hasTerms(x)) predictors(x$terms) else colnames(x$means)
+  },
+  tags = c("Discriminant Analysis", "Linear Classifier"),
+  levels = function(x) names(x$prior),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/logicBag.R
+++ b/inst/model_sources/files/logicBag.R
@@ -1,61 +1,79 @@
-modelInfo <- list(label = "Bagged Logic Regression",
-                  library = "logicFS",
-                  loop = NULL,
-                  type = c('Regression', 'Classification'),
-                  parameters = data.frame(parameter = c('nleaves', 'ntrees'),
-                                          class = c('numeric', 'numeric'),
-                                          label = c('Maximum Number of Leaves', 'Number of Trees')),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- expand.grid(ntrees = (1:len) + 1, nleaves = 2^((1:len) + 6))
-                    } else {
-                      out <- data.frame(ntrees = sample(1:10, size = len, replace = TRUE),
-                                        nleaves = sample(1:10, size = len, replace = TRUE))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...){
-                    require(logicFS)
-                    logicFS::logic.bagging(as.matrix(x), y,
-                                  ntrees = param$ntrees,
-                                  nleaves = param$nleaves,
-                                  ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(modelFit$problemType == "Classification")
-                    {
-                      if(length(modelFit$obsLevels) == 2)
-                      {
-                        as.character(modelFit$obsLevels[predict(modelFit, newData = newdata) + 1])
-                      } else {
-                        as.character(predict(modelFit, newData = newdata))
-                      }
-                    } else predict(modelFit, newData = newdata)
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(length(modelFit$obsLevels) == 2)
-                    {
-                      out <- predict(modelFit, newData = newdata, type = "prob")
-                      out <- as.data.frame(cbind(out, 1 - out), stringsAsFactors = TRUE)
-                      colnames(out) <- modelFit$obsLevels
-                    } else {
-                      out <- predict(modelFit, newData = newdata, type = "prob")
-                    }
-                    out
-                  },
-                  predictors = function(x, ...) {
-                    varNums <- lapply(x$logreg.model,
-                                      function(y) lapply(y$trees,
-                                                         function(z) z$trees$knot))
-                    varNums <- sort(unique(unlist(varNums)))
-                    varNums <- varNums[varNums > 0]
-                    if(length(varNums) > 0) colnames(x$data)[varNums] else NA    
-                  },
-                  levels = function(x) x$obsLevels,
-                  notes = paste(
-                    "Unlike other packages used by `train`, the `logicFS`",
-                    "package is fully loaded when this model is used."
-                  ),
-                  tags = c("Logic Regression", "Linear Classifier", "Linear Regression", "Logistic Regression",
-                           "Bagging", "Ensemble Model", "Two Class Only", "Binary Predictors Only"),
-                  sort = function(x) x[order(x$ntrees, x$nleaves),])
+modelInfo <- list(
+  label = "Bagged Logic Regression",
+  library = "logicFS",
+  loop = NULL,
+  type = c('Regression', 'Classification'),
+  parameters = data.frame(
+    parameter = c('nleaves', 'ntrees'),
+    class = c('numeric', 'numeric'),
+    label = c('Maximum Number of Leaves', 'Number of Trees')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(ntrees = (1:len) + 1, nleaves = 2^((1:len) + 6))
+    } else {
+      out <- data.frame(
+        ntrees = sample(1:10, size = len, replace = TRUE),
+        nleaves = sample(1:10, size = len, replace = TRUE)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    require(logicFS)
+    logicFS::logic.bagging(
+      as.matrix(x),
+      y,
+      ntrees = param$ntrees,
+      nleaves = param$nleaves,
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (modelFit$problemType == "Classification") {
+      if (length(modelFit$obsLevels) == 2) {
+        as.character(modelFit$obsLevels[
+          predict(modelFit, newData = newdata) + 1
+        ])
+      } else {
+        as.character(predict(modelFit, newData = newdata))
+      }
+    } else {
+      predict(modelFit, newData = newdata)
+    }
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (length(modelFit$obsLevels) == 2) {
+      out <- predict(modelFit, newData = newdata, type = "prob")
+      out <- as.data.frame(cbind(out, 1 - out), stringsAsFactors = TRUE)
+      colnames(out) <- modelFit$obsLevels
+    } else {
+      out <- predict(modelFit, newData = newdata, type = "prob")
+    }
+    out
+  },
+  predictors = function(x, ...) {
+    varNums <- lapply(x$logreg.model, function(y) {
+      lapply(y$trees, function(z) z$trees$knot)
+    })
+    varNums <- sort(unique(unlist(varNums)))
+    varNums <- varNums[varNums > 0]
+    if (length(varNums) > 0) colnames(x$data)[varNums] else NA
+  },
+  levels = function(x) x$obsLevels,
+  notes = paste(
+    "Unlike other packages used by `train`, the `logicFS`",
+    "package is fully loaded when this model is used."
+  ),
+  tags = c(
+    "Logic Regression",
+    "Linear Classifier",
+    "Linear Regression",
+    "Logistic Regression",
+    "Bagging",
+    "Ensemble Model",
+    "Two Class Only",
+    "Binary Predictors Only"
+  ),
+  sort = function(x) x[order(x$ntrees, x$nleaves), ]
+)

--- a/inst/model_sources/files/logicBag.R
+++ b/inst/model_sources/files/logicBag.R
@@ -58,7 +58,11 @@ modelInfo <- list(
     })
     varNums <- sort(unique(unlist(varNums)))
     varNums <- varNums[varNums > 0]
-    if (length(varNums) > 0) colnames(x$data)[varNums] else NA
+    if (length(varNums) > 0) {
+      colnames(x$data)[varNums]
+    } else {
+      NA
+    }
   },
   levels = function(x) x$obsLevels,
   notes = paste(

--- a/inst/model_sources/files/logreg.R
+++ b/inst/model_sources/files/logreg.R
@@ -1,41 +1,63 @@
-modelInfo <- list(label = "Logic Regression",
-                  library = "LogicReg",
-                  loop = NULL,
-                  type = c('Regression', 'Classification'),
-                  parameters = data.frame(parameter = c('treesize', 'ntrees'),
-                                          class = c('numeric', 'numeric'),
-                                          label = c('Maximum Number of Leaves', 'Number of Trees')),
-                  grid = function(x, y, len = NULL, search = "grid") expand.grid(ntrees = (1:3) + 1, treesize = 2^(1+(1:len))),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...){
-                    isReg <- is.numeric(y)
-                    if(is.factor(y)) y <- ifelse(y == levels(y)[1], 1, 0)
-                    LogicReg::logreg(resp = y, bin = x,
-                                     ntrees = param$ntrees,
-                                     tree.control = LogicReg::logreg.tree.control(treesize = param$treesize),
-                                     select = 1,
-                                     type = ifelse(isReg, 2, 3),
-                                     ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(modelFit$type == "logistic")
-                    {
-                      out <- ifelse(predict(modelFit, newbin = newdata) >= .5,
-                                    modelFit$obsLevels[1], modelFit$obsLevels[2])
-                    } else out <- predict(modelFit, newbin = newdata)
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    tmp <- predict(modelFit, newbin = newdata)
-                    out <- cbind(tmp, 1 - tmp)
-                    colnames(out) <- modelFit$obsLevels
-                    out
-                  },
-                  predictors = function(x, ...) {
-                    getVarIndex <- function(y) unique(y$trees$knot)
-                    varNums <- unique(unlist(lapply(x$model$trees, getVarIndex)))
-                    varNums <- varNums[varNums > 0]
-                    if(length(varNums) > 0) colnames(x$binary)[varNums] else NA
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("Logic Regression", "Linear Classifier", "Linear Regression", "Logistic Regression", "Two Class Only", "Binary Predictors Only"),
-                  sort = function(x) x[order(x$ntrees, x$treesize),])
+modelInfo <- list(
+  label = "Logic Regression",
+  library = "LogicReg",
+  loop = NULL,
+  type = c('Regression', 'Classification'),
+  parameters = data.frame(
+    parameter = c('treesize', 'ntrees'),
+    class = c('numeric', 'numeric'),
+    label = c('Maximum Number of Leaves', 'Number of Trees')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    expand.grid(ntrees = (1:3) + 1, treesize = 2^(1 + (1:len)))
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    isReg <- is.numeric(y)
+    if (is.factor(y)) {
+      y <- ifelse(y == levels(y)[1], 1, 0)
+    }
+    LogicReg::logreg(
+      resp = y,
+      bin = x,
+      ntrees = param$ntrees,
+      tree.control = LogicReg::logreg.tree.control(treesize = param$treesize),
+      select = 1,
+      type = ifelse(isReg, 2, 3),
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (modelFit$type == "logistic") {
+      out <- ifelse(
+        predict(modelFit, newbin = newdata) >= .5,
+        modelFit$obsLevels[1],
+        modelFit$obsLevels[2]
+      )
+    } else {
+      out <- predict(modelFit, newbin = newdata)
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    tmp <- predict(modelFit, newbin = newdata)
+    out <- cbind(tmp, 1 - tmp)
+    colnames(out) <- modelFit$obsLevels
+    out
+  },
+  predictors = function(x, ...) {
+    getVarIndex <- function(y) unique(y$trees$knot)
+    varNums <- unique(unlist(lapply(x$model$trees, getVarIndex)))
+    varNums <- varNums[varNums > 0]
+    if (length(varNums) > 0) colnames(x$binary)[varNums] else NA
+  },
+  levels = function(x) x$obsLevels,
+  tags = c(
+    "Logic Regression",
+    "Linear Classifier",
+    "Linear Regression",
+    "Logistic Regression",
+    "Two Class Only",
+    "Binary Predictors Only"
+  ),
+  sort = function(x) x[order(x$ntrees, x$treesize), ]
+)

--- a/inst/model_sources/files/logreg.R
+++ b/inst/model_sources/files/logreg.R
@@ -48,7 +48,11 @@ modelInfo <- list(
     getVarIndex <- function(y) unique(y$trees$knot)
     varNums <- unique(unlist(lapply(x$model$trees, getVarIndex)))
     varNums <- varNums[varNums > 0]
-    if (length(varNums) > 0) colnames(x$binary)[varNums] else NA
+    if (length(varNums) > 0) {
+      colnames(x$binary)[varNums]
+    } else {
+      NA
+    }
   },
   levels = function(x) x$obsLevels,
   tags = c(

--- a/inst/model_sources/files/lssvmLinear.R
+++ b/inst/model_sources/files/lssvmLinear.R
@@ -1,42 +1,53 @@
-modelInfo <- list(label = "Least Squares Support Vector Machine",
-                  library = "kernlab",
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = c('tau'),
-                                          class = c("numeric"),
-                                          label = c('Regularization Parameter')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(tau = 2 ^((1:len) - 5))
-                    } else {
-                      out <- data.frame(tau = 2^runif(len, min = -5, max = 10))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    kernlab::lssvm(x = as.matrix(x), y = y,
-                                   tau = param$tau,
-                                   kernel = kernlab::polydot(degree = 1,
-                                                             scale = 1,
-                                                             offset = 1), ...)    
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {            
-                    out <- kernlab::predict(modelFit, as.matrix(newdata))
-                    if(is.matrix(out)) out <- out[,1]
-                    out
-                  },
-                  prob = NULL,
-                  predictors = function(x, ...) {
-                    if(hasTerms(x) & !is.null(x@terms))
-                    {
-                      out <- predictors.terms(x@terms)
-                    } else {
-                      out <- colnames(attr(x, "xmatrix"))
-                    }
-                    if(is.null(out)) out <- names(attr(x, "scaling")$x.scale$`scaled:center`)
-                    if(is.null(out)) out <-NA
-                    out
-                  },
-                  tags = c("Kernel Method", "Support Vector Machines", "Linear Classifier"),
-                  levels = function(x) lev(x),
-                  sort = function(x) x)
+modelInfo <- list(
+  label = "Least Squares Support Vector Machine",
+  library = "kernlab",
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = c('tau'),
+    class = c("numeric"),
+    label = c('Regularization Parameter')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(tau = 2^((1:len) - 5))
+    } else {
+      out <- data.frame(tau = 2^runif(len, min = -5, max = 10))
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    kernlab::lssvm(
+      x = as.matrix(x),
+      y = y,
+      tau = param$tau,
+      kernel = kernlab::polydot(degree = 1, scale = 1, offset = 1),
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- kernlab::predict(modelFit, as.matrix(newdata))
+    if (is.matrix(out)) {
+      out <- out[, 1]
+    }
+    out
+  },
+  prob = NULL,
+  predictors = function(x, ...) {
+    if (hasTerms(x) & !is.null(x@terms)) {
+      out <- predictors.terms(x@terms)
+    } else {
+      out <- colnames(attr(x, "xmatrix"))
+    }
+    if (is.null(out)) {
+      out <- names(attr(x, "scaling")$x.scale$`scaled:center`)
+    }
+    if (is.null(out)) {
+      out <- NA
+    }
+    out
+  },
+  tags = c("Kernel Method", "Support Vector Machines", "Linear Classifier"),
+  levels = function(x) lev(x),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/lssvmPoly.R
+++ b/inst/model_sources/files/lssvmPoly.R
@@ -1,46 +1,65 @@
-modelInfo <- list(label = "Least Squares Support Vector Machine with Polynomial Kernel",
-                  library = "kernlab",
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = c('degree', 'scale', 'tau'),
-                                          class = c("numeric", "numeric", "numeric"),
-                                          label = c('Polynomial Degree', 'Scale', 'Regularization Parameter')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(degree = seq(1, min(len, 3)),      
-                                         scale = 10 ^((1:len) - 4),
-                                         tau = 2 ^((1:len) - 5))
-                    } else {
-                      out <- data.frame(degree = sample(1:3, size = len, replace = TRUE),
-                                        scale = 10^runif(len, min = -5, log10(2)),
-                                        tau = 2^runif(len, min = -5, max = 10))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    kernlab::lssvm(x = as.matrix(x), y = y,
-                      	          tau = param$tau,
-                                  kernel = kernlab::polydot(degree = param$degree,
-                                                            scale = param$scale,
-                                                            offset = 1), ...)         
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {  
-                    out <- kernlab::predict(modelFit, as.matrix(newdata))
-                    if(is.matrix(out)) out <- out[,1]
-                    out
-                  },
-                  prob = NULL,
-                  predictors = function(x, ...) {
-                    if(hasTerms(x) & !is.null(x@terms))
-                    {
-                      out <- predictors.terms(x@terms)
-                    } else {
-                      out <- colnames(attr(x, "xmatrix"))
-                    }
-                    if(is.null(out)) out <- names(attr(x, "scaling")$xscale$`scaled:center`)
-                    if(is.null(out)) out <-NA
-                    out
-                  },
-                  tags = c("Kernel Method", "Support Vector Machines", "Polynomial Model"),
-                  levels = function(x) lev(x),
-                  sort = function(x) x)
+modelInfo <- list(
+  label = "Least Squares Support Vector Machine with Polynomial Kernel",
+  library = "kernlab",
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = c('degree', 'scale', 'tau'),
+    class = c("numeric", "numeric", "numeric"),
+    label = c('Polynomial Degree', 'Scale', 'Regularization Parameter')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        degree = seq(1, min(len, 3)),
+        scale = 10^((1:len) - 4),
+        tau = 2^((1:len) - 5)
+      )
+    } else {
+      out <- data.frame(
+        degree = sample(1:3, size = len, replace = TRUE),
+        scale = 10^runif(len, min = -5, log10(2)),
+        tau = 2^runif(len, min = -5, max = 10)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    kernlab::lssvm(
+      x = as.matrix(x),
+      y = y,
+      tau = param$tau,
+      kernel = kernlab::polydot(
+        degree = param$degree,
+        scale = param$scale,
+        offset = 1
+      ),
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- kernlab::predict(modelFit, as.matrix(newdata))
+    if (is.matrix(out)) {
+      out <- out[, 1]
+    }
+    out
+  },
+  prob = NULL,
+  predictors = function(x, ...) {
+    if (hasTerms(x) & !is.null(x@terms)) {
+      out <- predictors.terms(x@terms)
+    } else {
+      out <- colnames(attr(x, "xmatrix"))
+    }
+    if (is.null(out)) {
+      out <- names(attr(x, "scaling")$xscale$`scaled:center`)
+    }
+    if (is.null(out)) {
+      out <- NA
+    }
+    out
+  },
+  tags = c("Kernel Method", "Support Vector Machines", "Polynomial Model"),
+  levels = function(x) lev(x),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/lssvmRadial.R
+++ b/inst/model_sources/files/lssvmRadial.R
@@ -1,45 +1,62 @@
-modelInfo <- list(label = "Least Squares Support Vector Machine with Radial Basis Function Kernel",
-                  library = "kernlab",
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = c('sigma', 'tau'),
-                                          class = c("numeric","numeric"),
-                                          label = c('Sigma', 'Regularization Parameter')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    sigmas <- kernlab::sigest(as.matrix(x), na.action = na.omit, scaled = TRUE)
-                    if(search == "grid") {
-                      out <- expand.grid(sigma = seq(min(sigmas), max(sigmas), length = min(6, len)),
-                                         tau = 2 ^((1:len) - 5))
-                    } else {
-                      rng <- extendrange(log(sigmas), f = .75)
-                      out <- data.frame(sigma = exp(runif(len, min = rng[1], max = rng[2])),
-                                        tau = 2^runif(len, min = -5, max = 10))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    kernlab::lssvm(x = as.matrix(x), y = y,
-                                   tau = param$tau,
-                                   kernel = "rbfdot",
-                                   kpar = list(sigma = param$sigma), ...)         
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {  
-                    out <- kernlab::predict(modelFit, as.matrix(newdata))
-                    if(is.matrix(out)) out <- out[,1]
-                    out
-                  },
-                  prob = NULL,
-                  predictors = function(x, ...) {
-                    if(hasTerms(x) & !is.null(x@terms))
-                    {
-                      out <- predictors.terms(x@terms)
-                    } else {
-                      out <- colnames(attr(x, "xmatrix"))
-                    }
-                    if(is.null(out)) out <- names(attr(x, "scaling")$x.scale$`scaled:center`)
-                    if(is.null(out)) out <-NA
-                    out
-                  },
-                  tags = c("Kernel Method", "Support Vector Machines", "Radial Basis Function"),
-                  levels = function(x) lev(x),
-                  sort = function(x) x)
+modelInfo <- list(
+  label = "Least Squares Support Vector Machine with Radial Basis Function Kernel",
+  library = "kernlab",
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = c('sigma', 'tau'),
+    class = c("numeric", "numeric"),
+    label = c('Sigma', 'Regularization Parameter')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    sigmas <- kernlab::sigest(as.matrix(x), na.action = na.omit, scaled = TRUE)
+    if (search == "grid") {
+      out <- expand.grid(
+        sigma = seq(min(sigmas), max(sigmas), length = min(6, len)),
+        tau = 2^((1:len) - 5)
+      )
+    } else {
+      rng <- extendrange(log(sigmas), f = .75)
+      out <- data.frame(
+        sigma = exp(runif(len, min = rng[1], max = rng[2])),
+        tau = 2^runif(len, min = -5, max = 10)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    kernlab::lssvm(
+      x = as.matrix(x),
+      y = y,
+      tau = param$tau,
+      kernel = "rbfdot",
+      kpar = list(sigma = param$sigma),
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- kernlab::predict(modelFit, as.matrix(newdata))
+    if (is.matrix(out)) {
+      out <- out[, 1]
+    }
+    out
+  },
+  prob = NULL,
+  predictors = function(x, ...) {
+    if (hasTerms(x) & !is.null(x@terms)) {
+      out <- predictors.terms(x@terms)
+    } else {
+      out <- colnames(attr(x, "xmatrix"))
+    }
+    if (is.null(out)) {
+      out <- names(attr(x, "scaling")$x.scale$`scaled:center`)
+    }
+    if (is.null(out)) {
+      out <- NA
+    }
+    out
+  },
+  tags = c("Kernel Method", "Support Vector Machines", "Radial Basis Function"),
+  levels = function(x) lev(x),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/lvq.R
+++ b/inst/model_sources/files/lvq.R
@@ -1,32 +1,51 @@
-modelInfo <- list(label = "Learning Vector Quantization",
-                  library = "class",
-                  loop = NULL,
-                  type = "Classification",
-                  parameters = data.frame(parameter = c("size", "k"),
-                                          class = c("numeric", "numeric"),
-                                          label = c('Codebook Size', '#Prototypes')),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    p <- ncol(x)
-                    ng <- length(levels(y))
-                    n <- nrow(x)
-                    tmp <- min(round(0.4*ng*(ng-1 + p/2),0), n)
-                    if(search == "grid") {
-                      out <- expand.grid(size = floor(seq(tmp, 2*tmp, length = len)),
-                                         k = -4 + (1:len)*5)
-                      out$size <- floor(out$size)
-                    } else {
-                      out <- data.frame(size = sample(tmp:(2*tmp), size = len, replace = TRUE),
-                                        k = sample(1:(nrow(x) - 2), size = len, replace = TRUE))
-                    }
-                    out <- subset(out, size < n & k < n)
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    class::lvq3(x, y, class::lvqinit(x, y, size = param$size, k = min(param$k, nrow(x)-length(levels(y)))), ...)
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL)
-                    class::lvqtest(modelFit , newdata),
-                  levels = function(x) x$obsLevels,
-                  prob = NULL,
-                  tags = "Prototype Models",
-                  sort = function(x) x[order(-x$k, -x$size),])
+modelInfo <- list(
+  label = "Learning Vector Quantization",
+  library = "class",
+  loop = NULL,
+  type = "Classification",
+  parameters = data.frame(
+    parameter = c("size", "k"),
+    class = c("numeric", "numeric"),
+    label = c('Codebook Size', '#Prototypes')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    p <- ncol(x)
+    ng <- length(levels(y))
+    n <- nrow(x)
+    tmp <- min(round(0.4 * ng * (ng - 1 + p / 2), 0), n)
+    if (search == "grid") {
+      out <- expand.grid(
+        size = floor(seq(tmp, 2 * tmp, length = len)),
+        k = -4 + (1:len) * 5
+      )
+      out$size <- floor(out$size)
+    } else {
+      out <- data.frame(
+        size = sample(tmp:(2 * tmp), size = len, replace = TRUE),
+        k = sample(1:(nrow(x) - 2), size = len, replace = TRUE)
+      )
+    }
+    out <- subset(out, size < n & k < n)
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    class::lvq3(
+      x,
+      y,
+      class::lvqinit(
+        x,
+        y,
+        size = param$size,
+        k = min(param$k, nrow(x) - length(levels(y)))
+      ),
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    class::lvqtest(modelFit, newdata)
+  },
+  levels = function(x) x$obsLevels,
+  prob = NULL,
+  tags = "Prototype Models",
+  sort = function(x) x[order(-x$k, -x$size), ]
+)

--- a/inst/model_sources/files/manb.R
+++ b/inst/model_sources/files/manb.R
@@ -24,10 +24,10 @@ modelInfo <- list(
   },
   loop = NULL,
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     struct <- bnclassify::nb(class = '.outcome', dataset = dat)

--- a/inst/model_sources/files/manb.R
+++ b/inst/model_sources/files/manb.R
@@ -1,37 +1,58 @@
-modelInfo <- list(label = "Model Averaged Naive Bayes Classifier",
-                  library = "bnclassify",
-                  type = "Classification",
-                  parameters = data.frame(parameter = c("smooth", "prior"),
-                                          class = c("numeric", "numeric"),
-                                          label = c("Smoothing Parameter", "Prior Probability")),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") { 
-                      out <- expand.grid(smooth = 0:(len-1), prior = seq(.1, .9, length = len))
-                    } else {
-                      out <- data.frame(smooth= runif(len, min = 0, max = 10),
-                                        prior = runif(len))
-                    }
-                    out$smooth[out$smooth <= 0] <- .05
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    struct <- bnclassify::nb(class = '.outcome', dataset = dat)
-                    bnclassify::lp(struct, dat, smooth = param$smooth,
-                                   manb_prior = param$prior,
-                                   ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata)       
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata, prob = TRUE) 
-                  },
-                  levels = function(x) x$obsLevels,
-                  predictors = function(x, s = NULL, ...) x$xNames,
-                  tags = c("Bayesian Model", "Categorical Predictors Only"),
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Model Averaged Naive Bayes Classifier",
+  library = "bnclassify",
+  type = "Classification",
+  parameters = data.frame(
+    parameter = c("smooth", "prior"),
+    class = c("numeric", "numeric"),
+    label = c("Smoothing Parameter", "Prior Probability")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        smooth = 0:(len - 1),
+        prior = seq(.1, .9, length = len)
+      )
+    } else {
+      out <- data.frame(
+        smooth = runif(len, min = 0, max = 10),
+        prior = runif(len)
+      )
+    }
+    out$smooth[out$smooth <= 0] <- .05
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    struct <- bnclassify::nb(class = '.outcome', dataset = dat)
+    bnclassify::lp(
+      struct,
+      dat,
+      smooth = param$smooth,
+      manb_prior = param$prior,
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata, prob = TRUE)
+  },
+  levels = function(x) x$obsLevels,
+  predictors = function(x, s = NULL, ...) x$xNames,
+  tags = c("Bayesian Model", "Categorical Predictors Only"),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/mda.R
+++ b/inst/model_sources/files/mda.R
@@ -12,10 +12,10 @@ modelInfo <- list(
     data.frame(subclasses = (1:len) + 1)
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     mda::mda(

--- a/inst/model_sources/files/mda.R
+++ b/inst/model_sources/files/mda.R
@@ -1,23 +1,38 @@
-modelInfo <- list(label = "Mixture Discriminant Analysis",
-                  library = "mda",
-                  loop = NULL,
-                  type = c('Classification'),
-                  parameters = data.frame(parameter = c('subclasses'),
-                                          class = c('numeric'),
-                                          label = c('#Subclasses Per Class')),
-                  grid = function(x, y, len = NULL, search = "grid") 
-                    data.frame(subclasses = (1:len) + 1),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    mda::mda(as.formula(".outcome ~ ."), data = dat,
-                             subclasses = param$subclasses, ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) 
-                    predict(modelFit, newdata),
-                  prob = function(modelFit, newdata, submodels = NULL)
-                    predict(modelFit, newdata, type = "posterior"),
-                  predictors = function(x, ...) predictors(x$terms),
-                  levels = function(x) x$obsLevels,
-                  tags = c("Discriminant Analysis", "Mixture Model"),
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Mixture Discriminant Analysis",
+  library = "mda",
+  loop = NULL,
+  type = c('Classification'),
+  parameters = data.frame(
+    parameter = c('subclasses'),
+    class = c('numeric'),
+    label = c('#Subclasses Per Class')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(subclasses = (1:len) + 1)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    mda::mda(
+      as.formula(".outcome ~ ."),
+      data = dat,
+      subclasses = param$subclasses,
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata, type = "posterior")
+  },
+  predictors = function(x, ...) predictors(x$terms),
+  levels = function(x) x$obsLevels,
+  tags = c("Discriminant Analysis", "Mixture Model"),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/mlp.R
+++ b/inst/model_sources/files/mlp.R
@@ -1,46 +1,50 @@
-modelInfo <- list(label = "Multi-Layer Perceptron",
-                  library = "RSNNS",
-                  loop = NULL,
-                  type = c('Regression', 'Classification'),
-                  parameters = data.frame(parameter = c('size'),
-                                          class = c('numeric'),
-                                          label = c('#Hidden Units')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- data.frame(size =  ((1:len) * 2) - 1)
-                    } else {
-                      out <- data.frame(size = unique(sample(1:20, size = len, replace = TRUE)))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    theDots <- list(...)
-                    theDots <- theDots[!(names(theDots) %in% c("size", "linOut"))]                   
-                    
-                    if(is.factor(y)) {
-                      y <- RSNNS:::decodeClassLabels(y)
-                      lin <- FALSE
-                    } else lin <- TRUE
-                    args <- list(x = x,
-                                 y = y,
-                                 size = param$size,
-                                 linOut = lin)
-                    args <- c(args, theDots)
-                    do.call(RSNNS::mlp, args)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata)
-                    if(modelFit$problemType == "Classification")
-                    {
-                      out <- modelFit$obsLevels[apply(out, 1, which.max)]
-                    } else out <- out[,1]
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata)
-                    colnames(out) <- modelFit$obsLevels
-                    out
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("Neural Network"),
-                  sort = function(x) x[order(x$size),])
+modelInfo <- list(
+  label = "Multi-Layer Perceptron",
+  library = "RSNNS",
+  loop = NULL,
+  type = c('Regression', 'Classification'),
+  parameters = data.frame(
+    parameter = c('size'),
+    class = c('numeric'),
+    label = c('#Hidden Units')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(size = ((1:len) * 2) - 1)
+    } else {
+      out <- data.frame(size = unique(sample(1:20, size = len, replace = TRUE)))
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    theDots <- list(...)
+    theDots <- theDots[!(names(theDots) %in% c("size", "linOut"))]
+
+    if (is.factor(y)) {
+      y <- RSNNS:::decodeClassLabels(y)
+      lin <- FALSE
+    } else {
+      lin <- TRUE
+    }
+    args <- list(x = x, y = y, size = param$size, linOut = lin)
+    args <- c(args, theDots)
+    do.call(RSNNS::mlp, args)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata)
+    if (modelFit$problemType == "Classification") {
+      out <- modelFit$obsLevels[apply(out, 1, which.max)]
+    } else {
+      out <- out[, 1]
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata)
+    colnames(out) <- modelFit$obsLevels
+    out
+  },
+  levels = function(x) x$obsLevels,
+  tags = c("Neural Network"),
+  sort = function(x) x[order(x$size), ]
+)

--- a/inst/model_sources/files/mlpKerasDecay.R
+++ b/inst/model_sources/files/mlpKerasDecay.R
@@ -1,147 +1,174 @@
-modelInfo <- list(label = "Multilayer Perceptron Network with Weight Decay",
-                  library = "keras",
-                  loop = NULL,
-                  type = c('Regression', "Classification"),
-                  parameters = data.frame(
-                    parameter = c('size', 'lambda', "batch_size",
-                                  "lr", "rho", "decay", 
-                                  "activation"),
-                    class = c(rep('numeric', 6), "character"),
-                    label = c('#Hidden Units', 'L2 Regularization', 
-                              "Batch Size", "Learning Rate",
-                              "Rho", "Learning Rate Decay",
-                              "Activation Function")
-                  ),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    afuncs <- c("sigmoid", "relu", "tanh")
-                    if(search == "grid") {
-                      out <- expand.grid(
-                        size = ((1:len) * 2) - 1, 
-                        lambda = c(0, 10 ^ seq(-1, -4, length = len - 1)), 
-                        batch_size = floor(nrow(x)/3),
-                        lr = 2e-6,
-                        rho = .9,
-                        decay = 0,
-                        activation = "relu"
-                      )
-                    } else {
-                      n <- nrow(x)
-                      out <- data.frame(
-                        size = sample(2:20, replace = TRUE, size = len),
-                        lambda = 10^runif(len, min = -5, 1),
-                        batch_size = floor(n*runif(len, min = .1)),
-                        lr = runif(len),
-                        rho = runif(len),
-                        decay = 10^runif(len, min = -5, 0),
-                        activation = sample(
-                          afuncs, 
-                          size = len, 
-                          replace = TRUE
-                        )
-                      )
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    require(dplyr)
-                    K <- keras::backend()
-                    K$clear_session()
-                    if(!is.matrix(x)) x <- as.matrix(x)
-                    model <- keras::keras_model_sequential()
-                    model %>% 
-                      keras::layer_dense(
-                        units = param$size, 
-                        activation = as.character(param$activation), 
-                        input_shape = ncol(x),
-                        kernel_initializer = keras::initializer_glorot_uniform(),
-                        kernel_regularizer = keras::regularizer_l2(param$lambda)
-                      )
-                    if(is.factor(y)) {
-                      y <- class2ind(y)
-                      model %>% 
-                        keras::layer_dense(
-                          units = length(lev), 
-                          activation = 'softmax',
-                          kernel_regularizer = keras::regularizer_l2(param$lambda)
-                        ) %>% keras::compile(
-                          loss = "categorical_crossentropy",
-                          optimizer = keras::optimizer_rmsprop(
-                            lr = param$lr,
-                            rho = param$rho,
-                            decay = param$decay
-                          ),
-                          metrics = "accuracy"
-                        )
-                    } else {
-                      model %>% 
-                        keras::layer_dense(
-                          units = 1, 
-                          activation = 'linear',
-                          kernel_regularizer = keras::regularizer_l2(param$lambda)
-                        ) %>% keras::compile(
-                          loss = "mean_squared_error",
-                          optimizer = keras::optimizer_rmsprop(
-                            lr = param$lr,
-                            rho = param$rho,
-                            decay = param$decay
-                          ),
-                          metrics = "mean_squared_error"
-                        )
-                    }
-                    model %>% keras::fit(
-                      x = x, 
-                      y = y,
-                      batch_size = param$batch_size,
-                      ...
-                    )
-                    if(last)
-                      model <- keras::serialize_model(model)
-                    list(object = model)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(inherits(modelFit$object, "raw"))
-                      modelFit$object <- keras::unserialize_model(modelFit$object)
-                    if(!is.matrix(newdata)) 
-                      newdata <- as.matrix(newdata)
-                    out <- predict(modelFit$object, newdata)
-                    ## check for model type
-                    if(ncol(out) == 1) {
-                      out <- out[, 1]
-                    } else {
-                      out <- modelFit$obsLevels[apply(out, 1, which.max)]
-                    }
-                    out
-                  },
-                  prob =  function(modelFit, newdata, submodels = NULL) {
-                    if(inherits(modelFit$object, "raw"))
-                      modelFit$object <- keras::unserialize_model(modelFit$object)
-                    if(!is.matrix(newdata)) 
-                      newdata <- as.matrix(newdata)
-                    out <- predict(modelFit$object, newdata)
-                    colnames(out) <- modelFit$obsLevels
-                    as.data.frame(out, stringsAsFactors = TRUE)
-                  },
-                  varImp = NULL,
-                  tags = c("Neural Network", "L2 Regularization"),
-                  sort = function(x) x[order(x$size, -x$lambda),],
-                  notes = paste("After `train` completes, the keras model object is serialized",
-                                "so that it can be used between R session. When predicting, the", 
-                                "code will temporarily unsearalize the object. To make the", 
-                                "predictions more efficient, the user might want to use ", 
-                                "`keras::unsearlize_model(object$finalModel$object)` in the current", 
-                                "R session so that that operation is only done once.",
-                                "Also, this model cannot be run in parallel due to",
-                                "the nature of how tensorflow does the computations.",
-                                
-                                "Unlike other packages used by `train`, the `dplyr`",
-                                "package is fully loaded when this model is used."),
-                  check = function(pkg) {
-                    testmod <- try(keras::keras_model_sequential(),
-                                   silent = TRUE)
-                    if(inherits(testmod, "try-error"))
-                      stop("Could not start a sequential model. ",
-                           "`tensorflow` might not be installed. ",
-                           "See `?install_tensorflow`.", 
-                           call. = FALSE)
-                    TRUE
-                  })
+modelInfo <- list(
+  label = "Multilayer Perceptron Network with Weight Decay",
+  library = "keras",
+  loop = NULL,
+  type = c('Regression', "Classification"),
+  parameters = data.frame(
+    parameter = c(
+      'size',
+      'lambda',
+      "batch_size",
+      "lr",
+      "rho",
+      "decay",
+      "activation"
+    ),
+    class = c(rep('numeric', 6), "character"),
+    label = c(
+      '#Hidden Units',
+      'L2 Regularization',
+      "Batch Size",
+      "Learning Rate",
+      "Rho",
+      "Learning Rate Decay",
+      "Activation Function"
+    )
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    afuncs <- c("sigmoid", "relu", "tanh")
+    if (search == "grid") {
+      out <- expand.grid(
+        size = ((1:len) * 2) - 1,
+        lambda = c(0, 10^seq(-1, -4, length = len - 1)),
+        batch_size = floor(nrow(x) / 3),
+        lr = 2e-6,
+        rho = .9,
+        decay = 0,
+        activation = "relu"
+      )
+    } else {
+      n <- nrow(x)
+      out <- data.frame(
+        size = sample(2:20, replace = TRUE, size = len),
+        lambda = 10^runif(len, min = -5, 1),
+        batch_size = floor(n * runif(len, min = .1)),
+        lr = runif(len),
+        rho = runif(len),
+        decay = 10^runif(len, min = -5, 0),
+        activation = sample(
+          afuncs,
+          size = len,
+          replace = TRUE
+        )
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    require(dplyr)
+    K <- keras::backend()
+    K$clear_session()
+    if (!is.matrix(x)) {
+      x <- as.matrix(x)
+    }
+    model <- keras::keras_model_sequential()
+    model %>%
+      keras::layer_dense(
+        units = param$size,
+        activation = as.character(param$activation),
+        input_shape = ncol(x),
+        kernel_initializer = keras::initializer_glorot_uniform(),
+        kernel_regularizer = keras::regularizer_l2(param$lambda)
+      )
+    if (is.factor(y)) {
+      y <- class2ind(y)
+      model %>%
+        keras::layer_dense(
+          units = length(lev),
+          activation = 'softmax',
+          kernel_regularizer = keras::regularizer_l2(param$lambda)
+        ) %>%
+        keras::compile(
+          loss = "categorical_crossentropy",
+          optimizer = keras::optimizer_rmsprop(
+            lr = param$lr,
+            rho = param$rho,
+            decay = param$decay
+          ),
+          metrics = "accuracy"
+        )
+    } else {
+      model %>%
+        keras::layer_dense(
+          units = 1,
+          activation = 'linear',
+          kernel_regularizer = keras::regularizer_l2(param$lambda)
+        ) %>%
+        keras::compile(
+          loss = "mean_squared_error",
+          optimizer = keras::optimizer_rmsprop(
+            lr = param$lr,
+            rho = param$rho,
+            decay = param$decay
+          ),
+          metrics = "mean_squared_error"
+        )
+    }
+    model %>%
+      keras::fit(
+        x = x,
+        y = y,
+        batch_size = param$batch_size,
+        ...
+      )
+    if (last) {
+      model <- keras::serialize_model(model)
+    }
+    list(object = model)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (inherits(modelFit$object, "raw")) {
+      modelFit$object <- keras::unserialize_model(modelFit$object)
+    }
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- predict(modelFit$object, newdata)
+    ## check for model type
+    if (ncol(out) == 1) {
+      out <- out[, 1]
+    } else {
+      out <- modelFit$obsLevels[apply(out, 1, which.max)]
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (inherits(modelFit$object, "raw")) {
+      modelFit$object <- keras::unserialize_model(modelFit$object)
+    }
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- predict(modelFit$object, newdata)
+    colnames(out) <- modelFit$obsLevels
+    as.data.frame(out, stringsAsFactors = TRUE)
+  },
+  varImp = NULL,
+  tags = c("Neural Network", "L2 Regularization"),
+  sort = function(x) x[order(x$size, -x$lambda), ],
+  notes = paste(
+    "After `train` completes, the keras model object is serialized",
+    "so that it can be used between R session. When predicting, the",
+    "code will temporarily unsearalize the object. To make the",
+    "predictions more efficient, the user might want to use ",
+    "`keras::unsearlize_model(object$finalModel$object)` in the current",
+    "R session so that that operation is only done once.",
+    "Also, this model cannot be run in parallel due to",
+    "the nature of how tensorflow does the computations.",
+
+    "Unlike other packages used by `train`, the `dplyr`",
+    "package is fully loaded when this model is used."
+  ),
+  check = function(pkg) {
+    testmod <- try(keras::keras_model_sequential(), silent = TRUE)
+    if (inherits(testmod, "try-error")) {
+      stop(
+        "Could not start a sequential model. ",
+        "`tensorflow` might not be installed. ",
+        "See `?install_tensorflow`.",
+        call. = FALSE
+      )
+    }
+    TRUE
+  }
+)

--- a/inst/model_sources/files/mlpKerasDecayCost.R
+++ b/inst/model_sources/files/mlpKerasDecayCost.R
@@ -1,137 +1,168 @@
-modelInfo <- list(label = "Multilayer Perceptron Network with Weight Decay",
-                  library = "keras",
-                  loop = NULL,
-                  type = "Classification",
-                  parameters = data.frame(
-                    parameter = c('size', 'lambda', "batch_size",
-                                  "lr", "rho", "decay", "cost", 
-                                  "activation"),
-                    class = c(rep('numeric', 7), "character"),
-                    label = c('#Hidden Units', 'L2 Regularization', 
-                              "Batch Size", "Learning Rate",
-                              "Rho", "Learning Rate Decay",
-                              "Cost",
-                              "Activation Function")
-                  ),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    afuncs <- c("sigmoid", "relu", "tanh")
-                    if(search == "grid") {
-                      out <- expand.grid(
-                        size = ((1:len) * 2) - 1, 
-                        lambda = c(0, 10 ^ seq(-1, -4, length = len - 1)), 
-                        batch_size = floor(nrow(x)/3),
-                        lr = 2e-6,
-                        rho = .9,
-                        decay = 0,
-                        activation = "relu",
-                        cost = 1:len
-                      )
-                    } else {
-                      n <- nrow(x)
-                      out <- data.frame(
-                        size = sample(2:20, replace = TRUE, size = len),
-                        lambda = 10^runif(len, min = -5, 1),
-                        batch_size = floor(n*runif(len, min = .1)),
-                        lr = runif(len),
-                        rho = runif(len),
-                        decay = 10^runif(len, min = -5, 0),
-                        activation = sample(
-                          afuncs, 
-                          size = len, 
-                          replace = TRUE
-                        ),
-                        cost = runif(len, min = 1, max = 20)
-                      )
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    require(dplyr)
-                    K <- keras::backend()
-                    K$clear_session()
-                    if(!is.matrix(x)) x <- as.matrix(x)
-                    model <- keras::keras_model_sequential()
-                    model %>% 
-                      keras::layer_dense(
-                        units = param$size, 
-                        activation = as.character(param$activation), 
-                        input_shape = ncol(x),
-                        kernel_initializer = keras::initializer_glorot_uniform(),
-                        kernel_regularizer = keras::regularizer_l2(param$lambda)
-                      )
-                    y <- class2ind(y)
-                    model %>% 
-                      keras::layer_dense(
-                        units = length(lev), 
-                        activation = 'softmax',
-                        kernel_regularizer = keras::regularizer_l2(param$lambda)
-                      ) %>% keras::compile(
-                        loss = "categorical_crossentropy",
-                        loss_weights = list(param$cost),
-                        optimizer = keras::optimizer_rmsprop(
-                          lr = param$lr,
-                          rho = param$rho,
-                          decay = param$decay
-                        ),
-                        metrics = "accuracy"
-                      )
-                    model %>% keras::fit(
-                      x = x, 
-                      y = y,
-                      batch_size = param$batch_size,
-                      ...
-                    )
-                    if(last)
-                      model <- keras::serialize_model(model)
-                    list(object = model)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(inherits(modelFit$object, "raw"))
-                      modelFit$object <- keras::unserialize_model(modelFit$object)
-                    if(!is.matrix(newdata)) 
-                      newdata <- as.matrix(newdata)
-                    out <- predict(modelFit$object, newdata)
-                    ## check for model type
-                    if(ncol(out) == 1) {
-                      out <- out[, 1]
-                    } else {
-                      out <- modelFit$obsLevels[apply(out, 1, which.max)]
-                    }
-                    out
-                  },
-                  prob =  function(modelFit, newdata, submodels = NULL) {
-                    if(inherits(modelFit$object, "raw"))
-                      modelFit$object <- keras::unserialize_model(modelFit$object)
-                    if(!is.matrix(newdata)) 
-                      newdata <- as.matrix(newdata)
-                    out <- predict(modelFit$object, newdata)
-                    colnames(out) <- modelFit$obsLevels
-                    as.data.frame(out, stringsAsFactors = TRUE)
-                  },
-                  varImp = NULL,
-                  tags = c("Neural Network", "L2 Regularization", "Cost Sensitive Learning", 
-                           "Two Class Only"),
-                  sort = function(x) x[order(x$size, -x$lambda),],
-                  notes = paste("After `train` completes, the keras model object is serialized",
-                                "so that it can be used between R session. When predicting, the", 
-                                "code will temporarily unsearalize the object. To make the", 
-                                "predictions more efficient, the user might want to use ", 
-                                "`keras::unsearlize_model(object$finalModel$object)` in the current", 
-                                "R session so that that operation is only done once.",
-                                "Also, this model cannot be run in parallel due to",
-                                "the nature of how tensorflow does the computations.",
-                                "Finally, the cost parameter weights the first",
-                                "class in the outcome vector.",
-                                
-                                "Unlike other packages used by `train`, the `dplyr`",
-                                "package is fully loaded when this model is used."),
-                  check = function(pkg) {
-                    testmod <- try(keras::keras_model_sequential(),
-                                   silent = TRUE)
-                    if(inherits(testmod, "try-error"))
-                      stop("Could not start a sequential model. ",
-                           "`tensorflow` might not be installed. ",
-                           "See `?install_tensorflow`.", 
-                           call. = FALSE)
-                    TRUE
-                  })
+modelInfo <- list(
+  label = "Multilayer Perceptron Network with Weight Decay",
+  library = "keras",
+  loop = NULL,
+  type = "Classification",
+  parameters = data.frame(
+    parameter = c(
+      'size',
+      'lambda',
+      "batch_size",
+      "lr",
+      "rho",
+      "decay",
+      "cost",
+      "activation"
+    ),
+    class = c(rep('numeric', 7), "character"),
+    label = c(
+      '#Hidden Units',
+      'L2 Regularization',
+      "Batch Size",
+      "Learning Rate",
+      "Rho",
+      "Learning Rate Decay",
+      "Cost",
+      "Activation Function"
+    )
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    afuncs <- c("sigmoid", "relu", "tanh")
+    if (search == "grid") {
+      out <- expand.grid(
+        size = ((1:len) * 2) - 1,
+        lambda = c(0, 10^seq(-1, -4, length = len - 1)),
+        batch_size = floor(nrow(x) / 3),
+        lr = 2e-6,
+        rho = .9,
+        decay = 0,
+        activation = "relu",
+        cost = 1:len
+      )
+    } else {
+      n <- nrow(x)
+      out <- data.frame(
+        size = sample(2:20, replace = TRUE, size = len),
+        lambda = 10^runif(len, min = -5, 1),
+        batch_size = floor(n * runif(len, min = .1)),
+        lr = runif(len),
+        rho = runif(len),
+        decay = 10^runif(len, min = -5, 0),
+        activation = sample(
+          afuncs,
+          size = len,
+          replace = TRUE
+        ),
+        cost = runif(len, min = 1, max = 20)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    require(dplyr)
+    K <- keras::backend()
+    K$clear_session()
+    if (!is.matrix(x)) {
+      x <- as.matrix(x)
+    }
+    model <- keras::keras_model_sequential()
+    model %>%
+      keras::layer_dense(
+        units = param$size,
+        activation = as.character(param$activation),
+        input_shape = ncol(x),
+        kernel_initializer = keras::initializer_glorot_uniform(),
+        kernel_regularizer = keras::regularizer_l2(param$lambda)
+      )
+    y <- class2ind(y)
+    model %>%
+      keras::layer_dense(
+        units = length(lev),
+        activation = 'softmax',
+        kernel_regularizer = keras::regularizer_l2(param$lambda)
+      ) %>%
+      keras::compile(
+        loss = "categorical_crossentropy",
+        loss_weights = list(param$cost),
+        optimizer = keras::optimizer_rmsprop(
+          lr = param$lr,
+          rho = param$rho,
+          decay = param$decay
+        ),
+        metrics = "accuracy"
+      )
+    model %>%
+      keras::fit(
+        x = x,
+        y = y,
+        batch_size = param$batch_size,
+        ...
+      )
+    if (last) {
+      model <- keras::serialize_model(model)
+    }
+    list(object = model)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (inherits(modelFit$object, "raw")) {
+      modelFit$object <- keras::unserialize_model(modelFit$object)
+    }
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- predict(modelFit$object, newdata)
+    ## check for model type
+    if (ncol(out) == 1) {
+      out <- out[, 1]
+    } else {
+      out <- modelFit$obsLevels[apply(out, 1, which.max)]
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (inherits(modelFit$object, "raw")) {
+      modelFit$object <- keras::unserialize_model(modelFit$object)
+    }
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- predict(modelFit$object, newdata)
+    colnames(out) <- modelFit$obsLevels
+    as.data.frame(out, stringsAsFactors = TRUE)
+  },
+  varImp = NULL,
+  tags = c(
+    "Neural Network",
+    "L2 Regularization",
+    "Cost Sensitive Learning",
+    "Two Class Only"
+  ),
+  sort = function(x) x[order(x$size, -x$lambda), ],
+  notes = paste(
+    "After `train` completes, the keras model object is serialized",
+    "so that it can be used between R session. When predicting, the",
+    "code will temporarily unsearalize the object. To make the",
+    "predictions more efficient, the user might want to use ",
+    "`keras::unsearlize_model(object$finalModel$object)` in the current",
+    "R session so that that operation is only done once.",
+    "Also, this model cannot be run in parallel due to",
+    "the nature of how tensorflow does the computations.",
+    "Finally, the cost parameter weights the first",
+    "class in the outcome vector.",
+
+    "Unlike other packages used by `train`, the `dplyr`",
+    "package is fully loaded when this model is used."
+  ),
+  check = function(pkg) {
+    testmod <- try(keras::keras_model_sequential(), silent = TRUE)
+    if (inherits(testmod, "try-error")) {
+      stop(
+        "Could not start a sequential model. ",
+        "`tensorflow` might not be installed. ",
+        "See `?install_tensorflow`.",
+        call. = FALSE
+      )
+    }
+    TRUE
+  }
+)

--- a/inst/model_sources/files/mlpKerasDropout.R
+++ b/inst/model_sources/files/mlpKerasDropout.R
@@ -1,149 +1,172 @@
-modelInfo <- list(label = "Multilayer Perceptron Network with Dropout",
-                  library = "keras",
-                  loop = NULL,
-                  type = c('Regression', "Classification"),
-                  parameters = data.frame(
-                    parameter = c('size', 'dropout', 
-                                  "batch_size",
-                                  "lr", "rho", "decay", 
-                                  "activation"),
-                    class = c(rep('numeric', 6), "character"),
-                    label = c('#Hidden Units', 'Dropout Rate', 
-                              "Batch Size", "Learning Rate",
-                              "Rho", "Learning Rate Decay",
-                              "Activation Function")
-                  ),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    afuncs <- c("sigmoid", "relu", "tanh")
-                    if(search == "grid") {
-                      out <- expand.grid(
-                        size = ((1:len) * 2) - 1, 
-                        dropout = seq(0, .7, length = len), 
-                        batch_size = floor(nrow(x)/3),
-                        lr = 2e-6,
-                        rho = .9,
-                        decay = 0,
-                        activation = "relu"
-                      )
-                    } else {
-                      n <- nrow(x)
-                      out <- data.frame(
-                        size = sample(2:20, replace = TRUE, size = len),
-                        dropout = runif(len, max = .7), 
-                        batch_size = floor(n*runif(len, min = .1)),
-                        lr = runif(len),
-                        rho = runif(len),
-                        decay = 10^runif(len, min = -5, 0),
-                        activation = sample(
-                          afuncs, 
-                          size = len, 
-                          replace = TRUE
-                        )
-                      )
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    require(dplyr)
-                    K <- keras::backend()
-                    K$clear_session()
-                    if(!is.matrix(x)) x <- as.matrix(x)
-                    model <- keras::keras_model_sequential()
-                    model %>% 
-                      keras::layer_dense(
-                        units = param$size, 
-                        activation = as.character(param$activation), 
-                        kernel_initializer = keras::initializer_glorot_uniform(),
-                        input_shape = ncol(x)
-                      ) %>%
-                      keras::layer_dropout(rate = param$dropout,
-                                           seed = sample.int(1000, 1))
-                    if(is.factor(y)) {
-                      y <- class2ind(y)
-                      model %>% 
-                        keras::layer_dense(
-                          units = length(lev), 
-                          activation = 'softmax'
-                        ) %>%
-                        keras::compile(
-                          loss = "categorical_crossentropy",
-                          optimizer = keras::optimizer_rmsprop(
-                            lr = param$lr,
-                            rho = param$rho,
-                            decay = param$decay
-                          ),
-                          metrics = "accuracy"
-                        )
-                    } else {
-                      model %>% 
-                        keras::layer_dense(
-                          units = 1, 
-                          activation = 'linear'
-                        ) %>%
-                        keras::compile(
-                          loss = "mean_squared_error",
-                          optimizer = keras::optimizer_rmsprop(
-                            lr = param$lr,
-                            rho = param$rho,
-                            decay = param$decay
-                          ),
-                          metrics = "mean_squared_error"
-                        )
-                    }
-                    model %>% keras::fit(
-                      x = x, 
-                      y = y,
-                      batch_size = param$batch_size,
-                      ...
-                    )
-                    if(last)
-                      model <- keras::serialize_model(model)
-                    list(object = model)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(inherits(modelFit$object, "raw"))
-                      modelFit$object <- keras::unserialize_model(modelFit$object)
-                    if(!is.matrix(newdata)) 
-                      newdata <- as.matrix(newdata)
-                    out <- predict(modelFit$object, newdata)
-                    ## check for model type
-                    if(ncol(out) == 1) {
-                      out <- out[, 1]
-                    } else {
-                      out <- modelFit$obsLevels[apply(out, 1, which.max)]
-                    }
-                    out
-                  },
-                  prob =  function(modelFit, newdata, submodels = NULL) {
-                    if(inherits(modelFit$object, "raw"))
-                      modelFit$object <- keras::unserialize_model(modelFit$object)
-                    if(!is.matrix(newdata)) 
-                      newdata <- as.matrix(newdata)
-                    out <- predict(modelFit$object, newdata)
-                    colnames(out) <- modelFit$obsLevels
-                    as.data.frame(out, stringsAsFactors = TRUE)
-                  },
-                  varImp = NULL,
-                  tags = c("Neural Network"),
-                  sort = function(x) x[order(x$size, -x$dropout),],
-                  notes = paste("After `train` completes, the keras model object is serialized",
-                                "so that it can be used between R session. When predicting, the", 
-                                "code will temporarily unsearalize the object. To make the", 
-                                "predictions more efficient, the user might want to use ", 
-                                "`keras::unsearlize_model(object$finalModel$object)` in the current", 
-                                "R session so that that operation is only done once.",
-                                "Also, this model cannot be run in parallel due to",
-                                "the nature of how tensorflow does the computations.",
-                                
-                                "Unlike other packages used by `train`, the `dplyr`",
-                                "package is fully loaded when this model is used."),
-                  check = function(pkg) {
-                    testmod <- try(keras::keras_model_sequential(),
-                                   silent = TRUE)
-                    if(inherits(testmod, "try-error"))
-                      stop("Could not start a sequential model. ",
-                           "`tensorflow` might not be installed. ",
-                           "See `?install_tensorflow`.", 
-                           call. = FALSE)
-                    TRUE
-                  })
+modelInfo <- list(
+  label = "Multilayer Perceptron Network with Dropout",
+  library = "keras",
+  loop = NULL,
+  type = c('Regression', "Classification"),
+  parameters = data.frame(
+    parameter = c(
+      'size',
+      'dropout',
+      "batch_size",
+      "lr",
+      "rho",
+      "decay",
+      "activation"
+    ),
+    class = c(rep('numeric', 6), "character"),
+    label = c(
+      '#Hidden Units',
+      'Dropout Rate',
+      "Batch Size",
+      "Learning Rate",
+      "Rho",
+      "Learning Rate Decay",
+      "Activation Function"
+    )
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    afuncs <- c("sigmoid", "relu", "tanh")
+    if (search == "grid") {
+      out <- expand.grid(
+        size = ((1:len) * 2) - 1,
+        dropout = seq(0, .7, length = len),
+        batch_size = floor(nrow(x) / 3),
+        lr = 2e-6,
+        rho = .9,
+        decay = 0,
+        activation = "relu"
+      )
+    } else {
+      n <- nrow(x)
+      out <- data.frame(
+        size = sample(2:20, replace = TRUE, size = len),
+        dropout = runif(len, max = .7),
+        batch_size = floor(n * runif(len, min = .1)),
+        lr = runif(len),
+        rho = runif(len),
+        decay = 10^runif(len, min = -5, 0),
+        activation = sample(
+          afuncs,
+          size = len,
+          replace = TRUE
+        )
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    require(dplyr)
+    K <- keras::backend()
+    K$clear_session()
+    if (!is.matrix(x)) {
+      x <- as.matrix(x)
+    }
+    model <- keras::keras_model_sequential()
+    model %>%
+      keras::layer_dense(
+        units = param$size,
+        activation = as.character(param$activation),
+        kernel_initializer = keras::initializer_glorot_uniform(),
+        input_shape = ncol(x)
+      ) %>%
+      keras::layer_dropout(rate = param$dropout, seed = sample.int(1000, 1))
+    if (is.factor(y)) {
+      y <- class2ind(y)
+      model %>%
+        keras::layer_dense(
+          units = length(lev),
+          activation = 'softmax'
+        ) %>%
+        keras::compile(
+          loss = "categorical_crossentropy",
+          optimizer = keras::optimizer_rmsprop(
+            lr = param$lr,
+            rho = param$rho,
+            decay = param$decay
+          ),
+          metrics = "accuracy"
+        )
+    } else {
+      model %>%
+        keras::layer_dense(
+          units = 1,
+          activation = 'linear'
+        ) %>%
+        keras::compile(
+          loss = "mean_squared_error",
+          optimizer = keras::optimizer_rmsprop(
+            lr = param$lr,
+            rho = param$rho,
+            decay = param$decay
+          ),
+          metrics = "mean_squared_error"
+        )
+    }
+    model %>%
+      keras::fit(
+        x = x,
+        y = y,
+        batch_size = param$batch_size,
+        ...
+      )
+    if (last) {
+      model <- keras::serialize_model(model)
+    }
+    list(object = model)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (inherits(modelFit$object, "raw")) {
+      modelFit$object <- keras::unserialize_model(modelFit$object)
+    }
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- predict(modelFit$object, newdata)
+    ## check for model type
+    if (ncol(out) == 1) {
+      out <- out[, 1]
+    } else {
+      out <- modelFit$obsLevels[apply(out, 1, which.max)]
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (inherits(modelFit$object, "raw")) {
+      modelFit$object <- keras::unserialize_model(modelFit$object)
+    }
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- predict(modelFit$object, newdata)
+    colnames(out) <- modelFit$obsLevels
+    as.data.frame(out, stringsAsFactors = TRUE)
+  },
+  varImp = NULL,
+  tags = c("Neural Network"),
+  sort = function(x) x[order(x$size, -x$dropout), ],
+  notes = paste(
+    "After `train` completes, the keras model object is serialized",
+    "so that it can be used between R session. When predicting, the",
+    "code will temporarily unsearalize the object. To make the",
+    "predictions more efficient, the user might want to use ",
+    "`keras::unsearlize_model(object$finalModel$object)` in the current",
+    "R session so that that operation is only done once.",
+    "Also, this model cannot be run in parallel due to",
+    "the nature of how tensorflow does the computations.",
+
+    "Unlike other packages used by `train`, the `dplyr`",
+    "package is fully loaded when this model is used."
+  ),
+  check = function(pkg) {
+    testmod <- try(keras::keras_model_sequential(), silent = TRUE)
+    if (inherits(testmod, "try-error")) {
+      stop(
+        "Could not start a sequential model. ",
+        "`tensorflow` might not be installed. ",
+        "See `?install_tensorflow`.",
+        call. = FALSE
+      )
+    }
+    TRUE
+  }
+)

--- a/inst/model_sources/files/mlpKerasDropoutCost.R
+++ b/inst/model_sources/files/mlpKerasDropoutCost.R
@@ -1,138 +1,162 @@
-modelInfo <- list(label = "Multilayer Perceptron Network with Dropout",
-                  library = "keras",
-                  loop = NULL,
-                  type = "Classification",
-                  parameters = data.frame(
-                    parameter = c('size', 'dropout', 
-                                  "batch_size",
-                                  "lr", "rho", "decay", "cost",
-                                  "activation"),
-                    class = c(rep('numeric', 7), "character"),
-                    label = c('#Hidden Units', 'Dropout Rate', 
-                              "Batch Size", "Learning Rate",
-                              "Rho", "Learning Rate Decay",
-                              "Cost", "Activation Function")
-                  ),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    afuncs <- c("sigmoid", "relu", "tanh")
-                    if(search == "grid") {
-                      out <- expand.grid(
-                        size = ((1:len) * 2) - 1, 
-                        dropout = seq(0, .7, length = len), 
-                        batch_size = floor(nrow(x)/3),
-                        lr = 2e-6,
-                        rho = .9,
-                        decay = 0,
-                        activation = "relu",
-                        cost = 1:len
-                      )
-                    } else {
-                      n <- nrow(x)
-                      out <- data.frame(
-                        size = sample(2:20, replace = TRUE, size = len),
-                        dropout = runif(len, max = .7), 
-                        batch_size = floor(n*runif(len, min = .1)),
-                        lr = runif(len),
-                        rho = runif(len),
-                        decay = 10^runif(len, min = -5, 0),
-                        activation = sample(
-                          afuncs, 
-                          size = len, 
-                          replace = TRUE
-                        ),
-                        cost = runif(len, min = 1, max = 20)
-                      )
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    require(dplyr)
-                    K <- keras::backend()
-                    K$clear_session()
-                    if(!is.matrix(x)) x <- as.matrix(x)
-                    model <- keras::keras_model_sequential()
-                    model %>% 
-                      keras::layer_dense(
-                        units = param$size, 
-                        activation = as.character(param$activation), 
-                        kernel_initializer = keras::initializer_glorot_uniform(),
-                        input_shape = ncol(x)
-                      ) %>%
-                      keras::layer_dropout(rate = param$dropout,
-                                           seed = sample.int(1000, 1))
-                    y <- class2ind(y)
-                    model %>% 
-                      keras::layer_dense(
-                        units = length(lev), 
-                        activation = 'softmax'
-                      ) %>%
-                      keras::compile(
-                        loss = "categorical_crossentropy",
-                        loss_weights = list(param$cost),
-                        optimizer = keras::optimizer_rmsprop(
-                          lr = param$lr,
-                          rho = param$rho,
-                          decay = param$decay
-                        ),
-                        metrics = "accuracy"
-                      )
-                    model %>% keras::fit(
-                      x = x, 
-                      y = y,
-                      batch_size = param$batch_size,
-                      ...
-                    )
-                    if(last)
-                      model <- keras::serialize_model(model)
-                    list(object = model)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(inherits(modelFit$object, "raw"))
-                      modelFit$object <- keras::unserialize_model(modelFit$object)
-                    if(!is.matrix(newdata)) 
-                      newdata <- as.matrix(newdata)
-                    out <- predict(modelFit$object, newdata)
-                    ## check for model type
-                    if(ncol(out) == 1) {
-                      out <- out[, 1]
-                    } else {
-                      out <- modelFit$obsLevels[apply(out, 1, which.max)]
-                    }
-                    out
-                  },
-                  prob =  function(modelFit, newdata, submodels = NULL) {
-                    if(inherits(modelFit$object, "raw"))
-                      modelFit$object <- keras::unserialize_model(modelFit$object)
-                    if(!is.matrix(newdata)) 
-                      newdata <- as.matrix(newdata)
-                    out <- predict(modelFit$object, newdata)
-                    colnames(out) <- modelFit$obsLevels
-                    as.data.frame(out, stringsAsFactors = TRUE)
-                  },
-                  varImp = NULL,
-                  tags = c("Neural Network", "Cost Sensitive Learning", 
-                           "Two Class Only"),
-                  sort = function(x) x[order(x$size, -x$dropout),],
-                  notes = paste("After `train` completes, the keras model object is serialized",
-                                "so that it can be used between R session. When predicting, the", 
-                                "code will temporarily unsearalize the object. To make the", 
-                                "predictions more efficient, the user might want to use ", 
-                                "`keras::unsearlize_model(object$finalModel$object)` in the current", 
-                                "R session so that that operation is only done once.",
-                                "Also, this model cannot be run in parallel due to",
-                                "the nature of how tensorflow does the computations.",
-                                "Finally, the cost parameter weights the first",
-                                "class in the outcome vector.",
-                                
-                                "Unlike other packages used by `train`, the `dplyr`",
-                                "package is fully loaded when this model is used."),
-                  check = function(pkg) {
-                    testmod <- try(keras::keras_model_sequential(),
-                                   silent = TRUE)
-                    if(inherits(testmod, "try-error"))
-                      stop("Could not start a sequential model. ",
-                           "`tensorflow` might not be installed. ",
-                           "See `?install_tensorflow`.", 
-                           call. = FALSE)
-                    TRUE
-                  })
+modelInfo <- list(
+  label = "Multilayer Perceptron Network with Dropout",
+  library = "keras",
+  loop = NULL,
+  type = "Classification",
+  parameters = data.frame(
+    parameter = c(
+      'size',
+      'dropout',
+      "batch_size",
+      "lr",
+      "rho",
+      "decay",
+      "cost",
+      "activation"
+    ),
+    class = c(rep('numeric', 7), "character"),
+    label = c(
+      '#Hidden Units',
+      'Dropout Rate',
+      "Batch Size",
+      "Learning Rate",
+      "Rho",
+      "Learning Rate Decay",
+      "Cost",
+      "Activation Function"
+    )
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    afuncs <- c("sigmoid", "relu", "tanh")
+    if (search == "grid") {
+      out <- expand.grid(
+        size = ((1:len) * 2) - 1,
+        dropout = seq(0, .7, length = len),
+        batch_size = floor(nrow(x) / 3),
+        lr = 2e-6,
+        rho = .9,
+        decay = 0,
+        activation = "relu",
+        cost = 1:len
+      )
+    } else {
+      n <- nrow(x)
+      out <- data.frame(
+        size = sample(2:20, replace = TRUE, size = len),
+        dropout = runif(len, max = .7),
+        batch_size = floor(n * runif(len, min = .1)),
+        lr = runif(len),
+        rho = runif(len),
+        decay = 10^runif(len, min = -5, 0),
+        activation = sample(
+          afuncs,
+          size = len,
+          replace = TRUE
+        ),
+        cost = runif(len, min = 1, max = 20)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    require(dplyr)
+    K <- keras::backend()
+    K$clear_session()
+    if (!is.matrix(x)) {
+      x <- as.matrix(x)
+    }
+    model <- keras::keras_model_sequential()
+    model %>%
+      keras::layer_dense(
+        units = param$size,
+        activation = as.character(param$activation),
+        kernel_initializer = keras::initializer_glorot_uniform(),
+        input_shape = ncol(x)
+      ) %>%
+      keras::layer_dropout(rate = param$dropout, seed = sample.int(1000, 1))
+    y <- class2ind(y)
+    model %>%
+      keras::layer_dense(
+        units = length(lev),
+        activation = 'softmax'
+      ) %>%
+      keras::compile(
+        loss = "categorical_crossentropy",
+        loss_weights = list(param$cost),
+        optimizer = keras::optimizer_rmsprop(
+          lr = param$lr,
+          rho = param$rho,
+          decay = param$decay
+        ),
+        metrics = "accuracy"
+      )
+    model %>%
+      keras::fit(
+        x = x,
+        y = y,
+        batch_size = param$batch_size,
+        ...
+      )
+    if (last) {
+      model <- keras::serialize_model(model)
+    }
+    list(object = model)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (inherits(modelFit$object, "raw")) {
+      modelFit$object <- keras::unserialize_model(modelFit$object)
+    }
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- predict(modelFit$object, newdata)
+    ## check for model type
+    if (ncol(out) == 1) {
+      out <- out[, 1]
+    } else {
+      out <- modelFit$obsLevels[apply(out, 1, which.max)]
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (inherits(modelFit$object, "raw")) {
+      modelFit$object <- keras::unserialize_model(modelFit$object)
+    }
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- predict(modelFit$object, newdata)
+    colnames(out) <- modelFit$obsLevels
+    as.data.frame(out, stringsAsFactors = TRUE)
+  },
+  varImp = NULL,
+  tags = c("Neural Network", "Cost Sensitive Learning", "Two Class Only"),
+  sort = function(x) x[order(x$size, -x$dropout), ],
+  notes = paste(
+    "After `train` completes, the keras model object is serialized",
+    "so that it can be used between R session. When predicting, the",
+    "code will temporarily unsearalize the object. To make the",
+    "predictions more efficient, the user might want to use ",
+    "`keras::unsearlize_model(object$finalModel$object)` in the current",
+    "R session so that that operation is only done once.",
+    "Also, this model cannot be run in parallel due to",
+    "the nature of how tensorflow does the computations.",
+    "Finally, the cost parameter weights the first",
+    "class in the outcome vector.",
+
+    "Unlike other packages used by `train`, the `dplyr`",
+    "package is fully loaded when this model is used."
+  ),
+  check = function(pkg) {
+    testmod <- try(keras::keras_model_sequential(), silent = TRUE)
+    if (inherits(testmod, "try-error")) {
+      stop(
+        "Could not start a sequential model. ",
+        "`tensorflow` might not be installed. ",
+        "See `?install_tensorflow`.",
+        call. = FALSE
+      )
+    }
+    TRUE
+  }
+)

--- a/inst/model_sources/files/mlpML.R
+++ b/inst/model_sources/files/mlpML.R
@@ -1,59 +1,69 @@
-modelInfo <- list(label = "Multi-Layer Perceptron, with multiple layers",
-                  library = "RSNNS",
-                  loop = NULL,
-                  type = c('Regression', 'Classification'),
-                  parameters = data.frame(parameter = c('layer1','layer2','layer3'),
-                                          class = c('numeric','numeric','numeric'),
-                                          label = c('#Hidden Units layer1','#Hidden Units layer2','#Hidden Units layer3')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- data.frame(layer1 = ((1:len) * 2) - 1, layer2 = 0, layer3 = 0)
-                    } else {
-                      out <- data.frame(layer1 = sample(2:20, replace = TRUE, size = len),
-                                        layer2 = sample(c(0, 2:20), replace = TRUE, size = len),
-                                        layer3 = sample(c(0, 2:20), replace = TRUE, size = len))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    theDots <- list(...)
-                    theDots <- theDots[!(names(theDots) %in% c("size", "linOut"))]
-                    
-                    if(is.factor(y)) {
-                      y <- RSNNS:::decodeClassLabels(y)
-                      lin <- FALSE
-                    } else lin <- TRUE
-                    
-                    
-                    nodes <- c(param$layer1, param$layer2, param$layer3)
-                    if (any(nodes == 0)) {
-                      nodes <- nodes[nodes > 0]
-                      warning(
-                        "At least one layer had zero units and ",
-                        "were removed. The new structure is ",
-                        paste0(nodes, collapse = "->"), call. = FALSE
-                      ) 
-                    }
-                    args <- list(x = x,
-                                 y = y,
-                                 size = nodes,
-                                 linOut = lin)
-                    args <- c(args, theDots)
-                    do.call(RSNNS::mlp, args)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata)
-                    if(modelFit$problemType == "Classification")
-                    {
-                      out <- modelFit$obsLevels[apply(out, 1, which.max)]
-                    } else out <- out[,1]
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata)
-                    colnames(out) <- modelFit$obsLevels
-                    out
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("Neural Network"),
-                  sort = function(x) x[order(x$layer1, x$layer2, x$layer3),])
+modelInfo <- list(
+  label = "Multi-Layer Perceptron, with multiple layers",
+  library = "RSNNS",
+  loop = NULL,
+  type = c('Regression', 'Classification'),
+  parameters = data.frame(
+    parameter = c('layer1', 'layer2', 'layer3'),
+    class = c('numeric', 'numeric', 'numeric'),
+    label = c(
+      '#Hidden Units layer1',
+      '#Hidden Units layer2',
+      '#Hidden Units layer3'
+    )
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(layer1 = ((1:len) * 2) - 1, layer2 = 0, layer3 = 0)
+    } else {
+      out <- data.frame(
+        layer1 = sample(2:20, replace = TRUE, size = len),
+        layer2 = sample(c(0, 2:20), replace = TRUE, size = len),
+        layer3 = sample(c(0, 2:20), replace = TRUE, size = len)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    theDots <- list(...)
+    theDots <- theDots[!(names(theDots) %in% c("size", "linOut"))]
+
+    if (is.factor(y)) {
+      y <- RSNNS:::decodeClassLabels(y)
+      lin <- FALSE
+    } else {
+      lin <- TRUE
+    }
+
+    nodes <- c(param$layer1, param$layer2, param$layer3)
+    if (any(nodes == 0)) {
+      nodes <- nodes[nodes > 0]
+      warning(
+        "At least one layer had zero units and ",
+        "were removed. The new structure is ",
+        paste0(nodes, collapse = "->"),
+        call. = FALSE
+      )
+    }
+    args <- list(x = x, y = y, size = nodes, linOut = lin)
+    args <- c(args, theDots)
+    do.call(RSNNS::mlp, args)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata)
+    if (modelFit$problemType == "Classification") {
+      out <- modelFit$obsLevels[apply(out, 1, which.max)]
+    } else {
+      out <- out[, 1]
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata)
+    colnames(out) <- modelFit$obsLevels
+    out
+  },
+  levels = function(x) x$obsLevels,
+  tags = c("Neural Network"),
+  sort = function(x) x[order(x$layer1, x$layer2, x$layer3), ]
+)

--- a/inst/model_sources/files/mlpSGD.R
+++ b/inst/model_sources/files/mlpSGD.R
@@ -131,8 +131,8 @@ modelInfo <- list(
       })[, -1]
       out <- modelFit$obsLevels[apply(out, 1, which.max)]
     } else {
-      out <- if (length(out) == 1) {
-        out[[1]][, 1]
+      if (length(out) == 1) {
+        out <- out[[1]][, 1]
       } else {
         out <- do.call("cbind", out)
         out <- apply(out, 1, mean)

--- a/inst/model_sources/files/mlpSGD.R
+++ b/inst/model_sources/files/mlpSGD.R
@@ -1,119 +1,181 @@
-modelInfo <- list(label = "Multilayer Perceptron Network by Stochastic Gradient Descent",
-                  library = c("FCNN4R", "plyr"),
-                  loop = NULL,
-                  type = c('Regression', "Classification"),
-                  parameters = data.frame(parameter = c('size', 'l2reg', 'lambda', "learn_rate", 
-                                                        "momentum", "gamma", "minibatchsz", "repeats"),
-                                          class = rep('numeric', 8),
-                                          label = c('#Hidden Units', 'L2 Regularization', 
-                                                    'RMSE Gradient Scaling', "Learning Rate", 
-                                                    "Momentum", "Learning Rate Decay", "Batch Size",
-                                                    "#Models")),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    n <- nrow(x)
-                    if(search == "grid") {
-                      out <- expand.grid(size = ((1:len) * 2) - 1, 
-                                         l2reg = c(0, 10 ^ seq(-1, -4, length = len - 1)), 
-                                         lambda = 0,
-                                         learn_rate = 2e-6, 
-                                         momentum = 0.9, 
-                                         gamma = seq(0, .9, length = len),
-                                         minibatchsz = floor(nrow(x)/3),
-                                         repeats = 1)
-                    } else {
-                      out <- data.frame(size = sample(2:20, replace = TRUE, size = len),
-                                        l2reg = 10^runif(len, min = -5, 1),
-                                        lambda = runif(len, max = .4),
-                                        learn_rate = runif(len),
-                                        momentum = runif(len, min = .5),
-                                        gamma = runif(len),
-                                        minibatchsz = floor(n*runif(len, min = .1)),
-                                        repeats = sample(1:10, replace = TRUE, size = len))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    if(!is.matrix(x)) x <- as.matrix(x)
-                    if(is.factor(y)) {
-                      y <- class2ind(y)
-                      net <- FCNN4R::mlp_net(c(ncol(x), param$size, ncol(y)))
-                      net <- FCNN4R::mlp_set_activation(net, layer = "h", activation = "sigmoid")
-                      net <- FCNN4R::mlp_set_activation(net, layer = "o", activation = "sigmoid")
+modelInfo <- list(
+  label = "Multilayer Perceptron Network by Stochastic Gradient Descent",
+  library = c("FCNN4R", "plyr"),
+  loop = NULL,
+  type = c('Regression', "Classification"),
+  parameters = data.frame(
+    parameter = c(
+      'size',
+      'l2reg',
+      'lambda',
+      "learn_rate",
+      "momentum",
+      "gamma",
+      "minibatchsz",
+      "repeats"
+    ),
+    class = rep('numeric', 8),
+    label = c(
+      '#Hidden Units',
+      'L2 Regularization',
+      'RMSE Gradient Scaling',
+      "Learning Rate",
+      "Momentum",
+      "Learning Rate Decay",
+      "Batch Size",
+      "#Models"
+    )
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    n <- nrow(x)
+    if (search == "grid") {
+      out <- expand.grid(
+        size = ((1:len) * 2) - 1,
+        l2reg = c(0, 10^seq(-1, -4, length = len - 1)),
+        lambda = 0,
+        learn_rate = 2e-6,
+        momentum = 0.9,
+        gamma = seq(0, .9, length = len),
+        minibatchsz = floor(nrow(x) / 3),
+        repeats = 1
+      )
+    } else {
+      out <- data.frame(
+        size = sample(2:20, replace = TRUE, size = len),
+        l2reg = 10^runif(len, min = -5, 1),
+        lambda = runif(len, max = .4),
+        learn_rate = runif(len),
+        momentum = runif(len, min = .5),
+        gamma = runif(len),
+        minibatchsz = floor(n * runif(len, min = .1)),
+        repeats = sample(1:10, replace = TRUE, size = len)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (!is.matrix(x)) {
+      x <- as.matrix(x)
+    }
+    if (is.factor(y)) {
+      y <- class2ind(y)
+      net <- FCNN4R::mlp_net(c(ncol(x), param$size, ncol(y)))
+      net <- FCNN4R::mlp_set_activation(
+        net,
+        layer = "h",
+        activation = "sigmoid"
+      )
+      net <- FCNN4R::mlp_set_activation(
+        net,
+        layer = "o",
+        activation = "sigmoid"
+      )
+    } else {
+      y <- matrix(y, ncol = 1)
+      net <- FCNN4R::mlp_net(c(ncol(x), param$size, 1))
+      net <- FCNN4R::mlp_set_activation(
+        net,
+        layer = "h",
+        activation = "sigmoid"
+      )
+      net <- FCNN4R::mlp_set_activation(net, layer = "o", activation = "linear")
+    }
 
-                    } else {
-                      y <- matrix(y, ncol = 1)
-                      net <- FCNN4R::mlp_net(c(ncol(x), param$size, 1))
-                      net <- FCNN4R::mlp_set_activation(net, layer = "h", activation = "sigmoid")
-                      net <- FCNN4R::mlp_set_activation(net, layer = "o", activation = "linear")
-                    }
-                    
-                    args <- list(net = net, 
-                                 input = x, output = y, 
-                                 learn_rate = param$learn_rate,
-                                 minibatchsz = param$minibatchsz,
-                                 l2reg = param$l2reg,
-                                 lambda = param$lambda,
-                                 gamma = param$gamma,
-                                 momentum = param$momentum)
-                    the_dots <- list(...) 
-                    if(!any(names(the_dots) == "tol_level")) {
-                      if(ncol(y) == 1) 
-                        args$tol_level <- sd(y[,1])/sqrt(nrow(y)) else
-                          args$tol_level <- .001
-                    } 
-                    
-                    if(!any(names(the_dots) == "max_epochs")) 
-                      args$max_epochs <- 1000
-                    args <- c(args, the_dots)
-                    out <- list(models = vector(mode = "list", length = param$repeats))
-                    for(i in 1:param$repeats) {
-                      args$net <- FCNN4R::mlp_rnd_weights(args$net)
-                      out$models[[i]] <- do.call(FCNN4R::mlp_teach_sgd, args)
-                    }
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    out <- lapply(modelFit$models, 
-                                  function(obj, newdata)
-                                    FCNN4R::mlp_eval(obj$net, input = newdata),
-                                  newdata = newdata)
-                    if(modelFit$problemType == "Classification") {
-                      out <- as.data.frame(do.call("rbind", out), stringsAsFactors = TRUE)
-                      out$sample <- rep(1:nrow(newdata), length(modelFit$models))
-                      out <- plyr::ddply(out, plyr::`.`(sample), function(x) colMeans(x[, -ncol(x)]))[, -1]
-                      out <- modelFit$obsLevels[apply(out, 1, which.max)]
-                    } else {
-                      out <- if(length(out) == 1) 
-                        out[[1]][,1]  else {
-                          out <- do.call("cbind", out)
-                          out <- apply(out, 1, mean)
-                        }
-                    }
-                    out
-                  },
-                  prob =  function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    out <- lapply(modelFit$models, 
-                                  function(obj, newdata)
-                                    FCNN4R::mlp_eval(obj$net, input = newdata),
-                                  newdata = newdata)
-                    out <- as.data.frame(do.call("rbind", out), stringsAsFactors = TRUE)
-                    out$sample <- rep(1:nrow(newdata), length(modelFit$models))
-                    out <- plyr::ddply(out, plyr::`.`(sample), function(x) colMeans(x[, -ncol(x)]))[, -1]
-                    out <- t(apply(out, 1, function(x) exp(x)/sum(exp(x))))
-                    colnames(out) <- modelFit$obsLevels
-                    as.data.frame(out, stringsAsFactors = TRUE)
-                  },
-                  varImp = function(object, ...) {
-                    imps <- lapply(object$models, caret:::GarsonWeights_FCNN4R, xnames = object$xNames)
-                    imps <- do.call("rbind", imps)
-                    imps <- apply(imps, 1, mean, na.rm = TRUE)
-                    imps <- data.frame(var = names(imps), imp = imps)
-                    imps <- plyr::ddply(imps, plyr::`.`(var), function(x) c(Overall = mean(x$imp)))
-                    rownames(imps) <- as.character(imps$var)
-                    imps$var <- NULL
-                    imps[object$xNames,,drop = FALSE]
-                  },
-                  tags = c("Neural Network", "L2 Regularization"),
-                  sort = function(x) x[order(x$size, -x$l2reg, -x$gamma),])
+    args <- list(
+      net = net,
+      input = x,
+      output = y,
+      learn_rate = param$learn_rate,
+      minibatchsz = param$minibatchsz,
+      l2reg = param$l2reg,
+      lambda = param$lambda,
+      gamma = param$gamma,
+      momentum = param$momentum
+    )
+    the_dots <- list(...)
+    if (!any(names(the_dots) == "tol_level")) {
+      if (ncol(y) == 1) {
+        args$tol_level <- sd(y[, 1]) / sqrt(nrow(y))
+      } else {
+        args$tol_level <- .001
+      }
+    }
+
+    if (!any(names(the_dots) == "max_epochs")) {
+      args$max_epochs <- 1000
+    }
+    args <- c(args, the_dots)
+    out <- list(models = vector(mode = "list", length = param$repeats))
+    for (i in 1:param$repeats) {
+      args$net <- FCNN4R::mlp_rnd_weights(args$net)
+      out$models[[i]] <- do.call(FCNN4R::mlp_teach_sgd, args)
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- lapply(
+      modelFit$models,
+      function(obj, newdata) {
+        FCNN4R::mlp_eval(obj$net, input = newdata)
+      },
+      newdata = newdata
+    )
+    if (modelFit$problemType == "Classification") {
+      out <- as.data.frame(do.call("rbind", out), stringsAsFactors = TRUE)
+      out$sample <- rep(1:nrow(newdata), length(modelFit$models))
+      out <- plyr::ddply(out, plyr::`.`(sample), function(x) {
+        colMeans(x[, -ncol(x)])
+      })[, -1]
+      out <- modelFit$obsLevels[apply(out, 1, which.max)]
+    } else {
+      out <- if (length(out) == 1) {
+        out[[1]][, 1]
+      } else {
+        out <- do.call("cbind", out)
+        out <- apply(out, 1, mean)
+      }
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- lapply(
+      modelFit$models,
+      function(obj, newdata) {
+        FCNN4R::mlp_eval(obj$net, input = newdata)
+      },
+      newdata = newdata
+    )
+    out <- as.data.frame(do.call("rbind", out), stringsAsFactors = TRUE)
+    out$sample <- rep(1:nrow(newdata), length(modelFit$models))
+    out <- plyr::ddply(out, plyr::`.`(sample), function(x) {
+      colMeans(x[, -ncol(x)])
+    })[, -1]
+    out <- t(apply(out, 1, function(x) exp(x) / sum(exp(x))))
+    colnames(out) <- modelFit$obsLevels
+    as.data.frame(out, stringsAsFactors = TRUE)
+  },
+  varImp = function(object, ...) {
+    imps <- lapply(
+      object$models,
+      caret:::GarsonWeights_FCNN4R,
+      xnames = object$xNames
+    )
+    imps <- do.call("rbind", imps)
+    imps <- apply(imps, 1, mean, na.rm = TRUE)
+    imps <- data.frame(var = names(imps), imp = imps)
+    imps <- plyr::ddply(imps, plyr::`.`(var), function(x) {
+      c(Overall = mean(x$imp))
+    })
+    rownames(imps) <- as.character(imps$var)
+    imps$var <- NULL
+    imps[object$xNames, , drop = FALSE]
+  },
+  tags = c("Neural Network", "L2 Regularization"),
+  sort = function(x) x[order(x$size, -x$l2reg, -x$gamma), ]
+)

--- a/inst/model_sources/files/mlpWeightDecay.R
+++ b/inst/model_sources/files/mlpWeightDecay.R
@@ -1,61 +1,78 @@
-modelInfo <- list(label = "Multi-Layer Perceptron",
-                  library = "RSNNS",
-                  loop = NULL,
-                  type = c('Regression', 'Classification'),
-                  parameters = data.frame(parameter = c('size', 'decay'),
-                                          class = c('numeric', 'numeric'),
-                                          label = c('#Hidden Units', 'Weight Decay')),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- expand.grid(size = ((1:len) * 2) - 1, 
-                                         decay = c(0, 10 ^ seq(-1, -4, length = len - 1)))
-                    } else {
-                      out <- data.frame(size = sample(1:20, size = len, replace = TRUE), 
-                                        decay = 10^runif(len, min = -5, max = 1))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    theDots <- list(...)
-                    theDots <- theDots[!(names(theDots) %in% c("size", "linOut"))]
-                    if(any(names(theDots) == "learnFunc"))
-                    {
-                      theDots$learnFunc <- NULL
-                      warning("Cannot over-ride 'learnFunc' argument for this model. BackpropWeightDecay is used.")
-                    }
-                    if(any(names(theDots) == "learnFuncParams"))
-                    {
-                      prms <- theDots$learnFuncParams
-                      prms[2] <-  param$decay
-                      warning("Over-riding weight decay value in the 'learnFuncParams' argument you passed in. Other values are retained")
-                    } else prms <- c(0.2, param$decay, 0.0, 0.0)    
-                    
-                    if(is.factor(y)) {
-                      y <- RSNNS:::decodeClassLabels(y)
-                      lin <- FALSE
-                    } else lin <- TRUE
-                    args <- list(x = x,
-                                 y = y,
-                                 learnFunc = "BackpropWeightDecay",
-                                 learnFuncParams = prms,                                
-                                 size = param$size,
-                                 linOut = lin)
-                    args <- c(args, theDots)
-                    do.call(RSNNS::mlp, args)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata)
-                    if(modelFit$problemType == "Classification")
-                    {
-                      out <- modelFit$obsLevels[apply(out, 1, which.max)]
-                    } else out <- out[,1]
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata)
-                    colnames(out) <- modelFit$obsLevels
-                    out
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("Neural Network","L2 Regularization"),
-                  sort = function(x) x[order(x$size, -x$decay),])
+modelInfo <- list(
+  label = "Multi-Layer Perceptron",
+  library = "RSNNS",
+  loop = NULL,
+  type = c('Regression', 'Classification'),
+  parameters = data.frame(
+    parameter = c('size', 'decay'),
+    class = c('numeric', 'numeric'),
+    label = c('#Hidden Units', 'Weight Decay')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        size = ((1:len) * 2) - 1,
+        decay = c(0, 10^seq(-1, -4, length = len - 1))
+      )
+    } else {
+      out <- data.frame(
+        size = sample(1:20, size = len, replace = TRUE),
+        decay = 10^runif(len, min = -5, max = 1)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    theDots <- list(...)
+    theDots <- theDots[!(names(theDots) %in% c("size", "linOut"))]
+    if (any(names(theDots) == "learnFunc")) {
+      theDots$learnFunc <- NULL
+      warning(
+        "Cannot over-ride 'learnFunc' argument for this model. BackpropWeightDecay is used."
+      )
+    }
+    if (any(names(theDots) == "learnFuncParams")) {
+      prms <- theDots$learnFuncParams
+      prms[2] <- param$decay
+      warning(
+        "Over-riding weight decay value in the 'learnFuncParams' argument you passed in. Other values are retained"
+      )
+    } else {
+      prms <- c(0.2, param$decay, 0.0, 0.0)
+    }
+
+    if (is.factor(y)) {
+      y <- RSNNS:::decodeClassLabels(y)
+      lin <- FALSE
+    } else {
+      lin <- TRUE
+    }
+    args <- list(
+      x = x,
+      y = y,
+      learnFunc = "BackpropWeightDecay",
+      learnFuncParams = prms,
+      size = param$size,
+      linOut = lin
+    )
+    args <- c(args, theDots)
+    do.call(RSNNS::mlp, args)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata)
+    if (modelFit$problemType == "Classification") {
+      out <- modelFit$obsLevels[apply(out, 1, which.max)]
+    } else {
+      out <- out[, 1]
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata)
+    colnames(out) <- modelFit$obsLevels
+    out
+  },
+  levels = function(x) x$obsLevels,
+  tags = c("Neural Network", "L2 Regularization"),
+  sort = function(x) x[order(x$size, -x$decay), ]
+)

--- a/inst/model_sources/files/mlpWeightDecayML.R
+++ b/inst/model_sources/files/mlpWeightDecayML.R
@@ -1,74 +1,99 @@
-modelInfo <- list(label = "Multi-Layer Perceptron, multiple layers",
-                  library = "RSNNS",
-                  loop = NULL,
-                  type = c('Regression', 'Classification'),
-                  parameters = data.frame(parameter = c('layer1','layer2','layer3', 'decay'),
-                                          class = c('numeric','numeric','numeric', 'numeric'),
-                                          label = c('#Hidden Units layer1','#Hidden Units layer2','#Hidden Units layer3', 'Weight Decay')),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- expand.grid(layer1 = ((1:len) * 2) - 1, layer2 = 0, layer3 = 0,
-                                         decay = c(0, 10 ^ seq(-1, -4, length = len - 1)))
-                    } else {
-                      out <- data.frame(layer1 = sample(2:20, replace = TRUE, size = len),
-                                        layer2 = sample(c(0, 2:20), replace = TRUE, size = len),
-                                        layer3 = sample(c(0, 2:20), replace = TRUE, size = len),
-                                        decay = 10^runif(len, min = -5, max = 1))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    theDots <- list(...)
-                    theDots <- theDots[!(names(theDots) %in% c("size", "linOut"))]
-                    if(any(names(theDots) == "learnFunc"))
-                    {
-                      theDots$learnFunc <- NULL
-                      warning("Cannot over-ride 'learnFunc' argument for this model. BackpropWeightDecay is used.")
-                    }
-                    if(any(names(theDots) == "learnFuncParams"))
-                    {
-                      prms <- theDots$learnFuncParams
-                      prms[2] <-  param$decay
-                      warning("Over-riding weight decay value in the 'learnFuncParams' argument you passed in. Other values are retained")
-                    } else prms <- c(0.2, param$decay, 0.0, 0.0)
-                    
-                    if(is.factor(y)) {
-                      y <- RSNNS:::decodeClassLabels(y)
-                      lin <- FALSE
-                    } else lin <- TRUE
-                    
-                    nodes <- c(param$layer1, param$layer2, param$layer3)
-                    if (any(nodes == 0)) {
-                      nodes <- nodes[nodes > 0]
-                      warning(
-                        "At least one layer had zero units and ",
-                        "were removed. The new structure is ",
-                        paste0(nodes, collapse = "->"), call. = FALSE
-                      ) 
-                    }
-                    
-                    args <- list(x = x,
-                                 y = y,
-                                 learnFunc = "BackpropWeightDecay",
-                                 learnFuncParams = prms,
-                                 size = nodes,
-                                 linOut = lin)
-                    args <- c(args, theDots)
-                    do.call(RSNNS::mlp, args)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata)
-                    if(modelFit$problemType == "Classification")
-                    {
-                      out <- modelFit$obsLevels[apply(out, 1, which.max)]
-                    } else out <- out[,1]
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata)
-                    colnames(out) <- modelFit$obsLevels
-                    out
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("Neural Network","L2 Regularization"),
-                  sort = function(x) x[order(x$layer1, x$layer2, x$layer3, -x$decay),])
+modelInfo <- list(
+  label = "Multi-Layer Perceptron, multiple layers",
+  library = "RSNNS",
+  loop = NULL,
+  type = c('Regression', 'Classification'),
+  parameters = data.frame(
+    parameter = c('layer1', 'layer2', 'layer3', 'decay'),
+    class = c('numeric', 'numeric', 'numeric', 'numeric'),
+    label = c(
+      '#Hidden Units layer1',
+      '#Hidden Units layer2',
+      '#Hidden Units layer3',
+      'Weight Decay'
+    )
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        layer1 = ((1:len) * 2) - 1,
+        layer2 = 0,
+        layer3 = 0,
+        decay = c(0, 10^seq(-1, -4, length = len - 1))
+      )
+    } else {
+      out <- data.frame(
+        layer1 = sample(2:20, replace = TRUE, size = len),
+        layer2 = sample(c(0, 2:20), replace = TRUE, size = len),
+        layer3 = sample(c(0, 2:20), replace = TRUE, size = len),
+        decay = 10^runif(len, min = -5, max = 1)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    theDots <- list(...)
+    theDots <- theDots[!(names(theDots) %in% c("size", "linOut"))]
+    if (any(names(theDots) == "learnFunc")) {
+      theDots$learnFunc <- NULL
+      warning(
+        "Cannot over-ride 'learnFunc' argument for this model. BackpropWeightDecay is used."
+      )
+    }
+    if (any(names(theDots) == "learnFuncParams")) {
+      prms <- theDots$learnFuncParams
+      prms[2] <- param$decay
+      warning(
+        "Over-riding weight decay value in the 'learnFuncParams' argument you passed in. Other values are retained"
+      )
+    } else {
+      prms <- c(0.2, param$decay, 0.0, 0.0)
+    }
+
+    if (is.factor(y)) {
+      y <- RSNNS:::decodeClassLabels(y)
+      lin <- FALSE
+    } else {
+      lin <- TRUE
+    }
+
+    nodes <- c(param$layer1, param$layer2, param$layer3)
+    if (any(nodes == 0)) {
+      nodes <- nodes[nodes > 0]
+      warning(
+        "At least one layer had zero units and ",
+        "were removed. The new structure is ",
+        paste0(nodes, collapse = "->"),
+        call. = FALSE
+      )
+    }
+
+    args <- list(
+      x = x,
+      y = y,
+      learnFunc = "BackpropWeightDecay",
+      learnFuncParams = prms,
+      size = nodes,
+      linOut = lin
+    )
+    args <- c(args, theDots)
+    do.call(RSNNS::mlp, args)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata)
+    if (modelFit$problemType == "Classification") {
+      out <- modelFit$obsLevels[apply(out, 1, which.max)]
+    } else {
+      out <- out[, 1]
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata)
+    colnames(out) <- modelFit$obsLevels
+    out
+  },
+  levels = function(x) x$obsLevels,
+  tags = c("Neural Network", "L2 Regularization"),
+  sort = function(x) x[order(x$layer1, x$layer2, x$layer3, -x$decay), ]
+)

--- a/inst/model_sources/files/monmlp.R
+++ b/inst/model_sources/files/monmlp.R
@@ -1,56 +1,76 @@
-modelInfo <- list(label = "Monotone Multi-Layer Perceptron Neural Network",
-                  library = "monmlp",
-                  loop = NULL,
-                  type = c("Classification", "Regression"),
-                  parameters = data.frame(parameter = c('hidden1', 'n.ensemble'),
-                                          class = rep('numeric', 2),
-                                          label = c('#Hidden Units', "#Models")),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(hidden1 = ((1:len) * 2) - 1, 
-                                         n.ensemble = 1)
-                    } else {
-                      out <- data.frame(hidden1 = sample(2:20, replace = TRUE, size = len),
-                                        n.ensemble = sample(1:10, replace = TRUE, size = len))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    if(!is.matrix(x)) x <- as.matrix(x)
-                    y <- if(is.numeric(y) )  
-                      matrix(y, ncol = 1) else
-                        class2ind(y)
-                    out <- monmlp::monmlp.fit(y = y,
-                                              x = x,
-                                              hidden1 = param$hidden1,
-                                              n.ensemble = param$n.ensemble,
-                                              ...)
-                    list(model = out)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    out <- monmlp::monmlp.predict(newdata, modelFit$model)
-                    if(modelFit$problemType == "Classification") {
-                      out <- modelFit$obsLevels[apply(out, 1, which.max)]
-                    } else out <- out[, 1]
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    out <- monmlp::monmlp.predict(newdata, modelFit$model)
-                    out <- t(apply(out, 1, function(x) exp(x)/sum(exp(x))))
-                    colnames(out) <- modelFit$obsLevels
-                    out
-                  },
-                  predictors = function(x, ...) {
-                    colnames(attr(x$model, "x"))
-                  },
-                  varImp = NULL,
-                  levels = function(x) {
-                    y <- attr(x$model, "y")
-                    if(is.matrix(y) && ncol >= 2) 
-                      colnames(colnames) else NULL
-                  },
-                  oob = NULL,
-                  tags = "Neural Network",
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Monotone Multi-Layer Perceptron Neural Network",
+  library = "monmlp",
+  loop = NULL,
+  type = c("Classification", "Regression"),
+  parameters = data.frame(
+    parameter = c('hidden1', 'n.ensemble'),
+    class = rep('numeric', 2),
+    label = c('#Hidden Units', "#Models")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(hidden1 = ((1:len) * 2) - 1, n.ensemble = 1)
+    } else {
+      out <- data.frame(
+        hidden1 = sample(2:20, replace = TRUE, size = len),
+        n.ensemble = sample(1:10, replace = TRUE, size = len)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (!is.matrix(x)) {
+      x <- as.matrix(x)
+    }
+    y <- if (is.numeric(y)) {
+      matrix(y, ncol = 1)
+    } else {
+      class2ind(y)
+    }
+    out <- monmlp::monmlp.fit(
+      y = y,
+      x = x,
+      hidden1 = param$hidden1,
+      n.ensemble = param$n.ensemble,
+      ...
+    )
+    list(model = out)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- monmlp::monmlp.predict(newdata, modelFit$model)
+    if (modelFit$problemType == "Classification") {
+      out <- modelFit$obsLevels[apply(out, 1, which.max)]
+    } else {
+      out <- out[, 1]
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- monmlp::monmlp.predict(newdata, modelFit$model)
+    out <- t(apply(out, 1, function(x) exp(x) / sum(exp(x))))
+    colnames(out) <- modelFit$obsLevels
+    out
+  },
+  predictors = function(x, ...) {
+    colnames(attr(x$model, "x"))
+  },
+  varImp = NULL,
+  levels = function(x) {
+    y <- attr(x$model, "y")
+    if (is.matrix(y) && ncol >= 2) {
+      colnames(colnames)
+    } else {
+      NULL
+    }
+  },
+  oob = NULL,
+  tags = "Neural Network",
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/monmlp.R
+++ b/inst/model_sources/files/monmlp.R
@@ -23,10 +23,10 @@ modelInfo <- list(
     if (!is.matrix(x)) {
       x <- as.matrix(x)
     }
-    y <- if (is.numeric(y)) {
-      matrix(y, ncol = 1)
+    if (is.numeric(y)) {
+      y <- matrix(y, ncol = 1)
     } else {
-      class2ind(y)
+      y <- class2ind(y)
     }
     out <- monmlp::monmlp.fit(
       y = y,

--- a/inst/model_sources/files/msaenet.R
+++ b/inst/model_sources/files/msaenet.R
@@ -1,87 +1,121 @@
-modelInfo <- list(label = "Multi-Step Adaptive MCP-Net",
-                  library = "msaenet",
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('alphas', 'nsteps', "scale"),
-                                          class = c("numeric", "numeric", "numeric"),
-                                          label = c('Alpha', '#Adaptive Estimation Steps',
-                                                    "Adaptive Weight Scaling Factor")),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(alphas = seq(0.05, 0.95, length = len),
-                                         nsteps = 2:(len+1),
-                                         scale  = 2:(len+1))
-                    } else {
-                      out <- data.frame(alphas = runif(len, min = 0.05, max = 0.95),
-                                        nsteps = sample(2:10, size = len, replace = TRUE),
-                                        scale = runif(len, min = .25, max = 4))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    if(length(levels(y)) > 2)
-                      stop("Only two class problems are supported by `msamnet`", call. = FALSE)
+modelInfo <- list(
+  label = "Multi-Step Adaptive MCP-Net",
+  library = "msaenet",
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c('alphas', 'nsteps', "scale"),
+    class = c("numeric", "numeric", "numeric"),
+    label = c(
+      'Alpha',
+      '#Adaptive Estimation Steps',
+      "Adaptive Weight Scaling Factor"
+    )
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        alphas = seq(0.05, 0.95, length = len),
+        nsteps = 2:(len + 1),
+        scale = 2:(len + 1)
+      )
+    } else {
+      out <- data.frame(
+        alphas = runif(len, min = 0.05, max = 0.95),
+        nsteps = sample(2:10, size = len, replace = TRUE),
+        scale = runif(len, min = .25, max = 4)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (length(levels(y)) > 2) {
+      stop("Only two class problems are supported by `msamnet`", call. = FALSE)
+    }
 
-                    theDots <- list(...)
-                    
-                    if(all(names(theDots) != "family")) {
-                      if(length(levels(y)) > 0) {
-                        fam <- "binomial"
-                      } else fam <- "gaussian"    
-                      theDots$family <- fam   
-                    }
-                    # we will only send a single alpha/nsteps combo to the 
-                    # function so avoid an extra meaningless cv loop
-                    if(all(names(theDots) != "tune")) 
-                      theDots$tune <- "aic"
-                    if(all(names(theDots) != "tune.nsteps")) 
-                      theDots$tune.nsteps <- "aic"                                    
-                    
-                    if(!is.matrix(x))
-                      x <- as.matrix(x)
-                    
-                    modelArgs <- c(list(x = x,
-                                        y = y,
-                                        alphas = param$alphas,
-                                        nsteps = param$nsteps,
-                                        scale = param$scale),
-                                   theDots)
-                    
-                    do.call(getFromNamespace("msamnet", "msaenet"), modelArgs) 
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    out <- msaenet:::predict.msaenet(modelFit, newdata, type = "response")
-                    if(modelFit$model$family == "binomial") {
-                      out <- ifelse(out > .4, modelFit$obsLevels[2], modelFit$obsLevels[1])
-                    }
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    out <- msaenet:::predict.msaenet(modelFit, newdata, type = "response")
-                    out <- as.data.frame(cbind(1-out, out), stringsAsFactors = TRUE)
-                    colnames(out) <- modelFit$obsLevels
-                    out
-                  },
-                  predictors = function(x, ...) {
-                    coefs <- msaenet:::predict.msaenet(x, newx = NULL, type = "coefficients")
-                    coefs <- rownames(coefs)[coefs != 0]
-                    coefs <- coefs[coefs != "(Intercept)"]
-                    coefs
-                  },
-                  varImp = function(object, ...) {
-                    coefs <- msaenet:::predict.msaenet(object, newx = NULL, type = "coefficients")
-                    coefs <- abs(coefs[rownames(coefs) != "(Intercept)",,drop = FALSE])
-                    colnames(coefs) <- "Overall"
-                    coefs
-                  },
-                  levels = function(x) if(any(names(x) == "obsLevels")) x$obsLevels else NULL,
-                  tags = c("Generalized Linear Model", "Implicit Feature Selection", 
-                           "L1 Regularization", "L2 Regularization", "Linear Classifier",
-                           "Linear Regression"),
-                  sort = function(x) x[order(x$alphas, x$nsteps),],
-                  trim = function(x) {
-                    x$call <- NULL
-                    x
-                  })
+    theDots <- list(...)
+
+    if (all(names(theDots) != "family")) {
+      if (length(levels(y)) > 0) {
+        fam <- "binomial"
+      } else {
+        fam <- "gaussian"
+      }
+      theDots$family <- fam
+    }
+    # we will only send a single alpha/nsteps combo to the
+    # function so avoid an extra meaningless cv loop
+    if (all(names(theDots) != "tune")) {
+      theDots$tune <- "aic"
+    }
+    if (all(names(theDots) != "tune.nsteps")) {
+      theDots$tune.nsteps <- "aic"
+    }
+
+    if (!is.matrix(x)) {
+      x <- as.matrix(x)
+    }
+
+    modelArgs <- c(
+      list(
+        x = x,
+        y = y,
+        alphas = param$alphas,
+        nsteps = param$nsteps,
+        scale = param$scale
+      ),
+      theDots
+    )
+
+    do.call(getFromNamespace("msamnet", "msaenet"), modelArgs)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- msaenet:::predict.msaenet(modelFit, newdata, type = "response")
+    if (modelFit$model$family == "binomial") {
+      out <- ifelse(out > .4, modelFit$obsLevels[2], modelFit$obsLevels[1])
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- msaenet:::predict.msaenet(modelFit, newdata, type = "response")
+    out <- as.data.frame(cbind(1 - out, out), stringsAsFactors = TRUE)
+    colnames(out) <- modelFit$obsLevels
+    out
+  },
+  predictors = function(x, ...) {
+    coefs <- msaenet:::predict.msaenet(x, newx = NULL, type = "coefficients")
+    coefs <- rownames(coefs)[coefs != 0]
+    coefs <- coefs[coefs != "(Intercept)"]
+    coefs
+  },
+  varImp = function(object, ...) {
+    coefs <- msaenet:::predict.msaenet(
+      object,
+      newx = NULL,
+      type = "coefficients"
+    )
+    coefs <- abs(coefs[rownames(coefs) != "(Intercept)", , drop = FALSE])
+    colnames(coefs) <- "Overall"
+    coefs
+  },
+  levels = function(x) if (any(names(x) == "obsLevels")) x$obsLevels else NULL,
+  tags = c(
+    "Generalized Linear Model",
+    "Implicit Feature Selection",
+    "L1 Regularization",
+    "L2 Regularization",
+    "Linear Classifier",
+    "Linear Regression"
+  ),
+  sort = function(x) x[order(x$alphas, x$nsteps), ],
+  trim = function(x) {
+    x$call <- NULL
+    x
+  }
+)

--- a/inst/model_sources/files/msaenet.R
+++ b/inst/model_sources/files/msaenet.R
@@ -104,7 +104,13 @@ modelInfo <- list(
     colnames(coefs) <- "Overall"
     coefs
   },
-  levels = function(x) if (any(names(x) == "obsLevels")) x$obsLevels else NULL,
+  levels = function(x) {
+    if (any(names(x) == "obsLevels")) {
+      x$obsLevels
+    } else {
+      NULL
+    }
+  },
   tags = c(
     "Generalized Linear Model",
     "Implicit Feature Selection",

--- a/inst/model_sources/files/multinom.R
+++ b/inst/model_sources/files/multinom.R
@@ -1,60 +1,74 @@
-modelInfo <- list(label = "Penalized Multinomial Regression",
-                  library = "nnet",
-                  loop = NULL,
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = c('decay'),
-                                          class = c("numeric"),
-                                          label = c('Weight Decay')),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- expand.grid(decay = c(0, 10 ^ seq(-1, -4, length = len - 1)))
-                    } else {
-                      out <- data.frame(decay = 10^runif(len, min = -5, 1))
-                    }
-                    out
-                  }, 
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    if(!is.null(wts)) {
-                      out <- nnet::multinom(.outcome ~ .,
-                                            data = dat,
-                                            weights = wts,                      
-                                            decay = param$decay,
-                                            ...)
-                    } else out <- nnet::multinom(.outcome ~ .,
-                                                 data = dat,
-                                                 decay = param$decay,
-                                                 ...)
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL)
-                    predict(modelFit, newdata, type="class"),
-                  prob = function(modelFit, newdata, submodels = NULL){
-                    out <- predict(modelFit, newdata, type = "probs")
-                    if(nrow(newdata) == 1) {
-                      out <- as.data.frame(t(out), stringsAsFactors = TRUE)
-                    }
-                    if(length(modelFit$obsLevels) == 2) {
-                      out <- cbind(1 - out, out)
-                      colnames(out) <-  modelFit$obsLevels
-                    }
-                    out
-                  },
-                  predictors = function(x, ...) if(hasTerms(x)) predictors(x$terms) else NA,
-                  varImp = function(object, ...) {
-                    out <- abs(coef(object))
-                    if(is.vector(out)) {
-                      out <- data.frame(Overall = out)
-                      rownames(out) <- names(coef(object))
-                    } else {
-                      out <- as.data.frame(apply(out, 2, sum), stringsAsFactors = TRUE)
-                      names(out)[1] <- "Overall"
-                    }
-                    subset(out, rownames(out) != "(Intercept)")
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("Neural Network", "L2 Regularization", 
-                           "Logistic Regression", "Linear Classifier", 
-                           "Accepts Case Weights"),
-                  sort = function(x) x[order(-x[,1]),])
+modelInfo <- list(
+  label = "Penalized Multinomial Regression",
+  library = "nnet",
+  loop = NULL,
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = c('decay'),
+    class = c("numeric"),
+    label = c('Weight Decay')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(decay = c(0, 10^seq(-1, -4, length = len - 1)))
+    } else {
+      out <- data.frame(decay = 10^runif(len, min = -5, 1))
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    if (!is.null(wts)) {
+      out <- nnet::multinom(
+        .outcome ~ .,
+        data = dat,
+        weights = wts,
+        decay = param$decay,
+        ...
+      )
+    } else {
+      out <- nnet::multinom(.outcome ~ ., data = dat, decay = param$decay, ...)
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata, type = "class")
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata, type = "probs")
+    if (nrow(newdata) == 1) {
+      out <- as.data.frame(t(out), stringsAsFactors = TRUE)
+    }
+    if (length(modelFit$obsLevels) == 2) {
+      out <- cbind(1 - out, out)
+      colnames(out) <- modelFit$obsLevels
+    }
+    out
+  },
+  predictors = function(x, ...) if (hasTerms(x)) predictors(x$terms) else NA,
+  varImp = function(object, ...) {
+    out <- abs(coef(object))
+    if (is.vector(out)) {
+      out <- data.frame(Overall = out)
+      rownames(out) <- names(coef(object))
+    } else {
+      out <- as.data.frame(apply(out, 2, sum), stringsAsFactors = TRUE)
+      names(out)[1] <- "Overall"
+    }
+    subset(out, rownames(out) != "(Intercept)")
+  },
+  levels = function(x) x$obsLevels,
+  tags = c(
+    "Neural Network",
+    "L2 Regularization",
+    "Logistic Regression",
+    "Linear Classifier",
+    "Accepts Case Weights"
+  ),
+  sort = function(x) x[order(-x[, 1]), ]
+)

--- a/inst/model_sources/files/multinom.R
+++ b/inst/model_sources/files/multinom.R
@@ -17,10 +17,10 @@ modelInfo <- list(
     out
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     if (!is.null(wts)) {
@@ -50,7 +50,13 @@ modelInfo <- list(
     }
     out
   },
-  predictors = function(x, ...) if (hasTerms(x)) predictors(x$terms) else NA,
+  predictors = function(x, ...) {
+    if (hasTerms(x)) {
+      predictors(x$terms)
+    } else {
+      NA
+    }
+  },
   varImp = function(object, ...) {
     out <- abs(coef(object))
     if (is.vector(out)) {

--- a/inst/model_sources/files/mxnet.R
+++ b/inst/model_sources/files/mxnet.R
@@ -1,90 +1,137 @@
-modelInfo <- list(label = "Neural Network",
-                  library = "mxnet",
-                  loop = NULL,
-                  type = c('Classification', 'Regression'),
-                  parameters = data.frame(parameter = c('layer1', 'layer2', 'layer3',
-                                                        "learning.rate", "momentum", "dropout",
-                                                        "activation"),
-                                          class = c(rep('numeric', 6), "character"),
-                                          label = c('#Hidden Units in Layer 1', '#Hidden Units in Layer 2',
-                                                    '#Hidden Units in Layer 3',
-                                                    "Learning Rate", "Momentum",
-                                                    "Dropout Rate",
-                                                    "Activation Function")),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(layer1 = ((1:len) * 2) - 1, layer2 = 0, layer3 = 0,
-                                         learning.rate = 2e-6,
-                                         momentum = 0.9,
-                                         dropout = seq(0, .7, length = len),
-                                         activation = 'relu')
-                    } else {
-                      out <- data.frame(layer1 = sample(2:20, replace = TRUE, size = len),
-                                        layer2 = 0,
-                                        layer3 = 0,
-                                        learning.rate = runif(len),
-                                        momentum = runif(len),
-                                        dropout = runif(len, max = .7),
-                                        activation = sample(c('relu', 'sigmoid', 'tanh', 'softrelu'), replace= TRUE, size=len))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    mxnet::mx.set.seed(21)
-                    num_units <- param[grepl("layer[1-9]", names(param))]
-                    num_units <- num_units[num_units > 0]
-                    if(!is.matrix(x)) x <- as.matrix(x)
-                    if(is.numeric(y)) {
-                      out <- mxnet::mx.mlp(data = x,
-                                           label = y,
-                                           hidden_node = num_units,
-                                           out_node = 1,
-                                           out_activation = "rmse",
-                                           learning.rate = param$learning.rate,
-                                           momentum = param$momentum,
-                                           eval.metric = mxnet::mx.metric.rmse,
-                                           array.layout = "rowmajor",
-                                           activation = rep( as.character(param$activation), length(num_units)),
-                                           # Use He/MSRA when available in R
-                                           initializer = mxnet::mx.init.Xavier(factor_type = "avg", magnitude = 3, rnd_type = 'uniform'),
-                                           ...)
-                    } else {
-                      y <- as.numeric(y) - 1
-                      out <- mxnet::mx.mlp(data = x,
-                                           label = y,
-                                           hidden_node = num_units,
-                                           out_node = length(unique(y)),
-                                           out_activation = "softmax",
-                                           learning.rate = param$learning.rate,
-                                           momentum = param$momentum,
-                                           eval.metric = mxnet::mx.metric.accuracy,
-                                           array.layout = "rowmajor",
-                                           activation = rep( as.character(param$activation), length(num_units)),
-                                           initializer = mxnet::mx.init.Xavier(factor_type = "avg", magnitude = 3, rnd_type = 'uniform'),
-                                           ...)
-                    }
-                    if(last)
-                      out <- mxnet::mx.serialize(out)
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    pred <- predict(modelFit, newdata, array.layout = 'rowmajor')
-                    if(modelFit$problemType == "Regression") {
-                      pred <- pred[1,]
-                    } else pred <- modelFit$obsLevels[apply(pred, 2, which.max)]
-                    pred
-                  },
-                  predictors = function(x, ...)  {
-                    if(any(names(x) == "xNames")) x$xNames else NA
-                  },
-                  prob =  function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    pred <- t(predict(modelFit, newdata, array.layout = 'rowmajor'))
-                    colnames(pred) <- modelFit$obsLevels
-                    pred
-                  },
-                  notes = paste("The `mxnet` package is not yet on CRAN.",
-                                "See [https://mxnet.apache.org/](https://mxnet.apache.org/) for installation instructions."),
-                  tags = c("Neural Network"),
-                  sort = function(x) x[order(x$layer1, x$layer2, x$layer3),])
+modelInfo <- list(
+  label = "Neural Network",
+  library = "mxnet",
+  loop = NULL,
+  type = c('Classification', 'Regression'),
+  parameters = data.frame(
+    parameter = c(
+      'layer1',
+      'layer2',
+      'layer3',
+      "learning.rate",
+      "momentum",
+      "dropout",
+      "activation"
+    ),
+    class = c(rep('numeric', 6), "character"),
+    label = c(
+      '#Hidden Units in Layer 1',
+      '#Hidden Units in Layer 2',
+      '#Hidden Units in Layer 3',
+      "Learning Rate",
+      "Momentum",
+      "Dropout Rate",
+      "Activation Function"
+    )
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        layer1 = ((1:len) * 2) - 1,
+        layer2 = 0,
+        layer3 = 0,
+        learning.rate = 2e-6,
+        momentum = 0.9,
+        dropout = seq(0, .7, length = len),
+        activation = 'relu'
+      )
+    } else {
+      out <- data.frame(
+        layer1 = sample(2:20, replace = TRUE, size = len),
+        layer2 = 0,
+        layer3 = 0,
+        learning.rate = runif(len),
+        momentum = runif(len),
+        dropout = runif(len, max = .7),
+        activation = sample(
+          c('relu', 'sigmoid', 'tanh', 'softrelu'),
+          replace = TRUE,
+          size = len
+        )
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    mxnet::mx.set.seed(21)
+    num_units <- param[grepl("layer[1-9]", names(param))]
+    num_units <- num_units[num_units > 0]
+    if (!is.matrix(x)) {
+      x <- as.matrix(x)
+    }
+    if (is.numeric(y)) {
+      out <- mxnet::mx.mlp(
+        data = x,
+        label = y,
+        hidden_node = num_units,
+        out_node = 1,
+        out_activation = "rmse",
+        learning.rate = param$learning.rate,
+        momentum = param$momentum,
+        eval.metric = mxnet::mx.metric.rmse,
+        array.layout = "rowmajor",
+        activation = rep(as.character(param$activation), length(num_units)),
+        # Use He/MSRA when available in R
+        initializer = mxnet::mx.init.Xavier(
+          factor_type = "avg",
+          magnitude = 3,
+          rnd_type = 'uniform'
+        ),
+        ...
+      )
+    } else {
+      y <- as.numeric(y) - 1
+      out <- mxnet::mx.mlp(
+        data = x,
+        label = y,
+        hidden_node = num_units,
+        out_node = length(unique(y)),
+        out_activation = "softmax",
+        learning.rate = param$learning.rate,
+        momentum = param$momentum,
+        eval.metric = mxnet::mx.metric.accuracy,
+        array.layout = "rowmajor",
+        activation = rep(as.character(param$activation), length(num_units)),
+        initializer = mxnet::mx.init.Xavier(
+          factor_type = "avg",
+          magnitude = 3,
+          rnd_type = 'uniform'
+        ),
+        ...
+      )
+    }
+    if (last) {
+      out <- mxnet::mx.serialize(out)
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    pred <- predict(modelFit, newdata, array.layout = 'rowmajor')
+    if (modelFit$problemType == "Regression") {
+      pred <- pred[1, ]
+    } else {
+      pred <- modelFit$obsLevels[apply(pred, 2, which.max)]
+    }
+    pred
+  },
+  predictors = function(x, ...) {
+    if (any(names(x) == "xNames")) x$xNames else NA
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    pred <- t(predict(modelFit, newdata, array.layout = 'rowmajor'))
+    colnames(pred) <- modelFit$obsLevels
+    pred
+  },
+  notes = paste(
+    "The `mxnet` package is not yet on CRAN.",
+    "See [https://mxnet.apache.org/](https://mxnet.apache.org/) for installation instructions."
+  ),
+  tags = c("Neural Network"),
+  sort = function(x) x[order(x$layer1, x$layer2, x$layer3), ]
+)

--- a/inst/model_sources/files/mxnet.R
+++ b/inst/model_sources/files/mxnet.R
@@ -118,7 +118,11 @@ modelInfo <- list(
     pred
   },
   predictors = function(x, ...) {
-    if (any(names(x) == "xNames")) x$xNames else NA
+    if (any(names(x) == "xNames")) {
+      x$xNames
+    } else {
+      NA
+    }
   },
   prob = function(modelFit, newdata, submodels = NULL) {
     if (!is.matrix(newdata)) {

--- a/inst/model_sources/files/mxnetAdam.R
+++ b/inst/model_sources/files/mxnetAdam.R
@@ -128,7 +128,11 @@ modelInfo <- list(
     pred
   },
   predictors = function(x, ...) {
-    if (any(names(x) == "xNames")) x$xNames else NA
+    if (any(names(x) == "xNames")) {
+      x$xNames
+    } else {
+      NA
+    }
   },
   prob = function(modelFit, newdata, submodels = NULL) {
     if (!is.matrix(newdata)) {

--- a/inst/model_sources/files/mxnetAdam.R
+++ b/inst/model_sources/files/mxnetAdam.R
@@ -1,88 +1,160 @@
-modelInfo <- list(label = "Neural Network",
-                  library = "mxnet",
-                  type = c('Classification','Regression'),
-                  parameters = data.frame(parameter = c("layer1", "layer2", "layer3", "dropout",
-                                                        "beta1", "beta2", "learningrate", "activation"),
-                                          class = c(rep('numeric', 7), "character"),
-                                          label = c('#Hidden Units in Layer 1', '#Hidden Units in Layer 2', '#Hidden Units in Layer 3',
-                                                    "Dropout Rate",  "beta1", "beta2", "Learning Rate", "Activation Function")),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(layer1 = ((1:len) * 4) - 1, layer2 = 0, layer3 = 0,
-                                         learningrate = 2e-6,
-                                         beta1 = 0.9,
-                                         beta2 = 0.9999,
-                                         dropout = seq(0, .7, length = len),
-                                         activation = 'relu')
-                    } else {
-                      out <- data.frame(layer1 = sample(2:20, replace = TRUE, size = len),
-                                        layer2 = 0,
-                                        layer3 = 0,
-                                        learningrate = runif(len),
-                                        beta1 = runif(len),
-                                        beta2 = runif(len),
-                                        dropout = runif(len, max = 0.7),
-                                        activation = sample(c('relu', 'sigmoid', 'tanh', 'softrelu'), replace= TRUE, size=len))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    num_units <- param[grepl("layer[1-9]", names(param))]
-                    num_units <- num_units[num_units > 0]
-                    if(!is.matrix(x)) x <- as.matrix(x)
-                    if(is.numeric(y)) {
-                      mxnet::mx.set.seed(21)
-                      out <- mxnet::mx.mlp(data = x, label = y, out_node = 1, out_activation = "rmse",
-                                           optimizer = 'adam', eval.metric = mxnet::mx.metric.rmse, array.layout = "rowmajor",
-                                           learning.rate = param$learningrate,
-                                           beta1 = param$beta1,
-                                           beta2 = param$beta2,
-                                           dropout = param$dropout,
-                                           hidden_node = num_units,
-                                           activation = rep( as.character(param$activation), length(num_units)),
-                                           # Consider using He/MSRA paper when available in R
-                                           initializer = mxnet::mx.init.Xavier(factor_type = "avg", magnitude = 3, rnd_type = 'uniform'),
-                                           ...)
-                    } else {
-                      y <- as.numeric(y) - 1
-                      mxnet::mx.set.seed(21)
-                      out <- mxnet::mx.mlp(data = x, label = y, out_node = length(unique(y)), out_activation = "softmax",
-                                          optimizer = 'adam', eval.metric = mxnet::mx.metric.accuracy, array.layout = "rowmajor",
-                                          learning.rate = param$learningrate,
-                                          beta1 = param$beta1,
-                                          beta2 = param$beta2,
-                                          dropout = param$dropout,
-                                          hidden_node = num_units,
-                                          activation = rep( as.character(param$activation), length(num_units)),
-                                          initializer = mxnet::mx.init.Xavier(factor_type = "avg", magnitude = 3, rnd_type = 'uniform'),
-                                          ...)
-                    }
-                    if(last)
-                      out <- mxnet::mx.serialize(out)
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    pred <- predict(modelFit, newdata, array.layout = 'rowmajor')
-                    if(modelFit$problemType == "Regression") {
-                      pred <- pred[1,]
-                    } else {
-                      pred <- modelFit$obsLevels[apply(pred, 2, which.max)]
-                    }
-                    pred
-                  },
-                  predictors = function(x, ...)  {
-                    if(any(names(x) == "xNames")) x$xNames else NA
-                  },
-                  prob =  function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    pred <- t(predict(modelFit, newdata, array.layout = 'rowmajor'))
-                    colnames(pred) <- modelFit$obsLevels
-                    pred
-                  },
-                  notes = paste("The `mxnet` package is not yet on CRAN.",
-                                "See [https://mxnet.apache.org/](https://mxnet.apache.org/) for installation instructions.",
-                                "Users are strongly advised to define `num.round` themselves."),
-                  tags = c("Neural Network"),
-                  sort = function(x) x[order(x$layer1, x$layer2,x$layer3,
-                                             x$beta1, x$beta2, x$learningrate,x$dropout ),])
+modelInfo <- list(
+  label = "Neural Network",
+  library = "mxnet",
+  type = c('Classification', 'Regression'),
+  parameters = data.frame(
+    parameter = c(
+      "layer1",
+      "layer2",
+      "layer3",
+      "dropout",
+      "beta1",
+      "beta2",
+      "learningrate",
+      "activation"
+    ),
+    class = c(rep('numeric', 7), "character"),
+    label = c(
+      '#Hidden Units in Layer 1',
+      '#Hidden Units in Layer 2',
+      '#Hidden Units in Layer 3',
+      "Dropout Rate",
+      "beta1",
+      "beta2",
+      "Learning Rate",
+      "Activation Function"
+    )
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        layer1 = ((1:len) * 4) - 1,
+        layer2 = 0,
+        layer3 = 0,
+        learningrate = 2e-6,
+        beta1 = 0.9,
+        beta2 = 0.9999,
+        dropout = seq(0, .7, length = len),
+        activation = 'relu'
+      )
+    } else {
+      out <- data.frame(
+        layer1 = sample(2:20, replace = TRUE, size = len),
+        layer2 = 0,
+        layer3 = 0,
+        learningrate = runif(len),
+        beta1 = runif(len),
+        beta2 = runif(len),
+        dropout = runif(len, max = 0.7),
+        activation = sample(
+          c('relu', 'sigmoid', 'tanh', 'softrelu'),
+          replace = TRUE,
+          size = len
+        )
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    num_units <- param[grepl("layer[1-9]", names(param))]
+    num_units <- num_units[num_units > 0]
+    if (!is.matrix(x)) {
+      x <- as.matrix(x)
+    }
+    if (is.numeric(y)) {
+      mxnet::mx.set.seed(21)
+      out <- mxnet::mx.mlp(
+        data = x,
+        label = y,
+        out_node = 1,
+        out_activation = "rmse",
+        optimizer = 'adam',
+        eval.metric = mxnet::mx.metric.rmse,
+        array.layout = "rowmajor",
+        learning.rate = param$learningrate,
+        beta1 = param$beta1,
+        beta2 = param$beta2,
+        dropout = param$dropout,
+        hidden_node = num_units,
+        activation = rep(as.character(param$activation), length(num_units)),
+        # Consider using He/MSRA paper when available in R
+        initializer = mxnet::mx.init.Xavier(
+          factor_type = "avg",
+          magnitude = 3,
+          rnd_type = 'uniform'
+        ),
+        ...
+      )
+    } else {
+      y <- as.numeric(y) - 1
+      mxnet::mx.set.seed(21)
+      out <- mxnet::mx.mlp(
+        data = x,
+        label = y,
+        out_node = length(unique(y)),
+        out_activation = "softmax",
+        optimizer = 'adam',
+        eval.metric = mxnet::mx.metric.accuracy,
+        array.layout = "rowmajor",
+        learning.rate = param$learningrate,
+        beta1 = param$beta1,
+        beta2 = param$beta2,
+        dropout = param$dropout,
+        hidden_node = num_units,
+        activation = rep(as.character(param$activation), length(num_units)),
+        initializer = mxnet::mx.init.Xavier(
+          factor_type = "avg",
+          magnitude = 3,
+          rnd_type = 'uniform'
+        ),
+        ...
+      )
+    }
+    if (last) {
+      out <- mxnet::mx.serialize(out)
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    pred <- predict(modelFit, newdata, array.layout = 'rowmajor')
+    if (modelFit$problemType == "Regression") {
+      pred <- pred[1, ]
+    } else {
+      pred <- modelFit$obsLevels[apply(pred, 2, which.max)]
+    }
+    pred
+  },
+  predictors = function(x, ...) {
+    if (any(names(x) == "xNames")) x$xNames else NA
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    pred <- t(predict(modelFit, newdata, array.layout = 'rowmajor'))
+    colnames(pred) <- modelFit$obsLevels
+    pred
+  },
+  notes = paste(
+    "The `mxnet` package is not yet on CRAN.",
+    "See [https://mxnet.apache.org/](https://mxnet.apache.org/) for installation instructions.",
+    "Users are strongly advised to define `num.round` themselves."
+  ),
+  tags = c("Neural Network"),
+  sort = function(x) {
+    x[
+      order(
+        x$layer1,
+        x$layer2,
+        x$layer3,
+        x$beta1,
+        x$beta2,
+        x$learningrate,
+        x$dropout
+      ),
+    ]
+  }
+)

--- a/inst/model_sources/files/naive_bayes.R
+++ b/inst/model_sources/files/naive_bayes.R
@@ -48,7 +48,11 @@ modelInfo <- list(
     )
   },
   predictors = function(x, ...) {
-    if (hasTerms(x)) predictors(x$terms) else names(x$tables)
+    if (hasTerms(x)) {
+      predictors(x$terms)
+    } else {
+      names(x$tables)
+    }
   },
   tags = c("Bayesian Model"),
   levels = function(x) x$levels,

--- a/inst/model_sources/files/naive_bayes.R
+++ b/inst/model_sources/files/naive_bayes.R
@@ -1,27 +1,56 @@
-modelInfo <- list(label = "Naive Bayes",
-                  library = "naivebayes",
-                  loop = NULL,
-                  type = c('Classification'),
-                  parameters = data.frame(parameter = c('laplace', 'usekernel', "adjust"),
-                                          class = c('numeric', 'logical', "numeric"),
-                                          label = c('Laplace Correction', 'Distribution Type', "Bandwidth Adjustment")),
-                  grid = function(x, y, len = NULL, search = "grid") 
-                    expand.grid(usekernel = c(TRUE, FALSE), laplace = 0, adjust = 1),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                   if(param$usekernel) {
-                          out <- naivebayes::naive_bayes(x, y, usekernel = TRUE,  laplace = param$laplace, adjust = param$adjust, ...)
-                   } else out <- naivebayes::naive_bayes(x, y, usekernel = FALSE, laplace = param$laplace, ...)
-                   out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit , newdata)
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    as.data.frame(predict(modelFit, newdata, type = "prob"), stringsAsFactors = TRUE)
-                    },
-                  predictors = function(x, ...) if(hasTerms(x)) predictors(x$terms) else names(x$tables),
-                  tags = c("Bayesian Model"),
-                  levels = function(x) x$levels,
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Naive Bayes",
+  library = "naivebayes",
+  loop = NULL,
+  type = c('Classification'),
+  parameters = data.frame(
+    parameter = c('laplace', 'usekernel', "adjust"),
+    class = c('numeric', 'logical', "numeric"),
+    label = c('Laplace Correction', 'Distribution Type', "Bandwidth Adjustment")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    expand.grid(usekernel = c(TRUE, FALSE), laplace = 0, adjust = 1)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (param$usekernel) {
+      out <- naivebayes::naive_bayes(
+        x,
+        y,
+        usekernel = TRUE,
+        laplace = param$laplace,
+        adjust = param$adjust,
+        ...
+      )
+    } else {
+      out <- naivebayes::naive_bayes(
+        x,
+        y,
+        usekernel = FALSE,
+        laplace = param$laplace,
+        ...
+      )
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    as.data.frame(
+      predict(modelFit, newdata, type = "prob"),
+      stringsAsFactors = TRUE
+    )
+  },
+  predictors = function(x, ...) {
+    if (hasTerms(x)) predictors(x$terms) else names(x$tables)
+  },
+  tags = c("Bayesian Model"),
+  levels = function(x) x$levels,
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/nb.R
+++ b/inst/model_sources/files/nb.R
@@ -39,7 +39,11 @@ modelInfo <- list(
     predict(modelFit, newdata, type = "raw")$posterior
   },
   predictors = function(x, ...) {
-    if (hasTerms(x)) predictors(x$terms) else x$varnames
+    if (hasTerms(x)) {
+      predictors(x$terms)
+    } else {
+      x$varnames
+    }
   },
   tags = c("Bayesian Model"),
   levels = function(x) x$levels,

--- a/inst/model_sources/files/nb.R
+++ b/inst/model_sources/files/nb.R
@@ -1,27 +1,47 @@
-modelInfo <- list(label = "Naive Bayes",
-                  library = "klaR",
-                  loop = NULL,
-                  type = c('Classification'),
-                  parameters = data.frame(parameter = c('fL', 'usekernel', "adjust"),
-                                          class = c('numeric', 'logical', "numeric"),
-                                          label = c('Laplace Correction', 'Distribution Type', "Bandwidth Adjustment")),
-                  grid = function(x, y, len = NULL, search = "grid") 
-                    expand.grid(usekernel = c(TRUE, FALSE), fL = 0, adjust = 1),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                   if(param$usekernel) {
-                          out <- klaR::NaiveBayes(x, y, usekernel = TRUE,  fL = param$fL, adjust = param$adjust, ...)
-                   } else out <- klaR::NaiveBayes(x, y, usekernel = FALSE, fL = param$fL, ...)
-                   out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit , newdata)$class
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata, type = "raw")$posterior
-                    },
-                  predictors = function(x, ...) if(hasTerms(x)) predictors(x$terms) else x$varnames,
-                  tags = c("Bayesian Model"),
-                  levels = function(x) x$levels,
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Naive Bayes",
+  library = "klaR",
+  loop = NULL,
+  type = c('Classification'),
+  parameters = data.frame(
+    parameter = c('fL', 'usekernel', "adjust"),
+    class = c('numeric', 'logical', "numeric"),
+    label = c('Laplace Correction', 'Distribution Type', "Bandwidth Adjustment")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    expand.grid(usekernel = c(TRUE, FALSE), fL = 0, adjust = 1)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (param$usekernel) {
+      out <- klaR::NaiveBayes(
+        x,
+        y,
+        usekernel = TRUE,
+        fL = param$fL,
+        adjust = param$adjust,
+        ...
+      )
+    } else {
+      out <- klaR::NaiveBayes(x, y, usekernel = FALSE, fL = param$fL, ...)
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata)$class
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata, type = "raw")$posterior
+  },
+  predictors = function(x, ...) {
+    if (hasTerms(x)) predictors(x$terms) else x$varnames
+  },
+  tags = c("Bayesian Model"),
+  levels = function(x) x$levels,
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/nbDiscrete.R
+++ b/inst/model_sources/files/nbDiscrete.R
@@ -1,34 +1,50 @@
-modelInfo <- list(label = "Naive Bayes Classifier",
-                  library = "bnclassify",
-                  type = "Classification",
-                  parameters = data.frame(parameter = c("smooth"),
-                                          class = c("numeric"),
-                                          label = c("Smoothing Parameter")),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") { 
-                      out <- data.frame(smooth = 0:(len-1))
-                    } else {
-                      out <- data.frame(smooth= runif(len, min = 0, max = 10))
-                    }
-                    out  
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    bnclassify::bnc('nb', class = '.outcome', dataset = dat,
-                                    smooth = param$smooth,
-                                    ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata)       
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata, prob = TRUE) 
-                  },
-                  levels = function(x) x$obsLevels,
-                  predictors = function(x, s = NULL, ...) x$xNames,
-                  tags = c("Bayesian Model", "Categorical Predictors Only"),
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Naive Bayes Classifier",
+  library = "bnclassify",
+  type = "Classification",
+  parameters = data.frame(
+    parameter = c("smooth"),
+    class = c("numeric"),
+    label = c("Smoothing Parameter")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(smooth = 0:(len - 1))
+    } else {
+      out <- data.frame(smooth = runif(len, min = 0, max = 10))
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    bnclassify::bnc(
+      'nb',
+      class = '.outcome',
+      dataset = dat,
+      smooth = param$smooth,
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata, prob = TRUE)
+  },
+  levels = function(x) x$obsLevels,
+  predictors = function(x, s = NULL, ...) x$xNames,
+  tags = c("Bayesian Model", "Categorical Predictors Only"),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/nbDiscrete.R
+++ b/inst/model_sources/files/nbDiscrete.R
@@ -17,10 +17,10 @@ modelInfo <- list(
   },
   loop = NULL,
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     bnclassify::bnc(

--- a/inst/model_sources/files/nbSearch.R
+++ b/inst/model_sources/files/nbSearch.R
@@ -2,53 +2,82 @@ modelInfo <- list(
   label = "Semi-Naive Structure Learner Wrapper",
   library = "bnclassify",
   type = "Classification",
-  parameters = data.frame(parameter = c("k", 'epsilon', "smooth", "final_smooth", "direction"),
-                          class = c(rep("numeric", 4), "character"),
-                          label = c('#Folds', "Minimum Absolute Improvement", 
-                                    "Smoothing Parameter",
-                                    "Final Smoothing Parameter", "Search Direction")),
+  parameters = data.frame(
+    parameter = c("k", 'epsilon', "smooth", "final_smooth", "direction"),
+    class = c(rep("numeric", 4), "character"),
+    label = c(
+      '#Folds',
+      "Minimum Absolute Improvement",
+      "Smoothing Parameter",
+      "Final Smoothing Parameter",
+      "Search Direction"
+    )
+  ),
   grid = function(x, y, len = NULL, search = "grid") {
-    if(search == "grid") { 
-      out <- expand.grid(k = 10, epsilon = 0.01, smooth = 0.01,
-                         final_smooth = 1,
-                         direction = c("forward", "backwards"))
+    if (search == "grid") {
+      out <- expand.grid(
+        k = 10,
+        epsilon = 0.01,
+        smooth = 0.01,
+        final_smooth = 1,
+        direction = c("forward", "backwards")
+      )
     } else {
-      out <- data.frame(k = sample(3:10, size = len, replace = TRUE),
-                        epsilon = runif(len, min = 0, max = .05),
-                        smooth= runif(len, min = 0, max = 10),
-                        final_smooth= runif(len, min = 0, max = 10),
-                        direction = sample(c("forward", "backwards"), 
-                                           size = len, replace = TRUE))
+      out <- data.frame(
+        k = sample(3:10, size = len, replace = TRUE),
+        epsilon = runif(len, min = 0, max = .05),
+        smooth = runif(len, min = 0, max = 10),
+        final_smooth = runif(len, min = 0, max = 10),
+        direction = sample(
+          c("forward", "backwards"),
+          size = len,
+          replace = TRUE
+        )
+      )
     }
     out
   },
   loop = NULL,
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-    dat$.outcome <- y
-    if(param$direction == "forward") {
-      struct <- bnclassify::fssj(class = '.outcome', dataset = dat,
-                                 k = param$k,
-                                 epsilon = param$epsilon,
-                                 smooth = param$smooth)
+    dat <- if (is.data.frame(x)) {
+      x
     } else {
-      struct <- bnclassify::bsej(class = '.outcome', dataset = dat,
-                                 k = param$k,
-                                 epsilon = param$epsilon,
-                                 smooth = param$smooth)
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    if (param$direction == "forward") {
+      struct <- bnclassify::fssj(
+        class = '.outcome',
+        dataset = dat,
+        k = param$k,
+        epsilon = param$epsilon,
+        smooth = param$smooth
+      )
+    } else {
+      struct <- bnclassify::bsej(
+        class = '.outcome',
+        dataset = dat,
+        k = param$k,
+        epsilon = param$epsilon,
+        smooth = param$smooth
+      )
     }
     bnclassify::lp(struct, dat, smooth = param$final_smooth, ...)
   },
   predict = function(modelFit, newdata, submodels = NULL) {
-    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-    predict(modelFit, newdata)       
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata)
   },
   prob = function(modelFit, newdata, submodels = NULL) {
-    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-    predict(modelFit, newdata, prob = TRUE) 
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata, prob = TRUE)
   },
   levels = function(x) x$obsLevels,
   predictors = function(x, s = NULL, ...) x$xNames,
   tags = c("Bayesian Model", "Categorical Predictors Only"),
-  sort = function(x) x[order(x[,1]),]
+  sort = function(x) x[order(x[, 1]), ]
 )

--- a/inst/model_sources/files/nbSearch.R
+++ b/inst/model_sources/files/nbSearch.R
@@ -39,10 +39,10 @@ modelInfo <- list(
   },
   loop = NULL,
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     if (param$direction == "forward") {

--- a/inst/model_sources/files/neuralnet.R
+++ b/inst/model_sources/files/neuralnet.R
@@ -26,10 +26,10 @@ modelInfo <- list(
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
     colNames <- colnames(x)
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     form <- as.formula(paste(".outcome ~", paste(colNames, collapse = "+")))
@@ -44,7 +44,9 @@ modelInfo <- list(
     nodes <- c(param$layer1)
     if (param$layer2 > 0) {
       nodes <- c(nodes, param$layer2)
-      if (param$layer3 > 0) nodes <- c(nodes, param$layer3)
+      if (param$layer3 > 0) {
+        nodes <- c(nodes, param$layer3)
+      }
     }
     neuralnet::neuralnet(form, data = dat, hidden = nodes, ...)
   },

--- a/inst/model_sources/files/neuralnet.R
+++ b/inst/model_sources/files/neuralnet.R
@@ -1,38 +1,58 @@
-modelInfo <- list(label = "Neural Network",
-                  library = "neuralnet",
-                  loop = NULL,
-                  type = c('Regression'),
-                  parameters = data.frame(parameter = c('layer1', 'layer2', 'layer3'),
-                                          class = c('numeric', 'numeric', 'numeric'),
-                                          label = c('#Hidden Units in Layer 1', '#Hidden Units in Layer 2', '#Hidden Units in Layer 3')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(layer1 = ((1:len) * 2) - 1, layer2 = 0, layer3 = 0)
-                    } else {
-                      out <- data.frame(layer1 = sample(2:20, replace = TRUE, size = len),
-                                        layer2 = sample(c(0, 2:20), replace = TRUE, size = len),
-                                        layer3 = sample(c(0, 2:20), replace = TRUE, size = len))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    colNames <- colnames(x)
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    form <- as.formula(paste(".outcome ~",paste(colNames, collapse = "+")))
-                    if(param$layer1 == 0) stop("the first layer must have at least one hidden unit")
-                    if(param$layer2 == 0 & param$layer2 > 0) stop("the second layer must have at least one hidden unit if a third layer is specified")
-                    nodes <- c(param$layer1)
-                    if(param$layer2 > 0) {
-                      nodes <- c(nodes, param$layer2)
-                      if(param$layer3 > 0) nodes <- c(nodes, param$layer3)
-                    }
-                    neuralnet::neuralnet(form, data = dat, hidden = nodes, ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    newdata <- newdata[, modelFit$model.list$variables, drop = FALSE]
-                    neuralnet::compute(modelFit, covariate = newdata)$net.result[,1]
-                  },
-                  prob = NULL,
-                  tags = c("Neural Network"),
-                  sort = function(x) x[order(x$layer1, x$layer2, x$layer3),])
+modelInfo <- list(
+  label = "Neural Network",
+  library = "neuralnet",
+  loop = NULL,
+  type = c('Regression'),
+  parameters = data.frame(
+    parameter = c('layer1', 'layer2', 'layer3'),
+    class = c('numeric', 'numeric', 'numeric'),
+    label = c(
+      '#Hidden Units in Layer 1',
+      '#Hidden Units in Layer 2',
+      '#Hidden Units in Layer 3'
+    )
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(layer1 = ((1:len) * 2) - 1, layer2 = 0, layer3 = 0)
+    } else {
+      out <- data.frame(
+        layer1 = sample(2:20, replace = TRUE, size = len),
+        layer2 = sample(c(0, 2:20), replace = TRUE, size = len),
+        layer3 = sample(c(0, 2:20), replace = TRUE, size = len)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    colNames <- colnames(x)
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    form <- as.formula(paste(".outcome ~", paste(colNames, collapse = "+")))
+    if (param$layer1 == 0) {
+      stop("the first layer must have at least one hidden unit")
+    }
+    if (param$layer2 == 0 & param$layer2 > 0) {
+      stop(
+        "the second layer must have at least one hidden unit if a third layer is specified"
+      )
+    }
+    nodes <- c(param$layer1)
+    if (param$layer2 > 0) {
+      nodes <- c(nodes, param$layer2)
+      if (param$layer3 > 0) nodes <- c(nodes, param$layer3)
+    }
+    neuralnet::neuralnet(form, data = dat, hidden = nodes, ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    newdata <- newdata[, modelFit$model.list$variables, drop = FALSE]
+    neuralnet::compute(modelFit, covariate = newdata)$net.result[, 1]
+  },
+  prob = NULL,
+  tags = c("Neural Network"),
+  sort = function(x) x[order(x$layer1, x$layer2, x$layer3), ]
+)

--- a/inst/model_sources/files/nnet.R
+++ b/inst/model_sources/files/nnet.R
@@ -23,10 +23,10 @@ modelInfo <- list(
     out
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     if (!is.null(wts)) {
@@ -79,7 +79,13 @@ modelInfo <- list(
     }
     imp
   },
-  predictors = function(x, ...) if (hasTerms(x)) predictors(x$terms) else NA,
+  predictors = function(x, ...) {
+    if (hasTerms(x)) {
+      predictors(x$terms)
+    } else {
+      NA
+    }
+  },
   tags = c("Neural Network", "L2 Regularization", "Accepts Case Weights"),
   levels = function(x) x$lev,
   sort = function(x) x[order(x$size, -x$decay), ]

--- a/inst/model_sources/files/nnet.R
+++ b/inst/model_sources/files/nnet.R
@@ -1,67 +1,86 @@
-modelInfo <- list(label = "Neural Network",
-                  library = "nnet",
-                  loop = NULL,
-                  type = c("Classification", "Regression"),
-                  parameters = data.frame(parameter = c('size', 'decay'),
-                                          class = rep("numeric", 2),
-                                          label = c('#Hidden Units', 'Weight Decay')),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- expand.grid(size = ((1:len) * 2) - 1,
-                                         decay = c(0, 10 ^ seq(-1, -4, length = len - 1)))
-                    } else {
-                      out <- data.frame(size = sample(1:20, size = len, replace = TRUE),
-                                        decay = 10^runif(len, min = -5, 1))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    if(!is.null(wts)) {
-                      out <- nnet::nnet(.outcome ~ .,
-                                        data = dat,
-                                        weights = wts,
-                                        size = param$size,
-                                        decay = param$decay,
-                                        ...)
-                    } else out <- nnet::nnet(.outcome ~ .,
-                                             data = dat,
-                                             size = param$size,
-                                             decay = param$decay,
-                                             ...)
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(modelFit$problemType == "Classification")
-                    {
-                      out <- predict(modelFit, newdata, type="class")
-                    } else {
-                      out  <- predict(modelFit, newdata, type="raw")[,1]
-                    }
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL){
-                    out <- predict(modelFit, newdata)
-                    if(ncol(as.data.frame(out, stringsAsFactors = TRUE)) == 1) {
-                      out <- cbind(out, 1-out)
-                      dimnames(out)[[2]] <-  rev(modelFit$obsLevels)
-                    }
-                    out
-                  },
-                  varImp = function(object, ...) {
-                    imp <- caret:::GarsonWeights(object, ...)
-                    if(ncol(imp) > 1) {
-                      imp <- cbind(apply(imp, 1, mean), imp)
-                      colnames(imp)[1] <- "Overall"
-                    } else {
-                      imp <- as.data.frame(imp, stringsAsFactors = TRUE)
-                      names(imp) <- "Overall"
-                    }
-                    if(!is.null(object$xNames)) rownames(imp) <- object$xNames
-                    imp
-                  },
-                  predictors = function(x, ...) if(hasTerms(x)) predictors(x$terms) else NA,
-                  tags = c("Neural Network", "L2 Regularization", "Accepts Case Weights"),
-                  levels = function(x) x$lev,
-                  sort = function(x) x[order(x$size, -x$decay),])
+modelInfo <- list(
+  label = "Neural Network",
+  library = "nnet",
+  loop = NULL,
+  type = c("Classification", "Regression"),
+  parameters = data.frame(
+    parameter = c('size', 'decay'),
+    class = rep("numeric", 2),
+    label = c('#Hidden Units', 'Weight Decay')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        size = ((1:len) * 2) - 1,
+        decay = c(0, 10^seq(-1, -4, length = len - 1))
+      )
+    } else {
+      out <- data.frame(
+        size = sample(1:20, size = len, replace = TRUE),
+        decay = 10^runif(len, min = -5, 1)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    if (!is.null(wts)) {
+      out <- nnet::nnet(
+        .outcome ~ .,
+        data = dat,
+        weights = wts,
+        size = param$size,
+        decay = param$decay,
+        ...
+      )
+    } else {
+      out <- nnet::nnet(
+        .outcome ~ .,
+        data = dat,
+        size = param$size,
+        decay = param$decay,
+        ...
+      )
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (modelFit$problemType == "Classification") {
+      out <- predict(modelFit, newdata, type = "class")
+    } else {
+      out <- predict(modelFit, newdata, type = "raw")[, 1]
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata)
+    if (ncol(as.data.frame(out, stringsAsFactors = TRUE)) == 1) {
+      out <- cbind(out, 1 - out)
+      dimnames(out)[[2]] <- rev(modelFit$obsLevels)
+    }
+    out
+  },
+  varImp = function(object, ...) {
+    imp <- caret:::GarsonWeights(object, ...)
+    if (ncol(imp) > 1) {
+      imp <- cbind(apply(imp, 1, mean), imp)
+      colnames(imp)[1] <- "Overall"
+    } else {
+      imp <- as.data.frame(imp, stringsAsFactors = TRUE)
+      names(imp) <- "Overall"
+    }
+    if (!is.null(object$xNames)) {
+      rownames(imp) <- object$xNames
+    }
+    imp
+  },
+  predictors = function(x, ...) if (hasTerms(x)) predictors(x$terms) else NA,
+  tags = c("Neural Network", "L2 Regularization", "Accepts Case Weights"),
+  levels = function(x) x$lev,
+  sort = function(x) x[order(x$size, -x$decay), ]
+)

--- a/inst/model_sources/files/nnls.R
+++ b/inst/model_sources/files/nnls.R
@@ -1,29 +1,39 @@
-modelInfo <- list(label = "Non-Negative Least Squares",
-                  library = "nnls",
-                  loop = NULL,
-                  type = "Regression",
-                  parameters = data.frame(parameter = "parameter",
-                                          class = "character",
-                                          label = "parameter"),
-                  grid = function(x, y, len = NULL, search = "grid") data.frame(parameter = "none"),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    if(!is.matrix(x)) x <- as.matrix(x)
-                    out <- nnls::nnls(x, y)
-                    names(out$x) <- colnames(x)
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    out <- newdata %*% modelFit$x
-                    out[,1]
-                    },
-                  prob = NULL,
-                  predictors = function(x, ...) names(x$x)[x$x != 0],
-                  tags = "Linear Regression",
-                  varImp = function(object, ...) {
-                    out <- data.frame(Overall = object$x)
-                    rownames(out) <- names(object$x)
-                    out
-                    out   
-                  },
-                  sort = function(x) x)
+modelInfo <- list(
+  label = "Non-Negative Least Squares",
+  library = "nnls",
+  loop = NULL,
+  type = "Regression",
+  parameters = data.frame(
+    parameter = "parameter",
+    class = "character",
+    label = "parameter"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(parameter = "none")
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (!is.matrix(x)) {
+      x <- as.matrix(x)
+    }
+    out <- nnls::nnls(x, y)
+    names(out$x) <- colnames(x)
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- newdata %*% modelFit$x
+    out[, 1]
+  },
+  prob = NULL,
+  predictors = function(x, ...) names(x$x)[x$x != 0],
+  tags = "Linear Regression",
+  varImp = function(object, ...) {
+    out <- data.frame(Overall = object$x)
+    rownames(out) <- names(object$x)
+    out
+    out
+  },
+  sort = function(x) x
+)

--- a/inst/model_sources/files/nodeHarvest.R
+++ b/inst/model_sources/files/nodeHarvest.R
@@ -1,57 +1,78 @@
-modelInfo <- list(label = "Tree-Based Ensembles",
-                  library = c("nodeHarvest"),
-                  loop = NULL,
-                  type = c('Regression', 'Classification'),
-                  parameters = data.frame(parameter = c('maxinter', 'mode'),
-                                          class = c('numeric', 'character'),
-                                          label = c('Maximum Interaction Depth', 'Prediction Mode')),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- expand.grid(maxinter = 1:len, mode = c("mean", "outbag"))
-                    } else {
-                      out <- data.frame(maxinter = sample(1:20, size = len, replace = TRUE), 
-                                        mode = sample(c("mean", "outbag"), size = len, replace = TRUE))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...){
-                    if(!is.data.frame(x) | inherits(x, "tbl_df")) 
-                      x <- as.data.frame(x, stringsAsFactors = TRUE)
-                    if(is.numeric(y)) {
-                      out <- nodeHarvest::nodeHarvest(x, y,
-                                                      maxinter = param$maxinter,
-                                                      mode = param$mode,
-                                                      ...)
-                    } else {
-                      if(length(lev) > 2) stop("Two Class problems only")
-                      out <- nodeHarvest::nodeHarvest(x,
-                                                     ifelse(y == levels(y)[1], 1, 0),
-                                                     maxinter = param$maxinter,
-                                                     mode = param$mode,
-                                                     ...)                          
-                    }
-                    out   
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL){
-                    if(!is.data.frame(newdata) | inherits(newdata, "tbl_df")) 
-                      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    if(modelFit$problemType == "Regression") {
-                      predict(modelFit, as.matrix(newdata), maxshow = 0)
-                    } else  {
-                      prbs <- predict(modelFit, as.matrix(newdata), maxshow = 0)
-                      ifelse(prbs > .5, modelFit$obsLevels[1], modelFit$obsLevels[2])
-                    }
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL){
-                    if(!is.data.frame(newdata) | inherits(newdata, "tbl_df")) 
-                      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    out <- predict(modelFit, as.matrix(newdata), maxshow = 0)
-                    if(is.vector(out)) {
-                      out <- cbind(out, 1 - out)
-                      colnames(out) <- modelFit$obsLevels
-                    }
-                    out
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("Tree-Based Model", "Implicit Feature Selection", "Ensemble Model", "Two Class Only"),
-                  sort = function(x) x[order(x$maxinter, x$mode),])
+modelInfo <- list(
+  label = "Tree-Based Ensembles",
+  library = c("nodeHarvest"),
+  loop = NULL,
+  type = c('Regression', 'Classification'),
+  parameters = data.frame(
+    parameter = c('maxinter', 'mode'),
+    class = c('numeric', 'character'),
+    label = c('Maximum Interaction Depth', 'Prediction Mode')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(maxinter = 1:len, mode = c("mean", "outbag"))
+    } else {
+      out <- data.frame(
+        maxinter = sample(1:20, size = len, replace = TRUE),
+        mode = sample(c("mean", "outbag"), size = len, replace = TRUE)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (!is.data.frame(x) | inherits(x, "tbl_df")) {
+      x <- as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    if (is.numeric(y)) {
+      out <- nodeHarvest::nodeHarvest(
+        x,
+        y,
+        maxinter = param$maxinter,
+        mode = param$mode,
+        ...
+      )
+    } else {
+      if (length(lev) > 2) {
+        stop("Two Class problems only")
+      }
+      out <- nodeHarvest::nodeHarvest(
+        x,
+        ifelse(y == levels(y)[1], 1, 0),
+        maxinter = param$maxinter,
+        mode = param$mode,
+        ...
+      )
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata) | inherits(newdata, "tbl_df")) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    if (modelFit$problemType == "Regression") {
+      predict(modelFit, as.matrix(newdata), maxshow = 0)
+    } else {
+      prbs <- predict(modelFit, as.matrix(newdata), maxshow = 0)
+      ifelse(prbs > .5, modelFit$obsLevels[1], modelFit$obsLevels[2])
+    }
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata) | inherits(newdata, "tbl_df")) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    out <- predict(modelFit, as.matrix(newdata), maxshow = 0)
+    if (is.vector(out)) {
+      out <- cbind(out, 1 - out)
+      colnames(out) <- modelFit$obsLevels
+    }
+    out
+  },
+  levels = function(x) x$obsLevels,
+  tags = c(
+    "Tree-Based Model",
+    "Implicit Feature Selection",
+    "Ensemble Model",
+    "Two Class Only"
+  ),
+  sort = function(x) x[order(x$maxinter, x$mode), ]
+)

--- a/inst/model_sources/files/null.R
+++ b/inst/model_sources/files/null.R
@@ -1,22 +1,30 @@
-modelInfo <- list(label = "Non-Informative Model",
-                  library = NULL,
-                  type = c("Classification", "Regression"),
-                  parameters = data.frame(parameter = "parameter",
-                                          class = "character",
-                                          label = "parameter"),
-                  grid = function(x, y, len = NULL, search = "grid") data.frame(parameter = "none"),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    nullModel(y = y, ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    predict(modelFit, newdata)
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    predict(modelFit, newdata, type = "prob")
-                  },
-                  levels = function(x) x$levels,
-                  tags = NULL,
-                  notes = paste("Since this model always predicts",
-                                "the same value, R-squared values",
-                                "will always be estimated to be NA."),
-                  sort = function(x) x)
+modelInfo <- list(
+  label = "Non-Informative Model",
+  library = NULL,
+  type = c("Classification", "Regression"),
+  parameters = data.frame(
+    parameter = "parameter",
+    class = "character",
+    label = "parameter"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(parameter = "none")
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    nullModel(y = y, ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata, type = "prob")
+  },
+  levels = function(x) x$levels,
+  tags = NULL,
+  notes = paste(
+    "Since this model always predicts",
+    "the same value, R-squared values",
+    "will always be estimated to be NA."
+  ),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/ordinalNet.R
+++ b/inst/model_sources/files/ordinalNet.R
@@ -121,7 +121,13 @@ modelInfo <- list(
     rownames(out) <- names(betas)
     out
   },
-  levels = function(x) if (any(names(x) == "obsLevels")) x$obsLevels else NULL,
+  levels = function(x) {
+    if (any(names(x) == "obsLevels")) {
+      x$obsLevels
+    } else {
+      NULL
+    }
+  },
   tags = c(
     "Generalized Linear Model",
     "Implicit Feature Selection",

--- a/inst/model_sources/files/ordinalNet.R
+++ b/inst/model_sources/files/ordinalNet.R
@@ -1,97 +1,144 @@
-modelInfo <- list(label = "Penalized Ordinal Regression",
-                  library = c("ordinalNet", "plyr"),
-                  check = function(pkg) {
-                    requireNamespace("ordinalNet")
-                    current <- packageDescription("ordinalNet")$Version
-                    expected <- "2.0"
-                    if(compareVersion(current, expected) < 0)
-                      stop("This modeling workflow requires ordinalNet version ",
-                           expected, "or greater.", call. = FALSE)
-                  },
-                  type = "Classification",
-                  parameters = data.frame(
-                    parameter = c('alpha', 'criteria', 'link', 'lambda', 'modeltype', 'family'),
-                    class = c('numeric', 'character', 'character', 'numeric', 'character', 'character'),
-                    label = c('Mixing Percentage', 'Selection criterion', 'Link Function','Penalty Parameter', 'Model Form', 'Model Family')
-                  ),
-                  grid = function(x, y, len = NULL, search = 'grid') {
-                    links <- c("logit", "probit", "cloglog", "cauchit")
-                    modeltypes <- c('parallel', 'nonparallel', 'semiparallel')
-                    families <- c("cumulative", "sratio", "cratio", "acat")
-                    max_lambda <- max(ordinalNet::ordinalNet(x = x, y = y, alpha = 0.01, nLambda = 2)$lambdaVals)
-                    min_lambda <- 0.005 * max_lambda
-                    if (search == "grid") {
-                      out <- expand.grid(
-                        alpha = seq(0.1, 1, length = len),
-                        criteria = "aic",
-                        link = links,
-                        lambda = seq(from = min_lambda, to = max_lambda, length.out = len),
-                        modeltype = modeltypes,
-                        family = families
-                      )
-                    } else {
-                      out <- data.frame(
-                        alpha = runif(len, min = 0, 1),
-                        criteria = sample(c("aic", "bic"), size = len, replace = TRUE),
-                        link = sample(links, size = len, replace = TRUE),
-                        lambda = runif(len, min = min_lambda, max = max_lambda),
-                        modeltype = sample(modeltypes, size = len, replace = TRUE),
-                        family = sample(families, size = len, replace = T)
-                      )
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    if (!is.matrix(x)) x <- as.matrix(x)
-                    out <- ordinalNet::ordinalNet(
-                      x = x,
-                      y = y,
-                      alpha = param$alpha,
-                      link = as.character(param$link),
-                      lambdaVals = param$lambda,
-                      family = as.character(param$family),
-                      parallelTerms = (as.character(param$modeltype) %in% c('parallel', 'semiparallel')),
-                      nonparallelTerms = (as.character(param$modeltype) %in% c('semiparallel', 'nonparallel')),
-                      ...
-                    )
-                    out$.criteria <- as.character(param$criteria)
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if (!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    out <- predict(modelFit, newdata, criteria = modelFit$.criteria, type = "class")
-                    out <- modelFit$obsLevels[out]
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if (!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    out <- predict(modelFit, newdata, criteria = modelFit$.criteria, type = "response")
-                    colnames(out) <- modelFit$obsLevels
-                    out
-                  },
-                  predictors = function(x, lambda = NULL, ...) {
-                    betas <- coef(x, criteria = x$.criteria)
-                    out <- names(betas)[betas != 0]
-                    out[!grepl("^Intercept", out)]
-                  },
-                  varImp = function(object, lambda = NULL, ...) {
-                    betas <- coef(object, criteria = object$.criteria)
-                    betas <- betas[!grepl("^Intercept", names(betas))]
-                    out <- data.frame(Overall = abs(betas))
-                    rownames(out) <- names(betas)
-                    out
-                  },
-                  levels = function(x) if(any(names(x) == "obsLevels")) x$obsLevels else NULL,
-                  tags = c("Generalized Linear Model", "Implicit Feature Selection",
-                           "L1 Regularization", "L2 Regularization", "Linear Classifier",
-                           "Linear Regression", "Ordinal Outcomes"),
-                  sort = function(x) {
-                    model_type_order <- c('parallel' = 1, 'semiparallel' = 2, 'nonparallel' = 3)
-                    mt <- model_type_order[x$modeltype]
-                    a <- x$alpha
-                    l <- x$lambda
-                    family_order <- c("cratio" = 1, "sratio" = 2, "acat" = 3, "cumulative" = 4)
-                    f <- family_order[x$family]
-                    x[order(mt, a, l, f), ]
-                  },
-                  notes = "Requires ordinalNet package version >= 2.0")
+modelInfo <- list(
+  label = "Penalized Ordinal Regression",
+  library = c("ordinalNet", "plyr"),
+  check = function(pkg) {
+    requireNamespace("ordinalNet")
+    current <- packageDescription("ordinalNet")$Version
+    expected <- "2.0"
+    if (compareVersion(current, expected) < 0) {
+      stop(
+        "This modeling workflow requires ordinalNet version ",
+        expected,
+        "or greater.",
+        call. = FALSE
+      )
+    }
+  },
+  type = "Classification",
+  parameters = data.frame(
+    parameter = c('alpha', 'criteria', 'link', 'lambda', 'modeltype', 'family'),
+    class = c(
+      'numeric',
+      'character',
+      'character',
+      'numeric',
+      'character',
+      'character'
+    ),
+    label = c(
+      'Mixing Percentage',
+      'Selection criterion',
+      'Link Function',
+      'Penalty Parameter',
+      'Model Form',
+      'Model Family'
+    )
+  ),
+  grid = function(x, y, len = NULL, search = 'grid') {
+    links <- c("logit", "probit", "cloglog", "cauchit")
+    modeltypes <- c('parallel', 'nonparallel', 'semiparallel')
+    families <- c("cumulative", "sratio", "cratio", "acat")
+    max_lambda <- max(
+      ordinalNet::ordinalNet(x = x, y = y, alpha = 0.01, nLambda = 2)$lambdaVals
+    )
+    min_lambda <- 0.005 * max_lambda
+    if (search == "grid") {
+      out <- expand.grid(
+        alpha = seq(0.1, 1, length = len),
+        criteria = "aic",
+        link = links,
+        lambda = seq(from = min_lambda, to = max_lambda, length.out = len),
+        modeltype = modeltypes,
+        family = families
+      )
+    } else {
+      out <- data.frame(
+        alpha = runif(len, min = 0, 1),
+        criteria = sample(c("aic", "bic"), size = len, replace = TRUE),
+        link = sample(links, size = len, replace = TRUE),
+        lambda = runif(len, min = min_lambda, max = max_lambda),
+        modeltype = sample(modeltypes, size = len, replace = TRUE),
+        family = sample(families, size = len, replace = T)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (!is.matrix(x)) {
+      x <- as.matrix(x)
+    }
+    out <- ordinalNet::ordinalNet(
+      x = x,
+      y = y,
+      alpha = param$alpha,
+      link = as.character(param$link),
+      lambdaVals = param$lambda,
+      family = as.character(param$family),
+      parallelTerms = (as.character(param$modeltype) %in%
+        c('parallel', 'semiparallel')),
+      nonparallelTerms = (as.character(param$modeltype) %in%
+        c('semiparallel', 'nonparallel')),
+      ...
+    )
+    out$.criteria <- as.character(param$criteria)
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- predict(
+      modelFit,
+      newdata,
+      criteria = modelFit$.criteria,
+      type = "class"
+    )
+    out <- modelFit$obsLevels[out]
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- predict(
+      modelFit,
+      newdata,
+      criteria = modelFit$.criteria,
+      type = "response"
+    )
+    colnames(out) <- modelFit$obsLevels
+    out
+  },
+  predictors = function(x, lambda = NULL, ...) {
+    betas <- coef(x, criteria = x$.criteria)
+    out <- names(betas)[betas != 0]
+    out[!grepl("^Intercept", out)]
+  },
+  varImp = function(object, lambda = NULL, ...) {
+    betas <- coef(object, criteria = object$.criteria)
+    betas <- betas[!grepl("^Intercept", names(betas))]
+    out <- data.frame(Overall = abs(betas))
+    rownames(out) <- names(betas)
+    out
+  },
+  levels = function(x) if (any(names(x) == "obsLevels")) x$obsLevels else NULL,
+  tags = c(
+    "Generalized Linear Model",
+    "Implicit Feature Selection",
+    "L1 Regularization",
+    "L2 Regularization",
+    "Linear Classifier",
+    "Linear Regression",
+    "Ordinal Outcomes"
+  ),
+  sort = function(x) {
+    model_type_order <- c('parallel' = 1, 'semiparallel' = 2, 'nonparallel' = 3)
+    mt <- model_type_order[x$modeltype]
+    a <- x$alpha
+    l <- x$lambda
+    family_order <- c("cratio" = 1, "sratio" = 2, "acat" = 3, "cumulative" = 4)
+    f <- family_order[x$family]
+    x[order(mt, a, l, f), ]
+  },
+  notes = "Requires ordinalNet package version >= 2.0"
+)

--- a/inst/model_sources/files/ordinalRF.R
+++ b/inst/model_sources/files/ordinalRF.R
@@ -1,75 +1,109 @@
-modelInfo  <- list(label = "Random Forest",
-                   library = c("e1071", "ranger", "dplyr", "ordinalForest"),
-                   check = function(pkg){
-                     requireNamespace("ordinalForest")
-                     current <- packageDescription("ordinalForest")$Version
-                     expected <- "2.1"
-                     if(compareVersion(current, expected) < 0)
-                       stop("This modeling workflow requires ordinalForest version ",
-                            expected, "or greater.", call. = FALSE)
-                   },
-                   loop = NULL,
-                   type = c("Classification"),
-                   parameters = data.frame(parameter = c("nsets", "ntreeperdiv", "ntreefinal"),
-                                           class = c("numeric", "numeric", "numeric"),
-                                           label = c("# score sets tried prior to the approximation",
-                                                     "# of trees (small RFs)",
-                                                     "# of trees (final RF)")),
-                   grid = function(x, y, len = NULL, search = "grid"){
-                     if(search == "grid"){
-                       out <- expand.grid(nsets = seq_len(len)*50,
-                                          ntreeperdiv = seq_len(len)*50,
-                                          ntreefinal =  seq_len(len)*200)
-                     } else {
-                       out <-data.frame(nsets = sample(20, size = len, replace = TRUE)*50,
-                                        ntreeperdiv =sample(20, size = len, replace = TRUE)*50,
-                                        ntreefinal =  sample(2:20, size = len, replace = TRUE)*200
-                       )
-                     }
-                     out
-                   },
-                   fit = function(x, y, wts, param, lev, last, classProbs, ...){
-                     if((!is.data.frame(x))||dplyr::is.tbl(x)) x <- as.data.frame(x, stringsAsFactors = TRUE)
-                     x$.outcome <- y
-                     out <- ordinalForest::ordfor(depvar = ".outcome",
-                                                  data = x,
-                                                  nsets = param$nsets,
-                                                  ntreeperdiv = param$ntreeperdiv,
-                                                  ntreefinal =  param$ntreefinal,
-                                                  ...)
-                     out
-                   },
-                   predict = function(modelFit, newdata, submodels = NULL){
-                     if((!is.data.frame(newdata))||dplyr::is.tbl(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                     out <- predict(modelFit, newdata)$ypred
-                     out
-                   },
-                   prob = function(modelFit, newdata, submodels = NULL){
-                     if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                     out <- predict(modelFit, newdata)$classprobs
-                     colnames(out) <- modelFit$classes
-                     as.data.frame(out)
-                   },
-                   predictors = function(x, ...){
-                     var_index <- sort(unique(unlist(lapply(x$forestfinal$forest$split.varIDs, function(x) x))))
-                     var_index <-var_index[var_index > 0]
-                     x$forestfinal$forest$independent.variable.names[var_index]
-                   },
-                   varImp = function(object, ...){
-                     if(length(object$varimp) == 0)
-                       stop("No importance values available")
-                     imps <- object$varimp
-                     out <- data.frame(Overall = as.vector(imps))
-                     rownames(out) <- names(imps)
-                     out
-                   },
-                   levels = function(x){
-                     if(x$treetype == "Classification"){
-                       out <- levels(x$predictions)
-                     } else out <- NULL
-                     out
-                   },
-                   tags = c("Random Forest", "Ensemble Model", "Bagging",
-                            "Implicit Feature Selection", "Ordinal Outcomes" ),
-                   sort = function(x){ x[order(x[,1]),] }
+modelInfo <- list(
+  label = "Random Forest",
+  library = c("e1071", "ranger", "dplyr", "ordinalForest"),
+  check = function(pkg) {
+    requireNamespace("ordinalForest")
+    current <- packageDescription("ordinalForest")$Version
+    expected <- "2.1"
+    if (compareVersion(current, expected) < 0) {
+      stop(
+        "This modeling workflow requires ordinalForest version ",
+        expected,
+        "or greater.",
+        call. = FALSE
+      )
+    }
+  },
+  loop = NULL,
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = c("nsets", "ntreeperdiv", "ntreefinal"),
+    class = c("numeric", "numeric", "numeric"),
+    label = c(
+      "# score sets tried prior to the approximation",
+      "# of trees (small RFs)",
+      "# of trees (final RF)"
+    )
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        nsets = seq_len(len) * 50,
+        ntreeperdiv = seq_len(len) * 50,
+        ntreefinal = seq_len(len) * 200
+      )
+    } else {
+      out <- data.frame(
+        nsets = sample(20, size = len, replace = TRUE) * 50,
+        ntreeperdiv = sample(20, size = len, replace = TRUE) * 50,
+        ntreefinal = sample(2:20, size = len, replace = TRUE) * 200
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if ((!is.data.frame(x)) || dplyr::is.tbl(x)) {
+      x <- as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    x$.outcome <- y
+    out <- ordinalForest::ordfor(
+      depvar = ".outcome",
+      data = x,
+      nsets = param$nsets,
+      ntreeperdiv = param$ntreeperdiv,
+      ntreefinal = param$ntreefinal,
+      ...
+    )
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if ((!is.data.frame(newdata)) || dplyr::is.tbl(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    out <- predict(modelFit, newdata)$ypred
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    out <- predict(modelFit, newdata)$classprobs
+    colnames(out) <- modelFit$classes
+    as.data.frame(out)
+  },
+  predictors = function(x, ...) {
+    var_index <- sort(unique(unlist(lapply(
+      x$forestfinal$forest$split.varIDs,
+      function(x) x
+    ))))
+    var_index <- var_index[var_index > 0]
+    x$forestfinal$forest$independent.variable.names[var_index]
+  },
+  varImp = function(object, ...) {
+    if (length(object$varimp) == 0) {
+      stop("No importance values available")
+    }
+    imps <- object$varimp
+    out <- data.frame(Overall = as.vector(imps))
+    rownames(out) <- names(imps)
+    out
+  },
+  levels = function(x) {
+    if (x$treetype == "Classification") {
+      out <- levels(x$predictions)
+    } else {
+      out <- NULL
+    }
+    out
+  },
+  tags = c(
+    "Random Forest",
+    "Ensemble Model",
+    "Bagging",
+    "Implicit Feature Selection",
+    "Ordinal Outcomes"
+  ),
+  sort = function(x) {
+    x[order(x[, 1]), ]
+  }
 )

--- a/inst/model_sources/files/ownn.R
+++ b/inst/model_sources/files/ownn.R
@@ -12,7 +12,11 @@ modelInfo <- list(
     if (search == "grid") {
       out <- data.frame(K = (5:((2 * len) + 4))[(5:((2 * len) + 4)) %% 2 > 0])
     } else {
-      by_val <- if (is.factor(y)) length(levels(y)) else 1
+      if (is.factor(y)) {
+        by_val <- length(levels(y))
+      } else {
+        by_val <- 1
+      }
       out <- data.frame(
         K = sample(
           seq(1, floor(nrow(x) / 3), by = by_val),

--- a/inst/model_sources/files/ownn.R
+++ b/inst/model_sources/files/ownn.R
@@ -1,36 +1,49 @@
-modelInfo <- list(label = "Optimal Weighted Nearest Neighbor Classifier",
-                  library = "snn",
-                  loop = NULL,
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = "K",
-                                          class = "numeric",
-                                          label = "#Neighbors"),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- data.frame(K = (5:((2 * len)+4))[(5:((2 * len)+4))%%2 > 0])
-                    } else {
-                      by_val <- if(is.factor(y)) length(levels(y)) else 1
-                      out <- data.frame(K = sample(seq(1, floor(nrow(x)/3), by = by_val), size = len, replace = TRUE))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    if(!is.matrix(x)) x <- as.matrix(x)
-                    if(!(class(x[1,1]) %in% c("integer", "numeric")))
-                      stop("predictors should be all numeric")
-                    x <- cbind(x, as.numeric(y))
-                    colnames(x)[ncol(x)] <- ".outcome"
-                    list(dat = x, K = param$K)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    out <- snn::myownn(train = modelFit$dat,
-                                       test = newdata,
-                                       K = modelFit$K)
-                    modelFit$obsLevels[out]
-                  },
-                  predictors = function(x, ...) x$xNames,
-                  tags = "Prototype Models",
-                  prob = NULL,
-                  levels = function(x) x$obsLevels,
-                  sort = function(x) x[order(-x[,1]),])
+modelInfo <- list(
+  label = "Optimal Weighted Nearest Neighbor Classifier",
+  library = "snn",
+  loop = NULL,
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = "K",
+    class = "numeric",
+    label = "#Neighbors"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(K = (5:((2 * len) + 4))[(5:((2 * len) + 4)) %% 2 > 0])
+    } else {
+      by_val <- if (is.factor(y)) length(levels(y)) else 1
+      out <- data.frame(
+        K = sample(
+          seq(1, floor(nrow(x) / 3), by = by_val),
+          size = len,
+          replace = TRUE
+        )
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (!is.matrix(x)) {
+      x <- as.matrix(x)
+    }
+    if (!(class(x[1, 1]) %in% c("integer", "numeric"))) {
+      stop("predictors should be all numeric")
+    }
+    x <- cbind(x, as.numeric(y))
+    colnames(x)[ncol(x)] <- ".outcome"
+    list(dat = x, K = param$K)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- snn::myownn(train = modelFit$dat, test = newdata, K = modelFit$K)
+    modelFit$obsLevels[out]
+  },
+  predictors = function(x, ...) x$xNames,
+  tags = "Prototype Models",
+  prob = NULL,
+  levels = function(x) x$obsLevels,
+  sort = function(x) x[order(-x[, 1]), ]
+)

--- a/inst/model_sources/files/pam.R
+++ b/inst/model_sources/files/pam.R
@@ -1,119 +1,164 @@
-modelInfo <- list(label = "Nearest Shrunken Centroids",
-                  library = "pamr",
-                  type = "Classification",
-                  parameters = data.frame(parameter = 'threshold',
-                                          class = "numeric",
-                                          label = 'Shrinkage Threshold'),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    cc <- complete.cases(x) & complete.cases(y)
-                    x <- x[cc,,drop = FALSE]
-                    y <- y[cc]
-                    initialThresh <- pamr::pamr.train(list(x=t(x), y=y))$threshold
-                    initialThresh <- initialThresh[-c(1, length(initialThresh))]
-                    if(search == "grid") {
-                      out <- data.frame(threshold = 
-                                          seq(from = min(initialThresh),
-                                              to = max(initialThresh), 
-                                              length = len))
-                    } else {
-                      out <- data.frame(threshold = 
-                                          runif(len, 
-                                                min = min(initialThresh),
-                                                max = max(initialThresh)))
-                    }
-                    out
-                    
-                  },
-                  loop = function(grid) {   
-                    grid <- grid[order(grid$threshold, decreasing = TRUE),, drop = FALSE]
-                    loop <- grid[1,,drop = FALSE]
-                    submodels <- list(grid[-1,,drop = FALSE])       
-                    list(loop = loop, submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    res <- pamr::pamr.train(list(x = t(x), y = y), 
-                                            threshold = param$threshold, ...)
-                    if (last) {
-                      res$xData <- x
-                      res$yData <- y
-                    }
-                    res
-                  }, 
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- pamr::pamr.predict(modelFit,
-                                              t(newdata),
-                                              threshold = modelFit$tuneValue$threshold)
-                    if(!is.null(submodels)) {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
-                      for(j in seq(along = submodels$threshold)) {
-                        tmp[[j+1]] <- pamr::pamr.predict(modelFit,
-                                                         t(newdata),
-                                                         threshold = submodels$threshold[j])
-                      }
-                      out <- tmp
-                    }
-                    out         
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- pamr::pamr.predict(modelFit, t(newdata),
-                                              threshold = modelFit$tuneValue$threshold,
-                                              type= "posterior")
-                    if(!is.null(submodels)) {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
-                      
-                      for(j in seq(along = submodels$threshold)) {
-                        tmpProb <-  pamr::pamr.predict(modelFit, t(newdata),
-                                                       threshold =  submodels$threshold[j],
-                                                       type= "posterior")
-                        tmp[[j+1]] <- as.data.frame(tmpProb[, modelFit$obsLevels, drop = FALSE], stringsAsFactors = TRUE)
-                      }
-                      out <- tmp
-                    }   
-                    out
-                  },
-                  predictors = function(x, newdata = NULL, threshold = NULL,  ...) {
-                    if (is.null(newdata)) {
-                      if (!is.null(x$xData))
-                        newdata <- x$xData
-                      else
-                        stop("must supply newdata")
-                    }
-                    if (is.null(threshold)) {
-                      if (!is.null(x$threshold))
-                        threshold <-
-                          x$threshold
-                      else
-                        stop("must supply threshold")
-                    }
-                    varIndex <- pamr::pamr.predict(x, 
-                                                   newx = newdata, 
-                                                   threshold = threshold, 
-                                                   type = "nonzero")
-                    colnames(newdata)[varIndex]
-                  },
-                  varImp = function (object, threshold = NULL, data = NULL, ...) {
-                    if(is.null(data)) 
-                      data <- object$xData
-                    if(is.null(threshold)) 
-                      threshold <- object$tuneValue$threshold
-                    if( dim(object$centroids)[1] != dim(data)[2]) 
-                      stop("the number of columns (=variables) is not consistent with the pamr object")
-                    
-                    if(is.null(dimnames(data)))  {
-                      featureNames <- paste("Feature", seq(along = data[1,]), sep = "")
-                      colnames(data) <- featureNames
-                    } else featureNames <- dimnames(data)[[2]]
-                    
-                    x <- t(data)
-                    retainedX <- x[object$gene.subset, object$sample.subset, drop = F]
-                    centroids <- pamr::pamr.predict(object, x, threshold = threshold, type = "cent")
-                    standCentroids <- (centroids - object$centroid.overall)/object$sd
-                    rownames(standCentroids) <- featureNames
-                    colnames(standCentroids) <- names(object$prior)
-                    as.data.frame(standCentroids, stringsAsFactors = TRUE)
-                  },
-                  levels = function(x) names(x$prior),
-                  tags = c("Prototype Models", "Implicit Feature Selection", "Linear Classifier"),
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Nearest Shrunken Centroids",
+  library = "pamr",
+  type = "Classification",
+  parameters = data.frame(
+    parameter = 'threshold',
+    class = "numeric",
+    label = 'Shrinkage Threshold'
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    cc <- complete.cases(x) & complete.cases(y)
+    x <- x[cc, , drop = FALSE]
+    y <- y[cc]
+    initialThresh <- pamr::pamr.train(list(x = t(x), y = y))$threshold
+    initialThresh <- initialThresh[-c(1, length(initialThresh))]
+    if (search == "grid") {
+      out <- data.frame(
+        threshold = seq(
+          from = min(initialThresh),
+          to = max(initialThresh),
+          length = len
+        )
+      )
+    } else {
+      out <- data.frame(
+        threshold = runif(
+          len,
+          min = min(initialThresh),
+          max = max(initialThresh)
+        )
+      )
+    }
+    out
+  },
+  loop = function(grid) {
+    grid <- grid[order(grid$threshold, decreasing = TRUE), , drop = FALSE]
+    loop <- grid[1, , drop = FALSE]
+    submodels <- list(grid[-1, , drop = FALSE])
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    res <- pamr::pamr.train(
+      list(x = t(x), y = y),
+      threshold = param$threshold,
+      ...
+    )
+    if (last) {
+      res$xData <- x
+      res$yData <- y
+    }
+    res
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- pamr::pamr.predict(
+      modelFit,
+      t(newdata),
+      threshold = modelFit$tuneValue$threshold
+    )
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
+      for (j in seq(along = submodels$threshold)) {
+        tmp[[j + 1]] <- pamr::pamr.predict(
+          modelFit,
+          t(newdata),
+          threshold = submodels$threshold[j]
+        )
+      }
+      out <- tmp
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- pamr::pamr.predict(
+      modelFit,
+      t(newdata),
+      threshold = modelFit$tuneValue$threshold,
+      type = "posterior"
+    )
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
+
+      for (j in seq(along = submodels$threshold)) {
+        tmpProb <- pamr::pamr.predict(
+          modelFit,
+          t(newdata),
+          threshold = submodels$threshold[j],
+          type = "posterior"
+        )
+        tmp[[j + 1]] <- as.data.frame(
+          tmpProb[, modelFit$obsLevels, drop = FALSE],
+          stringsAsFactors = TRUE
+        )
+      }
+      out <- tmp
+    }
+    out
+  },
+  predictors = function(x, newdata = NULL, threshold = NULL, ...) {
+    if (is.null(newdata)) {
+      if (!is.null(x$xData)) {
+        newdata <- x$xData
+      } else {
+        stop("must supply newdata")
+      }
+    }
+    if (is.null(threshold)) {
+      if (!is.null(x$threshold)) {
+        threshold <-
+          x$threshold
+      } else {
+        stop("must supply threshold")
+      }
+    }
+    varIndex <- pamr::pamr.predict(
+      x,
+      newx = newdata,
+      threshold = threshold,
+      type = "nonzero"
+    )
+    colnames(newdata)[varIndex]
+  },
+  varImp = function(object, threshold = NULL, data = NULL, ...) {
+    if (is.null(data)) {
+      data <- object$xData
+    }
+    if (is.null(threshold)) {
+      threshold <- object$tuneValue$threshold
+    }
+    if (dim(object$centroids)[1] != dim(data)[2]) {
+      stop(
+        "the number of columns (=variables) is not consistent with the pamr object"
+      )
+    }
+
+    if (is.null(dimnames(data))) {
+      featureNames <- paste("Feature", seq(along = data[1, ]), sep = "")
+      colnames(data) <- featureNames
+    } else {
+      featureNames <- dimnames(data)[[2]]
+    }
+
+    x <- t(data)
+    retainedX <- x[object$gene.subset, object$sample.subset, drop = F]
+    centroids <- pamr::pamr.predict(
+      object,
+      x,
+      threshold = threshold,
+      type = "cent"
+    )
+    standCentroids <- (centroids - object$centroid.overall) / object$sd
+    rownames(standCentroids) <- featureNames
+    colnames(standCentroids) <- names(object$prior)
+    as.data.frame(standCentroids, stringsAsFactors = TRUE)
+  },
+  levels = function(x) names(x$prior),
+  tags = c(
+    "Prototype Models",
+    "Implicit Feature Selection",
+    "Linear Classifier"
+  ),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/parRF.R
+++ b/inst/model_sources/files/parRF.R
@@ -28,10 +28,8 @@ modelInfo <- list(
     workers <- foreach::getDoParWorkers()
     import::from(foreach, `%dopar%`)
     theDots <- list(...)
-    theDots$ntree <- if (is.null(theDots$ntree)) {
-      formals(randomForest:::randomForest.default)$ntree
-    } else {
-      theDots$ntree
+    if (is.null(theDots$ntree)) {
+      theDots$ntree <- formals(randomForest:::randomForest.default)$ntree
     }
 
     theDots$x <- x
@@ -106,10 +104,10 @@ modelInfo <- list(
         e1071::classAgreement(x$confusion[, -dim(x$confusion)[2]])[["kappa"]]
       )
     )
-    names(out) <- if (x$type == "regression") {
-      c("RMSE", "Rsquared")
+    if (x$type == "regression") {
+      names(out) <- c("RMSE", "Rsquared")
     } else {
-      c("Accuracy", "Kappa")
+      names(out) <- c("Accuracy", "Kappa")
     }
     out
   }

--- a/inst/model_sources/files/parRF.R
+++ b/inst/model_sources/files/parRF.R
@@ -1,84 +1,116 @@
-modelInfo <- list(label = "Parallel Random Forest",
-                  library = c("e1071", "randomForest", "foreach", "import"),
-                  loop = NULL,
-                  type = c("Classification", "Regression"),
-                  parameters = data.frame(parameter = "mtry",
-                                          class = "numeric",
-                                          label = "#Randomly Selected Predictors"),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- data.frame(mtry = caret::var_seq(p = ncol(x), 
-                                                              classification = is.factor(y), 
-                                                              len = len))
-                    } else {
-                      out <- data.frame(mtry = unique(sample(1:ncol(x), size = len, replace = TRUE)))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    workers <- foreach::getDoParWorkers()
-		                import::from(foreach, `%dopar%`)
-                    theDots <- list(...)
-                    theDots$ntree <- if(is.null(theDots$ntree)) 
-                      formals(randomForest:::randomForest.default)$ntree else 
-                        theDots$ntree
-                    
-                    theDots$x <- x
-                    theDots$y <- y
-                    theDots$mtry <- param$mtry
-                    theDots$ntree <- ceiling(theDots$ntree/workers)                       
-                    iter_seeds <- sample.int(10000, size = workers)
-                    out <- foreach::foreach(ntree = 1:workers, .combine = randomForest::combine) %dopar% {
-                      set.seed(iter_seeds[workers])
-                      do.call(randomForest::randomForest, theDots)
-                    }
-                    if(!inherits(out, "randomForest")) 
-                      out <- do.call("randomForest::combine", out)
-                    out$call["x"] <- "x"
-                    out$call["y"] <- "y"
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) 
-                    predict(modelFit, newdata),
-                  prob = function(modelFit, newdata, submodels = NULL)
-                    predict(modelFit, newdata, type = "prob"),
-                  predictors = function(x, ...) {
-                    ## After doing some testing, it looks like randomForest
-                    ## will only try to split on plain main effects (instead
-                    ## of interactions or terms like I(x^2).
-                    varIndex <- as.numeric(names(table(x$forest$bestvar)))
-                    varIndex <- varIndex[varIndex > 0]
-                    varsUsed <- names(x$forest$ncat)[varIndex]
-                    varsUsed
-                  },
-                  varImp = function(object, ...){
-                    varImp <- randomForest::importance(object, ...)
-                    if(object$type == "regression")
-                      varImp <- data.frame(Overall = varImp[,"%IncMSE"])
-                    else {
-                      retainNames <- levels(object$y)
-                      if(all(retainNames %in% colnames(varImp))) {
-                        varImp <- varImp[, retainNames]
-                      } else {
-                        varImp <- data.frame(Overall = varImp[,1])
-                      }
-                    }
-                    
-                    out <- as.data.frame(varImp, stringsAsFactors = TRUE)
-                    if(dim(out)[2] == 2) {
-                      tmp <- apply(out, 1, mean)
-                      out[,1] <- out[,2] <- tmp  
-                    }
-                    out
-                  },
-                  levels = function(x) x$classes,
-                  tags = c("Random Forest", "Ensemble Model", "Bagging", "Implicit Feature Selection"),
-                  sort = function(x) x[order(x[,1]),],
-                  oob = function(x) {
-                    out <- switch(x$type,
-                                  regression =   c(sqrt(max(x$mse[length(x$mse)], 0)), x$rsq[length(x$rsq)]),
-                                  classification =  c(1 - x$err.rate[x$ntree, "OOB"],
-                                                      e1071::classAgreement(x$confusion[,-dim(x$confusion)[2]])[["kappa"]]))
-                    names(out) <- if(x$type == "regression") c("RMSE", "Rsquared") else c("Accuracy", "Kappa")
-                    out
-                  })
+modelInfo <- list(
+  label = "Parallel Random Forest",
+  library = c("e1071", "randomForest", "foreach", "import"),
+  loop = NULL,
+  type = c("Classification", "Regression"),
+  parameters = data.frame(
+    parameter = "mtry",
+    class = "numeric",
+    label = "#Randomly Selected Predictors"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(
+        mtry = caret::var_seq(
+          p = ncol(x),
+          classification = is.factor(y),
+          len = len
+        )
+      )
+    } else {
+      out <- data.frame(
+        mtry = unique(sample(1:ncol(x), size = len, replace = TRUE))
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    workers <- foreach::getDoParWorkers()
+    import::from(foreach, `%dopar%`)
+    theDots <- list(...)
+    theDots$ntree <- if (is.null(theDots$ntree)) {
+      formals(randomForest:::randomForest.default)$ntree
+    } else {
+      theDots$ntree
+    }
+
+    theDots$x <- x
+    theDots$y <- y
+    theDots$mtry <- param$mtry
+    theDots$ntree <- ceiling(theDots$ntree / workers)
+    iter_seeds <- sample.int(10000, size = workers)
+    out <- foreach::foreach(
+      ntree = 1:workers,
+      .combine = randomForest::combine
+    ) %dopar%
+      {
+        set.seed(iter_seeds[workers])
+        do.call(randomForest::randomForest, theDots)
+      }
+    if (!inherits(out, "randomForest")) {
+      out <- do.call("randomForest::combine", out)
+    }
+    out$call["x"] <- "x"
+    out$call["y"] <- "y"
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata, type = "prob")
+  },
+  predictors = function(x, ...) {
+    ## After doing some testing, it looks like randomForest
+    ## will only try to split on plain main effects (instead
+    ## of interactions or terms like I(x^2).
+    varIndex <- as.numeric(names(table(x$forest$bestvar)))
+    varIndex <- varIndex[varIndex > 0]
+    varsUsed <- names(x$forest$ncat)[varIndex]
+    varsUsed
+  },
+  varImp = function(object, ...) {
+    varImp <- randomForest::importance(object, ...)
+    if (object$type == "regression") {
+      varImp <- data.frame(Overall = varImp[, "%IncMSE"])
+    } else {
+      retainNames <- levels(object$y)
+      if (all(retainNames %in% colnames(varImp))) {
+        varImp <- varImp[, retainNames]
+      } else {
+        varImp <- data.frame(Overall = varImp[, 1])
+      }
+    }
+
+    out <- as.data.frame(varImp, stringsAsFactors = TRUE)
+    if (dim(out)[2] == 2) {
+      tmp <- apply(out, 1, mean)
+      out[, 1] <- out[, 2] <- tmp
+    }
+    out
+  },
+  levels = function(x) x$classes,
+  tags = c(
+    "Random Forest",
+    "Ensemble Model",
+    "Bagging",
+    "Implicit Feature Selection"
+  ),
+  sort = function(x) x[order(x[, 1]), ],
+  oob = function(x) {
+    out <- switch(
+      x$type,
+      regression = c(sqrt(max(x$mse[length(x$mse)], 0)), x$rsq[length(x$rsq)]),
+      classification = c(
+        1 - x$err.rate[x$ntree, "OOB"],
+        e1071::classAgreement(x$confusion[, -dim(x$confusion)[2]])[["kappa"]]
+      )
+    )
+    names(out) <- if (x$type == "regression") {
+      c("RMSE", "Rsquared")
+    } else {
+      c("Accuracy", "Kappa")
+    }
+    out
+  }
+)

--- a/inst/model_sources/files/partDSA.R
+++ b/inst/model_sources/files/partDSA.R
@@ -99,7 +99,9 @@ modelInfo <- list(
     if (is.null(cuts) & !is.null(x$tuneValue)) {
       cuts <- x$tuneValue$cut.off.growth[1]
     } else {
-      if (is.null(cuts)) stop("please supply a value for 'cuts'")
+      if (is.null(cuts)) {
+        stop("please supply a value for 'cuts'")
+      }
     }
     tmp <- x$var.importance[, cuts]
     names(tmp)[which(tmp != 0)]
@@ -111,7 +113,9 @@ modelInfo <- list(
     if (is.null(cuts) & !is.null(object$tuneValue)) {
       cuts <- object$tuneValue$cut.off.growth[1]
     } else {
-      if (is.null(cuts)) stop("please supply a value for 'cuts'")
+      if (is.null(cuts)) {
+        stop("please supply a value for 'cuts'")
+      }
     }
     tmp <- object$var.importance[, cuts]
     out <- data.frame(Overall = tmp)

--- a/inst/model_sources/files/partDSA.R
+++ b/inst/model_sources/files/partDSA.R
@@ -1,98 +1,122 @@
-modelInfo <- list(label = "partDSA",
-                  library = "partDSA",
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('cut.off.growth', 'MPD'),
-                                          class = c("numeric", "numeric"),
-                                          label = c('Number of Terminal Partitions', 'Minimum Percent Difference')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(cut.off.growth = 1:len, MPD = .1)
-                    } else {
-                      out <- data.frame(cut.off.growth = sample(1:20, size = len, replace = TRUE),
-                                        MPD = runif(len, min = 0, max = .5))
-                    }
-                    out
-                  },
-                  loop = function(grid) {   
-                    grid <- grid[order(grid$MPD, grid$cut.off.growth, decreasing = TRUE),, drop = FALSE]
-                    
-                    uniqueMPD <- unique(grid$MPD)
-                    
-                    loop <- data.frame(MPD = uniqueMPD)
-                    loop$cut.off.growth <- NA
-                    
-                    submodels <- vector(mode = "list", length = length(uniqueMPD))
-                    
-                    for(i in seq(along = uniqueMPD)) {
-                      subCuts <- grid[grid$MPD == uniqueMPD[i],"cut.off.growth"]
-                      loop$cut.off.growth[loop$MPD == uniqueMPD[i]] <- subCuts[which.max(subCuts)]
-                      submodels[[i]] <- data.frame(cut.off.growth = subCuts[-which.max(subCuts)])
-                    }
-                    list(loop = loop, submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    if(!is.data.frame(x) | inherits(x, "tbl_df")) 
-                      x <- as.data.frame(x, stringsAsFactors = TRUE)
-                    partDSA::partDSA(x, y,
-                                     control = partDSA::DSA.control(
-                                       cut.off.growth = param$cut.off.growth,
-                                       MPD = param$MPD,
-                                       vfold = 1),
-                                     ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata) | inherits(newdata, "tbl_df")) 
-                      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    if(!is.null(submodels)) {
-                      tmp <- c(modelFit$tuneValue$cut.off.growth, submodels$cut.off.growth)
-                      
-                      ## There are cases where the number of models saved by the function is
-                      ## less than the values in cut.off.growth (e.g. cut.off.growth = 1:10
-                      ## but partDSA only has 6 partitions). We will predict the "overage" using
-                      ## the largest model in the obejct (e.g. models 7:10 predicted by model 6).
-                      if(modelFit$problemType == "Classification") {
-                        out <- partDSA::predict.dsa(modelFit, newdata)
-                        if(max(tmp) > length(out)) tmp[tmp > length(out)] <- length(out)
-                        out <- out[tmp]
-                      } else {
-                        out <- partDSA::predict.dsa(modelFit, newdata)
-                        if(max(tmp) > ncol(out)) tmp[tmp > ncol(out)] <- ncol(out)
-                        out <- out[,tmp, drop= FALSE]
-                        out <- as.list(as.data.frame(out, stringsAsFactors = TRUE))
-                      }
-                    } else {
-                      ## There maybe less items than modelFit$cut.off.growth
-                      index <- min(modelFit$cut.off.growth, length(modelFit$test.set.risk.DSA))
-                      ## use best Tune
-                      if(modelFit$problemType == "Classification") {
-                        out <- as.character(partDSA::predict.dsa(modelFit, newdata)[[index]])
-                      } else {
-                        out <- partDSA::predict.dsa(modelFit, newdata)[,index]
-                      }
-                    }
-                    out        
-                  },
-                  predictors = function(x, cuts = NULL, ...) {
-                    if(is.null(cuts) & !is.null(x$tuneValue)) {
-                      cuts <- x$tuneValue$cut.off.growth[1]
-                    } else {
-                      if(is.null(cuts)) stop("please supply a value for 'cuts'")
-                    }
-                    tmp <- x$var.importance[,cuts]
-                    names(tmp)[which(tmp != 0)]
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = "",
-                  prob = NULL,
-                  varImp = function(object, cuts = NULL, ...) {
-                    if(is.null(cuts) & !is.null(object$tuneValue)) {
-                      cuts <- object$tuneValue$cut.off.growth[1]
-                    } else {
-                      if(is.null(cuts)) stop("please supply a value for 'cuts'")
-                    }
-                    tmp <- object$var.importance[,cuts]
-                    out <- data.frame(Overall = tmp)
-                    rownames(out) <- names(tmp)
-                    out
-                  },
-                  sort = function(x) x[order(x$cut.off.growth, x$MPD),])
+modelInfo <- list(
+  label = "partDSA",
+  library = "partDSA",
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c('cut.off.growth', 'MPD'),
+    class = c("numeric", "numeric"),
+    label = c('Number of Terminal Partitions', 'Minimum Percent Difference')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(cut.off.growth = 1:len, MPD = .1)
+    } else {
+      out <- data.frame(
+        cut.off.growth = sample(1:20, size = len, replace = TRUE),
+        MPD = runif(len, min = 0, max = .5)
+      )
+    }
+    out
+  },
+  loop = function(grid) {
+    grid <- grid[
+      order(grid$MPD, grid$cut.off.growth, decreasing = TRUE),
+      ,
+      drop = FALSE
+    ]
+
+    uniqueMPD <- unique(grid$MPD)
+
+    loop <- data.frame(MPD = uniqueMPD)
+    loop$cut.off.growth <- NA
+
+    submodels <- vector(mode = "list", length = length(uniqueMPD))
+
+    for (i in seq(along = uniqueMPD)) {
+      subCuts <- grid[grid$MPD == uniqueMPD[i], "cut.off.growth"]
+      loop$cut.off.growth[loop$MPD == uniqueMPD[i]] <- subCuts[which.max(
+        subCuts
+      )]
+      submodels[[i]] <- data.frame(
+        cut.off.growth = subCuts[-which.max(subCuts)]
+      )
+    }
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (!is.data.frame(x) | inherits(x, "tbl_df")) {
+      x <- as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    partDSA::partDSA(
+      x,
+      y,
+      control = partDSA::DSA.control(
+        cut.off.growth = param$cut.off.growth,
+        MPD = param$MPD,
+        vfold = 1
+      ),
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata) | inherits(newdata, "tbl_df")) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    if (!is.null(submodels)) {
+      tmp <- c(modelFit$tuneValue$cut.off.growth, submodels$cut.off.growth)
+
+      ## There are cases where the number of models saved by the function is
+      ## less than the values in cut.off.growth (e.g. cut.off.growth = 1:10
+      ## but partDSA only has 6 partitions). We will predict the "overage" using
+      ## the largest model in the obejct (e.g. models 7:10 predicted by model 6).
+      if (modelFit$problemType == "Classification") {
+        out <- partDSA::predict.dsa(modelFit, newdata)
+        if (max(tmp) > length(out)) {
+          tmp[tmp > length(out)] <- length(out)
+        }
+        out <- out[tmp]
+      } else {
+        out <- partDSA::predict.dsa(modelFit, newdata)
+        if (max(tmp) > ncol(out)) {
+          tmp[tmp > ncol(out)] <- ncol(out)
+        }
+        out <- out[, tmp, drop = FALSE]
+        out <- as.list(as.data.frame(out, stringsAsFactors = TRUE))
+      }
+    } else {
+      ## There maybe less items than modelFit$cut.off.growth
+      index <- min(modelFit$cut.off.growth, length(modelFit$test.set.risk.DSA))
+      ## use best Tune
+      if (modelFit$problemType == "Classification") {
+        out <- as.character(partDSA::predict.dsa(modelFit, newdata)[[index]])
+      } else {
+        out <- partDSA::predict.dsa(modelFit, newdata)[, index]
+      }
+    }
+    out
+  },
+  predictors = function(x, cuts = NULL, ...) {
+    if (is.null(cuts) & !is.null(x$tuneValue)) {
+      cuts <- x$tuneValue$cut.off.growth[1]
+    } else {
+      if (is.null(cuts)) stop("please supply a value for 'cuts'")
+    }
+    tmp <- x$var.importance[, cuts]
+    names(tmp)[which(tmp != 0)]
+  },
+  levels = function(x) x$obsLevels,
+  tags = "",
+  prob = NULL,
+  varImp = function(object, cuts = NULL, ...) {
+    if (is.null(cuts) & !is.null(object$tuneValue)) {
+      cuts <- object$tuneValue$cut.off.growth[1]
+    } else {
+      if (is.null(cuts)) stop("please supply a value for 'cuts'")
+    }
+    tmp <- object$var.importance[, cuts]
+    out <- data.frame(Overall = tmp)
+    rownames(out) <- names(tmp)
+    out
+  },
+  sort = function(x) x[order(x$cut.off.growth, x$MPD), ]
+)

--- a/inst/model_sources/files/pcaNNet.R
+++ b/inst/model_sources/files/pcaNNet.R
@@ -1,58 +1,77 @@
-modelInfo <- list(label = "Neural Networks with Feature Extraction",
-                  library = "nnet",
-                  loop = NULL,
-                  type = c("Classification", "Regression"),
-                  parameters = data.frame(parameter = c('size', 'decay'),
-                                          class = rep("numeric", 2),
-                                          label = c('#Hidden Units', 'Weight Decay')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(size = ((1:len) * 2) - 1, 
-                                         decay = c(0, 10 ^ seq(-1, -4, length = len - 1)))
-                    } else {
-                      out <- data.frame(size = sample(1:20, size = len, replace = TRUE), 
-                                        decay = 10^runif(len, min = -5, 1))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    if(!is.null(wts))
-                    {
-                      out <- caret::pcaNNet(.outcome ~ .,
-                                           data = dat,
-                                          weights = wts,
-                                          size = param$size,
-                                          decay = param$decay,
-                                          ...)
-                    } else out <- caret::pcaNNet(.outcome ~ .,
-                                                data = dat,
-                                                size = param$size,
-                                                decay = param$decay,
-                                                ...)
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL)
-                  {
-                    if(modelFit$problemType == "Classification")
-                    {
-                      out <- predict(modelFit, newdata, type="class")
-                    } else {
-                      out  <- predict(modelFit, newdata, type="raw")
-                    }
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL){
-                    out <- predict(modelFit, newdata, type = "prob")
-                    if(ncol(as.data.frame(out, stringsAsFactors = TRUE)) == 1)
-                    {
-                      out <- cbind(out, 1-out)
-                      dimnames(out)[[2]] <-  rev(modelFit$obsLevels)
-                    }
-                    out
-                  },
-                  predictors = function(x, ...) rownames(x$pc$rotation),
-                  levels = function(x) x$model$lev,
-                  tags = c("Neural Network", "Feature Extraction", "L2 Regularization", "Accepts Case Weights"),
-                  sort = function(x) x[order(x$size, -x$decay),])
+modelInfo <- list(
+  label = "Neural Networks with Feature Extraction",
+  library = "nnet",
+  loop = NULL,
+  type = c("Classification", "Regression"),
+  parameters = data.frame(
+    parameter = c('size', 'decay'),
+    class = rep("numeric", 2),
+    label = c('#Hidden Units', 'Weight Decay')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        size = ((1:len) * 2) - 1,
+        decay = c(0, 10^seq(-1, -4, length = len - 1))
+      )
+    } else {
+      out <- data.frame(
+        size = sample(1:20, size = len, replace = TRUE),
+        decay = 10^runif(len, min = -5, 1)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    if (!is.null(wts)) {
+      out <- caret::pcaNNet(
+        .outcome ~ .,
+        data = dat,
+        weights = wts,
+        size = param$size,
+        decay = param$decay,
+        ...
+      )
+    } else {
+      out <- caret::pcaNNet(
+        .outcome ~ .,
+        data = dat,
+        size = param$size,
+        decay = param$decay,
+        ...
+      )
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (modelFit$problemType == "Classification") {
+      out <- predict(modelFit, newdata, type = "class")
+    } else {
+      out <- predict(modelFit, newdata, type = "raw")
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata, type = "prob")
+    if (ncol(as.data.frame(out, stringsAsFactors = TRUE)) == 1) {
+      out <- cbind(out, 1 - out)
+      dimnames(out)[[2]] <- rev(modelFit$obsLevels)
+    }
+    out
+  },
+  predictors = function(x, ...) rownames(x$pc$rotation),
+  levels = function(x) x$model$lev,
+  tags = c(
+    "Neural Network",
+    "Feature Extraction",
+    "L2 Regularization",
+    "Accepts Case Weights"
+  ),
+  sort = function(x) x[order(x$size, -x$decay), ]
+)

--- a/inst/model_sources/files/pcaNNet.R
+++ b/inst/model_sources/files/pcaNNet.R
@@ -23,10 +23,10 @@ modelInfo <- list(
     out
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     if (!is.null(wts)) {

--- a/inst/model_sources/files/pcr.R
+++ b/inst/model_sources/files/pcr.R
@@ -25,10 +25,10 @@ modelInfo <- list(
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
     ncomp <- min(ncol(x), param$ncomp)
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     pls::pcr(.outcome ~ ., data = dat, ncomp = ncomp, ...)

--- a/inst/model_sources/files/pcr.R
+++ b/inst/model_sources/files/pcr.R
@@ -1,41 +1,58 @@
-modelInfo <- list(label = "Principal Component Analysis",
-                  library = "pls",
-                  type = "Regression",
-                  parameters = data.frame(parameter = 'ncomp',
-                                          class = "numeric",
-                                          label = '#Components'),
-                  grid = function(x, y, len = NULL, search = "grid")  {
-                    if(search == "grid") {
-                      out <- data.frame(ncomp = seq(1, min(ncol(x) - 1, len), by = 1))
-                    } else {
-                      out <- data.frame(ncomp = unique(sample(1:(ncol(x)-1), size = len, replace = TRUE)))
-                    }
-                    out
-                  },
-                  loop = function(grid) {
-                    grid <- grid[order(grid$ncomp, decreasing = TRUE),, drop = FALSE]
-                    loop <- grid[1,,drop = FALSE]
-                    submodels <- list(grid[-1,,drop = FALSE])
-                    list(loop = loop, submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    ncomp <- min(ncol(x), param$ncomp)
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    pls::pcr(.outcome ~ ., data = dat, ncomp = ncomp, ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- as.vector(pls:::predict.mvr(modelFit, newdata, ncomp = max(modelFit$ncomp)))
+modelInfo <- list(
+  label = "Principal Component Analysis",
+  library = "pls",
+  type = "Regression",
+  parameters = data.frame(
+    parameter = 'ncomp',
+    class = "numeric",
+    label = '#Components'
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(ncomp = seq(1, min(ncol(x) - 1, len), by = 1))
+    } else {
+      out <- data.frame(
+        ncomp = unique(sample(1:(ncol(x) - 1), size = len, replace = TRUE))
+      )
+    }
+    out
+  },
+  loop = function(grid) {
+    grid <- grid[order(grid$ncomp, decreasing = TRUE), , drop = FALSE]
+    loop <- grid[1, , drop = FALSE]
+    submodels <- list(grid[-1, , drop = FALSE])
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    ncomp <- min(ncol(x), param$ncomp)
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    pls::pcr(.outcome ~ ., data = dat, ncomp = ncomp, ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- as.vector(pls:::predict.mvr(
+      modelFit,
+      newdata,
+      ncomp = max(modelFit$ncomp)
+    ))
 
-                    if(!is.null(submodels))
-                    {
-                      tmp <- apply(predict(modelFit, newdata, ncomp = submodels$ncomp), 3, function(x) list(x))
-                      tmp <-  as.data.frame(tmp, stringsAsFactors = TRUE)
-                      out <- c(list(out), as.list(tmp))
-                    }
-                    out
-                  },
-                  predictors = function(x, ...) rownames(x$projection),
-                  tags = c("Linear Regression", "Feature Extraction"),
-                  prob = NULL,
-                  sort = function(x) x[order(x[,1]),])
+    if (!is.null(submodels)) {
+      tmp <- apply(
+        predict(modelFit, newdata, ncomp = submodels$ncomp),
+        3,
+        function(x) list(x)
+      )
+      tmp <- as.data.frame(tmp, stringsAsFactors = TRUE)
+      out <- c(list(out), as.list(tmp))
+    }
+    out
+  },
+  predictors = function(x, ...) rownames(x$projection),
+  tags = c("Linear Regression", "Feature Extraction"),
+  prob = NULL,
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/pda.R
+++ b/inst/model_sources/files/pda.R
@@ -17,10 +17,10 @@ modelInfo <- list(
     out
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     if (!is.null(wts)) {

--- a/inst/model_sources/files/pda.R
+++ b/inst/model_sources/files/pda.R
@@ -1,42 +1,55 @@
-modelInfo <- list(label = "Penalized Discriminant Analysis",
-                  library = "mda",
-                  loop = NULL,
-                  type = c('Classification'),
-                  parameters = data.frame(parameter = c('lambda'),
-                                          class = c('numeric'),
-                                          label = c('Shrinkage Penalty Coefficient')),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- data.frame(lambda =  c(0, 10 ^ seq(-1, -4, length = len - 1)))
-                    } else {
-                      out <- data.frame(lambda = 10^runif(len, min = -5, 1))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    if(!is.null(wts))
-                    {
-                      out <- mda::fda(as.formula(".outcome ~ ."),
-                                      data = dat,
-                                      method = mda::gen.ridge,
-                                      weights = wts,
-                                      lambda = param$lambda,
-                                      ...)
-                    } else {
-                      out <- mda::fda(as.formula(".outcome ~ ."),
-                                      data = dat,
-                                      method = mda::gen.ridge,
-                                      lambda = param$lambda,
-                                      ...)
-                    }
-                    out                   
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) 
-                    predict(modelFit, newdata),
-                  prob = function(modelFit, newdata, submodels = NULL)
-                    predict(modelFit, newdata, type = "posterior"),
-                  levels = function(x) x$obsLevels,
-                  tags = c("Discriminant Analysis", "Polynomial Model", "Accepts Case Weights"),
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Penalized Discriminant Analysis",
+  library = "mda",
+  loop = NULL,
+  type = c('Classification'),
+  parameters = data.frame(
+    parameter = c('lambda'),
+    class = c('numeric'),
+    label = c('Shrinkage Penalty Coefficient')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(lambda = c(0, 10^seq(-1, -4, length = len - 1)))
+    } else {
+      out <- data.frame(lambda = 10^runif(len, min = -5, 1))
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    if (!is.null(wts)) {
+      out <- mda::fda(
+        as.formula(".outcome ~ ."),
+        data = dat,
+        method = mda::gen.ridge,
+        weights = wts,
+        lambda = param$lambda,
+        ...
+      )
+    } else {
+      out <- mda::fda(
+        as.formula(".outcome ~ ."),
+        data = dat,
+        method = mda::gen.ridge,
+        lambda = param$lambda,
+        ...
+      )
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata, type = "posterior")
+  },
+  levels = function(x) x$obsLevels,
+  tags = c("Discriminant Analysis", "Polynomial Model", "Accepts Case Weights"),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/pda2.R
+++ b/inst/model_sources/files/pda2.R
@@ -17,10 +17,10 @@ modelInfo <- list(
     out
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     if (!is.null(wts)) {

--- a/inst/model_sources/files/pda2.R
+++ b/inst/model_sources/files/pda2.R
@@ -1,42 +1,55 @@
-modelInfo <- list(label = "Penalized Discriminant Analysis",
-                  library = "mda",
-                  loop = NULL,
-                  type = c('Classification'),
-                  parameters = data.frame(parameter = c('df'),
-                                          class = c('numeric'),
-                                          label = c('Degrees of Freedom')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- data.frame(df = 2* (0:(len - 1) + 1))
-                    } else {
-                      out <- data.frame(df = runif(len, min = 1, max = 5))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    if(!is.null(wts))
-                    {
-                      out <- mda::fda(as.formula(".outcome ~ ."),
-                                      data = dat,
-                                      method = mda::gen.ridge,
-                                      weights = wts,
-                                      df = param$df,
-                                      ...)
-                    } else {
-                      out <- mda::fda(as.formula(".outcome ~ ."),
-                                      data = dat,
-                                      method = mda::gen.ridge,
-                                      df = param$df,
-                                      ...)
-                    }
-                    out                   
-                  },
-                  levels = function(x) x$obsLevels,
-                  predict = function(modelFit, newdata, submodels = NULL) 
-                    predict(modelFit, newdata),
-                  prob = function(modelFit, newdata, submodels = NULL)
-                    predict(modelFit, newdata, type = "posterior"),
-                  tags = c("Discriminant Analysis", "Polynomial Model", "Accepts Case Weights"),
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Penalized Discriminant Analysis",
+  library = "mda",
+  loop = NULL,
+  type = c('Classification'),
+  parameters = data.frame(
+    parameter = c('df'),
+    class = c('numeric'),
+    label = c('Degrees of Freedom')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(df = 2 * (0:(len - 1) + 1))
+    } else {
+      out <- data.frame(df = runif(len, min = 1, max = 5))
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    if (!is.null(wts)) {
+      out <- mda::fda(
+        as.formula(".outcome ~ ."),
+        data = dat,
+        method = mda::gen.ridge,
+        weights = wts,
+        df = param$df,
+        ...
+      )
+    } else {
+      out <- mda::fda(
+        as.formula(".outcome ~ ."),
+        data = dat,
+        method = mda::gen.ridge,
+        df = param$df,
+        ...
+      )
+    }
+    out
+  },
+  levels = function(x) x$obsLevels,
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata, type = "posterior")
+  },
+  tags = c("Discriminant Analysis", "Polynomial Model", "Accepts Case Weights"),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/penalized.R
+++ b/inst/model_sources/files/penalized.R
@@ -1,40 +1,51 @@
-modelInfo <- list(label = "Penalized Linear Regression",
-                  library = "penalized",
-                  type = c('Regression'),
-                  parameters = data.frame(parameter = c('lambda1', 'lambda2'),
-                                          class = c('numeric', 'numeric'),
-                                          label = c('L1 Penalty', 'L2 Penalty')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(lambda1 = 2^((1:len) -1),
-                                         lambda2 = 2^((1:len) -1))
-                    } else {
-                      out <- data.frame(lambda1 = 10^runif(len, min = -5, 1), 
-                                        lambda2 = 10^runif(len, min = -5, 1))
-                    }
-                    out
-                  },
-                    
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    penalized::penalized(y, x,
-                                         model = "linear",
-                                         lambda1 = param$lambda1,
-                                         lambda2 = param$lambda2,
-                                         ...) 
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- penalized::predict(modelFit, newdata)
-                    out <- if(is.vector(out)) out["mu"] else out[,"mu"]
-                    out
-                  },
-                  prob = NULL,
-                  predictors = function(x, ...) {
-                    out <- coef(x, "all")
-                    out <- names(out)[out != 0]
-                    out[out != "(Intercept)"]
-                  },
-                  tags = c("Implicit Feature Selection", 
-                           "L1 Regularization", "L2 Regularization",
-                           "Linear Regression"),
-                  sort = function(x) x[order(x$lambda1, x$lambda2),])
+modelInfo <- list(
+  label = "Penalized Linear Regression",
+  library = "penalized",
+  type = c('Regression'),
+  parameters = data.frame(
+    parameter = c('lambda1', 'lambda2'),
+    class = c('numeric', 'numeric'),
+    label = c('L1 Penalty', 'L2 Penalty')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(lambda1 = 2^((1:len) - 1), lambda2 = 2^((1:len) - 1))
+    } else {
+      out <- data.frame(
+        lambda1 = 10^runif(len, min = -5, 1),
+        lambda2 = 10^runif(len, min = -5, 1)
+      )
+    }
+    out
+  },
+
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    penalized::penalized(
+      y,
+      x,
+      model = "linear",
+      lambda1 = param$lambda1,
+      lambda2 = param$lambda2,
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- penalized::predict(modelFit, newdata)
+    out <- if (is.vector(out)) out["mu"] else out[, "mu"]
+    out
+  },
+  prob = NULL,
+  predictors = function(x, ...) {
+    out <- coef(x, "all")
+    out <- names(out)[out != 0]
+    out[out != "(Intercept)"]
+  },
+  tags = c(
+    "Implicit Feature Selection",
+    "L1 Regularization",
+    "L2 Regularization",
+    "Linear Regression"
+  ),
+  sort = function(x) x[order(x$lambda1, x$lambda2), ]
+)

--- a/inst/model_sources/files/penalized.R
+++ b/inst/model_sources/files/penalized.R
@@ -32,7 +32,11 @@ modelInfo <- list(
   },
   predict = function(modelFit, newdata, submodels = NULL) {
     out <- penalized::predict(modelFit, newdata)
-    out <- if (is.vector(out)) out["mu"] else out[, "mu"]
+    if (is.vector(out)) {
+      out <- out["mu"]
+    } else {
+      out <- out[, "mu"]
+    }
     out
   },
   prob = NULL,

--- a/inst/model_sources/files/plr.R
+++ b/inst/model_sources/files/plr.R
@@ -1,41 +1,55 @@
-modelInfo <- list(label = "Penalized Logistic Regression",
-                  library = "stepPlr",
-                  loop = NULL,
-                  type = c('Classification'),
-                  parameters = data.frame(parameter = c('lambda', 'cp'),
-                                          class = c('numeric', 'character'),
-                                          label = c('L2 Penalty', 'Complexity Parameter')),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <-  expand.grid(cp = "bic", 
-                                          lambda = c(0, 10 ^ seq(-1, -4, length = len - 1)))
-                    } else {
-                      out <- data.frame(cp = sample(c("aic", "bic"), size = len, replace = TRUE), 
-                                        lambda = 10^runif(len, min = -5, 1))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...){
-                    if(!is.matrix(x)) 
-                      x <- as.matrix(x)
-                    y <- ifelse(y == levels(y)[1], 1, 0)
-                    stepPlr::plr(x, y,
-                                 lambda = param$lambda,
-                                 cp = as.character(param$cp),
-                                 weights = if(!is.null(wts)) wts else rep(1,length(y)), 
-                                 ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL)  {
-                    ifelse(stepPlr::predict.plr(modelFit, as.matrix(newdata), type = "class") == 1,
-                           modelFit$obsLevels[1],
-                           modelFit$obsLevels[2])
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- stepPlr::predict.plr(modelFit, as.matrix(newdata), type = "response")
-                    out <- cbind(out, 1-out)
-                    dimnames(out)[[2]] <-  modelFit$obsLevels
-                    out
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("L2 Regularization", "Logistic Regression", "Linear Classifier"),
-                  sort = function(x) x[order(-x$lambda),])
+modelInfo <- list(
+  label = "Penalized Logistic Regression",
+  library = "stepPlr",
+  loop = NULL,
+  type = c('Classification'),
+  parameters = data.frame(
+    parameter = c('lambda', 'cp'),
+    class = c('numeric', 'character'),
+    label = c('L2 Penalty', 'Complexity Parameter')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        cp = "bic",
+        lambda = c(0, 10^seq(-1, -4, length = len - 1))
+      )
+    } else {
+      out <- data.frame(
+        cp = sample(c("aic", "bic"), size = len, replace = TRUE),
+        lambda = 10^runif(len, min = -5, 1)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (!is.matrix(x)) {
+      x <- as.matrix(x)
+    }
+    y <- ifelse(y == levels(y)[1], 1, 0)
+    stepPlr::plr(
+      x,
+      y,
+      lambda = param$lambda,
+      cp = as.character(param$cp),
+      weights = if (!is.null(wts)) wts else rep(1, length(y)),
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    ifelse(
+      stepPlr::predict.plr(modelFit, as.matrix(newdata), type = "class") == 1,
+      modelFit$obsLevels[1],
+      modelFit$obsLevels[2]
+    )
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- stepPlr::predict.plr(modelFit, as.matrix(newdata), type = "response")
+    out <- cbind(out, 1 - out)
+    dimnames(out)[[2]] <- modelFit$obsLevels
+    out
+  },
+  levels = function(x) x$obsLevels,
+  tags = c("L2 Regularization", "Logistic Regression", "Linear Classifier"),
+  sort = function(x) x[order(-x$lambda), ]
+)

--- a/inst/model_sources/files/pls.R
+++ b/inst/model_sources/files/pls.R
@@ -23,16 +23,16 @@ modelInfo <- list(
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
     ncomp <- min(ncol(x), param$ncomp)
-    out <- if (is.factor(y)) {
-      plsda(x, y, method = "oscorespls", ncomp = ncomp, ...)
+    if (is.factor(y)) {
+      out <- plsda(x, y, method = "oscorespls", ncomp = ncomp, ...)
     } else {
-      dat <- if (is.data.frame(x)) {
-        x
+      if (is.data.frame(x)) {
+        dat <- x
       } else {
-        as.data.frame(x, stringsAsFactors = TRUE)
+        dat <- as.data.frame(x, stringsAsFactors = TRUE)
       }
       dat$.outcome <- y
-      pls::plsr(
+      out <- pls::plsr(
         .outcome ~ .,
         data = dat,
         method = "oscorespls",
@@ -43,13 +43,13 @@ modelInfo <- list(
     out
   },
   predict = function(modelFit, newdata, submodels = NULL) {
-    out <- if (modelFit$problemType == "Classification") {
+    if (modelFit$problemType == "Classification") {
       if (!is.matrix(newdata)) {
         newdata <- as.matrix(newdata)
       }
       out <- predict(modelFit, newdata, type = "class")
     } else {
-      as.vector(pls:::predict.mvr(
+      out <- as.vector(pls:::predict.mvr(
         modelFit,
         newdata,
         ncomp = max(modelFit$ncomp)
@@ -130,7 +130,11 @@ modelInfo <- list(
 
     nms <- dimnames(perf)
     if (length(nms$estimate) > 1) {
-      pIndex <- if (is.null(estimate)) 1 else which(nms$estimate == estimate)
+      if (is.null(estimate)) {
+        pIndex <- 1
+      } else {
+        pIndex <- which(nms$estimate == estimate)
+      }
       perf <- perf[pIndex, , , drop = FALSE]
     }
     numResp <- dim(modelCoef)[2]

--- a/inst/model_sources/files/pls.R
+++ b/inst/model_sources/files/pls.R
@@ -1,136 +1,176 @@
-modelInfo <- list(label = "Partial Least Squares",
-                  library = "pls",
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = 'ncomp',
-                                          class = "numeric",
-                                          label = '#Components'),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- data.frame(ncomp = seq(1, min(ncol(x) - 1, len), by = 1))
-                    } else {
-                      out <- data.frame(ncomp = unique(sample(1:ncol(x), replace = TRUE)))
-                    }
-                    out
-                  },
-                  loop = function(grid) {
-                    grid <- grid[order(grid$ncomp, decreasing = TRUE),, drop = FALSE]
-                    loop <- grid[1,,drop = FALSE]
-                    submodels <- list(grid[-1,,drop = FALSE])
-                    list(loop = loop, submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    ncomp <- min(ncol(x), param$ncomp)
-                    out <- if(is.factor(y))
-                    {
-                      plsda(x, y, method = "oscorespls", ncomp = ncomp, ...)
-                    } else {
-                      dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                      dat$.outcome <- y
-                      pls::plsr(.outcome ~ ., data = dat, method = "oscorespls", ncomp = ncomp, ...)
-                    }
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- if(modelFit$problemType == "Classification")
-                    {
-                      if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                      out <- predict(modelFit, newdata, type="class")
+modelInfo <- list(
+  label = "Partial Least Squares",
+  library = "pls",
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = 'ncomp',
+    class = "numeric",
+    label = '#Components'
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(ncomp = seq(1, min(ncol(x) - 1, len), by = 1))
+    } else {
+      out <- data.frame(ncomp = unique(sample(1:ncol(x), replace = TRUE)))
+    }
+    out
+  },
+  loop = function(grid) {
+    grid <- grid[order(grid$ncomp, decreasing = TRUE), , drop = FALSE]
+    loop <- grid[1, , drop = FALSE]
+    submodels <- list(grid[-1, , drop = FALSE])
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    ncomp <- min(ncol(x), param$ncomp)
+    out <- if (is.factor(y)) {
+      plsda(x, y, method = "oscorespls", ncomp = ncomp, ...)
+    } else {
+      dat <- if (is.data.frame(x)) {
+        x
+      } else {
+        as.data.frame(x, stringsAsFactors = TRUE)
+      }
+      dat$.outcome <- y
+      pls::plsr(
+        .outcome ~ .,
+        data = dat,
+        method = "oscorespls",
+        ncomp = ncomp,
+        ...
+      )
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- if (modelFit$problemType == "Classification") {
+      if (!is.matrix(newdata)) {
+        newdata <- as.matrix(newdata)
+      }
+      out <- predict(modelFit, newdata, type = "class")
+    } else {
+      as.vector(pls:::predict.mvr(
+        modelFit,
+        newdata,
+        ncomp = max(modelFit$ncomp)
+      ))
+    }
 
-                    } else as.vector(pls:::predict.mvr(modelFit, newdata, ncomp = max(modelFit$ncomp)))
+    if (!is.null(submodels)) {
+      ## We'll merge the first set of predictions below
+      tmp <- vector(mode = "list", length = nrow(submodels))
 
-                    if(!is.null(submodels))
-                    {
-                      ## We'll merge the first set of predictions below
-                      tmp <- vector(mode = "list", length = nrow(submodels))
+      if (modelFit$problemType == "Classification") {
+        if (length(submodels$ncomp) > 1) {
+          tmp <- as.list(predict(modelFit, newdata, ncomp = submodels$ncomp))
+        } else {
+          tmp <- list(predict(modelFit, newdata, ncomp = submodels$ncomp))
+        }
+      } else {
+        tmp <- as.list(
+          as.data.frame(
+            apply(
+              predict(modelFit, newdata, ncomp = submodels$ncomp),
+              3,
+              function(x) list(x)
+            )
+          )
+        )
+      }
 
-                      if(modelFit$problemType == "Classification")
-                      {
-                        if(length(submodels$ncomp) > 1)
-                        {
-                          tmp <- as.list(predict(modelFit, newdata, ncomp = submodels$ncomp))
-                        } else tmp <- list(predict(modelFit, newdata, ncomp = submodels$ncomp))
+      out <- c(list(out), tmp)
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- predict(
+      modelFit,
+      newdata,
+      type = "prob",
+      ncomp = modelFit$tuneValue$ncomp
+    )
+    if (length(dim(out)) == 3) {
+      if (dim(out)[1] > 1) {
+        out <- out[,, 1]
+      } else {
+        out <- as.data.frame(t(out[,, 1]), stringsAsFactors = TRUE)
+      }
+    }
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
 
-                      } else {
-                        tmp <- as.list(
-                          as.data.frame(
-                            apply(predict(modelFit, newdata, ncomp = submodels$ncomp), 3, function(x) list(x))))
-                      }
+      for (j in seq(along = submodels$ncomp)) {
+        tmpProb <- predict(
+          modelFit,
+          newdata,
+          type = "prob",
+          ncomp = submodels$ncomp[j]
+        )
+        if (length(dim(tmpProb)) == 3) {
+          if (dim(tmpProb)[1] > 1) {
+            tmpProb <- tmpProb[,, 1]
+          } else {
+            tmpProb <- as.data.frame(t(tmpProb[,, 1]), stringsAsFactors = TRUE)
+          }
+        }
+        tmp[[j + 1]] <- as.data.frame(tmpProb[, modelFit$obsLevels])
+      }
+      out <- tmp
+    }
+    out
+  },
+  varImp = function(object, estimate = NULL, ...) {
+    library(pls)
+    modelCoef <- coef(object, intercept = FALSE, comps = 1:object$ncomp)
+    perf <- pls:::MSEP.mvr(object)$val
 
-                      out <- c(list(out), tmp)
-                    }
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    out <- predict(modelFit, newdata, type = "prob",  ncomp = modelFit$tuneValue$ncomp)
-                    if(length(dim(out)) == 3){
-                      if(dim(out)[1] > 1) {
-                        out <- out[,,1]
-                      } else {
-                        out <- as.data.frame(t(out[,,1]), stringsAsFactors = TRUE)
-                      }
-                    }
-                    if(!is.null(submodels))
-                    {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
+    nms <- dimnames(perf)
+    if (length(nms$estimate) > 1) {
+      pIndex <- if (is.null(estimate)) 1 else which(nms$estimate == estimate)
+      perf <- perf[pIndex, , , drop = FALSE]
+    }
+    numResp <- dim(modelCoef)[2]
 
-                      for(j in seq(along = submodels$ncomp))
-                      {
-                        tmpProb <- predict(modelFit, newdata, type = "prob",  ncomp = submodels$ncomp[j])
-                        if(length(dim(tmpProb)) == 3){
-                          if(dim(tmpProb)[1] > 1) {
-                            tmpProb <- tmpProb[,,1]
-                          } else {
-                            tmpProb <- as.data.frame(t(tmpProb[,,1]), stringsAsFactors = TRUE)
-                          }
-                        }
-                        tmp[[j+1]] <- as.data.frame(tmpProb[, modelFit$obsLevels])
-                      }
-                      out <- tmp
-                    }
-                    out
-                  },
-                  varImp = function(object, estimate = NULL, ...) {
-                  	library(pls)
-                    modelCoef <- coef(object, intercept = FALSE, comps = 1:object$ncomp)
-                    perf <- pls:::MSEP.mvr(object)$val
+    if (numResp <= 2) {
+      modelCoef <- modelCoef[, 1, , drop = FALSE]
+      perf <- perf[, 1, ]
+      delta <- -diff(perf)
+      delta <- delta / sum(delta)
+      out <- data.frame(
+        Overall = apply(abs(modelCoef), 1, weighted.mean, w = delta)
+      )
+    } else {
+      if (dim(perf)[3] <= 2) {
+        # case ncomp = 1
+        perf <- -t(t(apply(perf[1, , ], 1, diff)))
+        perf <- t(t(apply(perf, 1, function(u) u / sum(u))))
+      } else {
+        perf <- -t(apply(perf[1, , ], 1, diff))
+        perf <- t(apply(perf, 1, function(u) u / sum(u)))
+      }
 
-                    nms <- dimnames(perf)
-                    if(length(nms$estimate) > 1) {
-                      pIndex <- if(is.null(estimate)) 1 else which(nms$estimate == estimate)
-                      perf <- perf[pIndex,,,drop = FALSE]
-                    }
-                    numResp <- dim(modelCoef)[2]
+      out <- matrix(NA, ncol = numResp, nrow = dim(modelCoef)[1])
 
-                    if(numResp <= 2) {
-                      modelCoef <- modelCoef[,1,,drop = FALSE]
-                      perf <- perf[,1,]
-                      delta <- -diff(perf)
-                      delta <- delta/sum(delta)
-                      out <- data.frame(Overall = apply(abs(modelCoef), 1,
-                                                        weighted.mean, w = delta))
-                    } else {       
-                      if(dim(perf)[3]<=2){ # case ncomp = 1
-                        perf <- -t(t(apply(perf[1,,], 1, diff)))
-                        perf <- t(t(apply(perf, 1, function(u) u/sum(u))))
-                      } else {
-                        perf <- -t(apply(perf[1,,], 1, diff))
-                        perf <- t(apply(perf, 1, function(u) u/sum(u)))
-                      }
-
-                      out <- matrix(NA, ncol = numResp, nrow = dim(modelCoef)[1])
-
-                      for(i in 1:numResp) {
-                        tmp <- abs(modelCoef[,i,, drop = FALSE])
-                        out[,i] <- apply(tmp, 1,  weighted.mean, w = perf[i,])
-                      }
-                      colnames(out) <- dimnames(modelCoef)[[2]]
-                      rownames(out) <- dimnames(modelCoef)[[1]]
-                    }
-                    as.data.frame(out, stringsAsFactors = TRUE)
-                  },
-                  predictors = function(x, ...) rownames(x$projection),
-                  levels = function(x) x$obsLevels,
-                  tags = c("Partial Least Squares", "Feature Extraction", "Linear Classifier", "Linear Regression"),
-                  sort = function(x) x[order(x[,1]),])
+      for (i in 1:numResp) {
+        tmp <- abs(modelCoef[, i, , drop = FALSE])
+        out[, i] <- apply(tmp, 1, weighted.mean, w = perf[i, ])
+      }
+      colnames(out) <- dimnames(modelCoef)[[2]]
+      rownames(out) <- dimnames(modelCoef)[[1]]
+    }
+    as.data.frame(out, stringsAsFactors = TRUE)
+  },
+  predictors = function(x, ...) rownames(x$projection),
+  levels = function(x) x$obsLevels,
+  tags = c(
+    "Partial Least Squares",
+    "Feature Extraction",
+    "Linear Classifier",
+    "Linear Regression"
+  ),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/plsRglm.R
+++ b/inst/model_sources/files/plsRglm.R
@@ -1,78 +1,95 @@
-modelInfo <- list(label = "Partial Least Squares Generalized Linear Models ",
-                  library = "plsRglm",
-                  loop = NULL,
-                  type = c("Classification", "Regression"),
-                  parameters = data.frame(parameter = c('nt', 'alpha.pvals.expli'),
-                                          class = c("numeric", "numeric"),
-                                          label = c('#PLS Components', 'p-Value threshold')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <-  expand.grid(nt = 1:len, 
-                                          alpha.pvals.expli = 10^(c(-2:(len-3), 0)))
-                    } else {
-                      out <- data.frame(nt = sample(1:ncol(x), size = len, replace = TRUE), 
-                                        alpha.pvals.expli = runif(len, min = 0, .2))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    require(plsRglm)
-                    if(is.factor(y)) {
-                      lv <- levels(y)
-                      y <- as.numeric(y)  - 1
-                      dst <- "pls-glm-logistic"
-                    } else {
-                      lv <- NULL
-                      dst <- "pls-glm-gaussian"
-                    }
-                    
-                    ## Intercept parameters if needed
-                    theDots <- list(...)
-                    if(any(names(theDots) == "modele")) {
-                      mod <- plsrRglm::plsRglm(y, x, 
-                                     	       nt = param$nt, 
-                                               pvals.expli = param$alpha.pvals.expli < 1,
-                                               sparse  = param$alpha.pvals.expli < 1,
-                                               alpha.pvals.expli = param$alpha.pvals.expli,
-                                               ...)
-                    } else {
-                      mod <- plsRglm::plsRglm(y, x, 
-                                              nt = param$nt, 
-                                              modele = dst, 
-                                              pvals.expli = param$alpha.pvals.expli < 1,
-                                              sparse  = param$alpha.pvals.expli < 1,
-                                              alpha.pvals.expli = param$alpha.pvals.expli,
-                                              ...)
-                    }
-                    mod
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL)
-                  {
-                    out <- predict(modelFit, newdata, type="response")
-                    if(modelFit$problemType == "Classification")
-                    {
-                      out <- factor(ifelse(out >= .5, 
-                                           modelFit$obsLevels[2], 
-                                           modelFit$obsLevels[1]))
-                    } 
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL){
-                    out <- predict(modelFit, newdata, type="response")
-                    out <- cbind(1 - out, out)
-                    dimnames(out)[[2]] <-  rev(modelFit$obsLevels)
-                    out
-                  },
-                  varImp = NULL,
-                  predictors = function(x, ...) {
-                    vars <- names(which(coef(x)[[2]][,1] != 0))
-                    vars[vars != "Intercept"]
-                  },
-                  notes = paste(
-                    "Unlike other packages used by `train`, the `plsRglm`",
-                    "package is fully loaded when this model is used."
-                  ),
-                  tags = c("Generalized Linear Models", 
-                           "Partial Least Squares", "Two Class Only"),
-                  levels = function(x) x$lev,
-                  sort = function(x) x[order(-x$alpha.pvals.expli, x$nt),])
+modelInfo <- list(
+  label = "Partial Least Squares Generalized Linear Models ",
+  library = "plsRglm",
+  loop = NULL,
+  type = c("Classification", "Regression"),
+  parameters = data.frame(
+    parameter = c('nt', 'alpha.pvals.expli'),
+    class = c("numeric", "numeric"),
+    label = c('#PLS Components', 'p-Value threshold')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        nt = 1:len,
+        alpha.pvals.expli = 10^(c(-2:(len - 3), 0))
+      )
+    } else {
+      out <- data.frame(
+        nt = sample(1:ncol(x), size = len, replace = TRUE),
+        alpha.pvals.expli = runif(len, min = 0, .2)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    require(plsRglm)
+    if (is.factor(y)) {
+      lv <- levels(y)
+      y <- as.numeric(y) - 1
+      dst <- "pls-glm-logistic"
+    } else {
+      lv <- NULL
+      dst <- "pls-glm-gaussian"
+    }
+
+    ## Intercept parameters if needed
+    theDots <- list(...)
+    if (any(names(theDots) == "modele")) {
+      mod <- plsrRglm::plsRglm(
+        y,
+        x,
+        nt = param$nt,
+        pvals.expli = param$alpha.pvals.expli < 1,
+        sparse = param$alpha.pvals.expli < 1,
+        alpha.pvals.expli = param$alpha.pvals.expli,
+        ...
+      )
+    } else {
+      mod <- plsRglm::plsRglm(
+        y,
+        x,
+        nt = param$nt,
+        modele = dst,
+        pvals.expli = param$alpha.pvals.expli < 1,
+        sparse = param$alpha.pvals.expli < 1,
+        alpha.pvals.expli = param$alpha.pvals.expli,
+        ...
+      )
+    }
+    mod
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata, type = "response")
+    if (modelFit$problemType == "Classification") {
+      out <- factor(ifelse(
+        out >= .5,
+        modelFit$obsLevels[2],
+        modelFit$obsLevels[1]
+      ))
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata, type = "response")
+    out <- cbind(1 - out, out)
+    dimnames(out)[[2]] <- rev(modelFit$obsLevels)
+    out
+  },
+  varImp = NULL,
+  predictors = function(x, ...) {
+    vars <- names(which(coef(x)[[2]][, 1] != 0))
+    vars[vars != "Intercept"]
+  },
+  notes = paste(
+    "Unlike other packages used by `train`, the `plsRglm`",
+    "package is fully loaded when this model is used."
+  ),
+  tags = c(
+    "Generalized Linear Models",
+    "Partial Least Squares",
+    "Two Class Only"
+  ),
+  levels = function(x) x$lev,
+  sort = function(x) x[order(-x$alpha.pvals.expli, x$nt), ]
+)

--- a/inst/model_sources/files/polr.R
+++ b/inst/model_sources/files/polr.R
@@ -3,34 +3,52 @@ modelInfo <- list(
   library = "MASS",
   loop = NULL,
   type = "Classification",
-  parameters = data.frame(parameter = "method",
-                          class = "character",
-                          label = "parameter"),
+  parameters = data.frame(
+    parameter = "method",
+    class = "character",
+    label = "parameter"
+  ),
   grid = function(x, y, len = NULL, search = "grid") {
-    if(search == "grid") {
-      out <- data.frame(method = c("logistic", "probit", "loglog", "cloglog", "cauchit"))
+    if (search == "grid") {
+      out <- data.frame(
+        method = c("logistic", "probit", "loglog", "cloglog", "cauchit")
+      )
     } else {
-      out <- data.frame(method = sample(c("logistic", "probit", "loglog", "cloglog", "cauchit"),
-                               size = len, replace = TRUE))
+      out <- data.frame(
+        method = sample(
+          c("logistic", "probit", "loglog", "cloglog", "cauchit"),
+          size = len,
+          replace = TRUE
+        )
+      )
     }
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
     modelArgs <- list(...)
 
     ## Set up data
-    dat <- if (is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
     dat$.outcome <- y
-    modelArgs <- c(list(formula = .outcome ~ .,
-                        data = dat,
-                        method = as.character(param$method)),
-                   modelArgs)
+    modelArgs <- c(
+      list(
+        formula = .outcome ~ .,
+        data = dat,
+        method = as.character(param$method)
+      ),
+      modelArgs
+    )
 
     ## Always force Hessian calculation
     modelArgs$Hess <- TRUE
 
     ## Pass in model weights, if any
-    if (!is.null(wts))
+    if (!is.null(wts)) {
       modelArgs$weights <- wts
+    }
 
     ## Fit model
     ans <- do.call(MASS::polr, modelArgs)
@@ -40,10 +58,12 @@ modelInfo <- list(
 
     ans
   },
-  predict = function(modelFit, newdata, preProc = NULL, submodels = NULL)
-    predict(modelFit, newdata = newdata, type = "class"),
-  prob = function(modelFit, newdata, preProc = NULL, submodels = NULL)
-    predict(modelFit, newdata = newdata, type = "probs"),
+  predict = function(modelFit, newdata, preProc = NULL, submodels = NULL) {
+    predict(modelFit, newdata = newdata, type = "class")
+  },
+  prob = function(modelFit, newdata, preProc = NULL, submodels = NULL) {
+    predict(modelFit, newdata = newdata, type = "probs")
+  },
   varImp = function(object, ...) {
     ## Extract coefficients (without cutpoints)
     cf <- coef(object)
@@ -56,13 +76,21 @@ modelInfo <- list(
 
     ## Organize output as in the method for `glm`
     out <- data.frame(Overall = abs(z))
-    if (!is.null(names(cf)))
+    if (!is.null(names(cf))) {
       rownames(out) <- names(cf)
+    }
 
     out
   },
   predictors = function(x, ...) predictors(terms(x)),
-  levels = function(x)
-    if (any(names(x) == "obsLevels")) x$obsLevels else NULL,
-  tags = c("Logistic Regression", "Linear Classifier", "Accepts Case Weights", "Ordinal Outcomes"),
-  sort = function(x) x)
+  levels = function(x) {
+    if (any(names(x) == "obsLevels")) x$obsLevels else NULL
+  },
+  tags = c(
+    "Logistic Regression",
+    "Linear Classifier",
+    "Accepts Case Weights",
+    "Ordinal Outcomes"
+  ),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/polr.R
+++ b/inst/model_sources/files/polr.R
@@ -27,10 +27,10 @@ modelInfo <- list(
     modelArgs <- list(...)
 
     ## Set up data
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     modelArgs <- c(
@@ -84,7 +84,11 @@ modelInfo <- list(
   },
   predictors = function(x, ...) predictors(terms(x)),
   levels = function(x) {
-    if (any(names(x) == "obsLevels")) x$obsLevels else NULL
+    if (any(names(x) == "obsLevels")) {
+      x$obsLevels
+    } else {
+      NULL
+    }
   },
   tags = c(
     "Logistic Regression",

--- a/inst/model_sources/files/ppr.R
+++ b/inst/model_sources/files/ppr.R
@@ -1,26 +1,27 @@
-modelInfo <- list(label = "Projection Pursuit Regression",
-                  library = NULL,
-                  loop = NULL,
-                  type = c('Regression'),
-                  parameters = data.frame(parameter = c('nterms'),
-                                          class = c('numeric'),
-                                          label = c('# Terms')),
-                  grid = function(x, y, len = NULL, search = "grid") data.frame(nterms = 1:len),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    if(!is.null(wts))
-                    {
-                      out <- ppr(as.matrix(x),
-                                 y,
-                                 weights = wts,
-                                 nterms = param$nterms,
-                                 ...)
-                    } else {
-                      out <- ppr(as.matrix(x), y, nterms = param$nterms, ...)
-                    }
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) predict(modelFit, newdata),
-                  prob = NULL,
-                  predictors = function(x, ...) x$xnames,
-                  tags = c("Feature Extraction", "Accepts Case Weights"),
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Projection Pursuit Regression",
+  library = NULL,
+  loop = NULL,
+  type = c('Regression'),
+  parameters = data.frame(
+    parameter = c('nterms'),
+    class = c('numeric'),
+    label = c('# Terms')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") data.frame(nterms = 1:len),
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (!is.null(wts)) {
+      out <- ppr(as.matrix(x), y, weights = wts, nterms = param$nterms, ...)
+    } else {
+      out <- ppr(as.matrix(x), y, nterms = param$nterms, ...)
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)
+  },
+  prob = NULL,
+  predictors = function(x, ...) x$xnames,
+  tags = c("Feature Extraction", "Accepts Case Weights"),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/pre.R
+++ b/inst/model_sources/files/pre.R
@@ -83,14 +83,14 @@ modelInfo <- list(
   ) {
     theDots <- list(...)
     if (!any(names(theDots) == "family")) {
-      theDots$family <- if (is.factor(y)) {
+      if (is.factor(y)) {
         if (nlevels(y) == 2L) {
-          "binomial"
+          theDots$family <- "binomial"
         } else {
-          "multinomial"
+          theDots$family <- "multinomial"
         }
       } else {
-        "gaussian"
+        theDots$family <- "gaussian"
       }
     }
     data <- data.frame(x, .outcome = y)

--- a/inst/model_sources/files/pre.R
+++ b/inst/model_sources/files/pre.R
@@ -1,21 +1,37 @@
 modelInfo <- list(
   library = "pre",
   type = c("Classification", "Regression"),
-  parameters = data.frame(parameter = c("sampfrac", "maxdepth",
-                                        "learnrate", "mtry",
-                                        "use.grad",
-                                        "penalty.par.val"),
-                          class = c(rep("numeric", times = 4),
-                                    "logical", "character"),
-                          label = c("Subsampling Fraction",
-                                    "Max Tree Depth",
-                                    "Shrinkage",
-                                    "# Randomly Selected Predictors",
-                                    "Employ Gradient Boosting",
-                                    "Regularization Parameter")),
-  grid = function(x, y, len = NULL, search = "grid",
-                  sampfrac = .5, maxdepth = 3L, learnrate = .01,
-                  mtry = Inf, use.grad = TRUE, penalty.par.val = "lambda.1se") {
+  parameters = data.frame(
+    parameter = c(
+      "sampfrac",
+      "maxdepth",
+      "learnrate",
+      "mtry",
+      "use.grad",
+      "penalty.par.val"
+    ),
+    class = c(rep("numeric", times = 4), "logical", "character"),
+    label = c(
+      "Subsampling Fraction",
+      "Max Tree Depth",
+      "Shrinkage",
+      "# Randomly Selected Predictors",
+      "Employ Gradient Boosting",
+      "Regularization Parameter"
+    )
+  ),
+  grid = function(
+    x,
+    y,
+    len = NULL,
+    search = "grid",
+    sampfrac = .5,
+    maxdepth = 3L,
+    learnrate = .01,
+    mtry = Inf,
+    use.grad = TRUE,
+    penalty.par.val = "lambda.1se"
+  ) {
     if (search == "grid") {
       if (!is.null(len)) {
         maxdepth <- c(3L, 4L, 2L, 5L, 1L, 6:len)[1:len]
@@ -26,25 +42,47 @@ modelInfo <- list(
           penalty.par.val = c("lambda.min", "lambda.1se")
         }
       }
-      out <- expand.grid(sampfrac = sampfrac, maxdepth = maxdepth,
-                         learnrate = learnrate, mtry = mtry,
-                         use.grad = use.grad,
-                         penalty.par.val = penalty.par.val)
+      out <- expand.grid(
+        sampfrac = sampfrac,
+        maxdepth = maxdepth,
+        learnrate = learnrate,
+        mtry = mtry,
+        use.grad = use.grad,
+        penalty.par.val = penalty.par.val
+      )
     } else if (search == "random") {
       out <- data.frame(
         sampfrac = sample(c(.5, .75, 1), size = len, replace = TRUE),
         maxdepth = sample(2L:6L, size = len, replace = TRUE),
         learnrate = sample(c(0.001, 0.01, 0.1), size = len, replace = TRUE),
-        mtry = sample(c(ceiling(sqrt(ncol(x))), ceiling(ncol(x)/3), ncol(x)), size = len, replace = TRUE),
+        mtry = sample(
+          c(ceiling(sqrt(ncol(x))), ceiling(ncol(x) / 3), ncol(x)),
+          size = len,
+          replace = TRUE
+        ),
         use.grad = sample(c(TRUE, FALSE), size = len, replace = TRUE),
-        penalty.par.val = sample(c("lambda.1se", "lambda.min"), size = len, replace = TRUE))
+        penalty.par.val = sample(
+          c("lambda.1se", "lambda.min"),
+          size = len,
+          replace = TRUE
+        )
+      )
     }
     return(out)
   },
-  fit = function(x, y, wts = NULL, param, lev = NULL, last = NULL,
-                 weights = NULL, classProbs, ...) {
+  fit = function(
+    x,
+    y,
+    wts = NULL,
+    param,
+    lev = NULL,
+    last = NULL,
+    weights = NULL,
+    classProbs,
+    ...
+  ) {
     theDots <- list(...)
-    if(!any(names(theDots) == "family")) {
+    if (!any(names(theDots) == "family")) {
       theDots$family <- if (is.factor(y)) {
         if (nlevels(y) == 2L) {
           "binomial"
@@ -57,41 +95,64 @@ modelInfo <- list(
     }
     data <- data.frame(x, .outcome = y)
     formula <- .outcome ~ .
-    if (is.null(weights)) { weights <- rep(1, times = nrow(x)) }
-    pre(formula = formula, data = data, weights = weights,
-        sampfrac = param$sampfrac, maxdepth = param$maxdepth,
-        learnrate = param$learnrate, mtry = param$mtry,
-        use.grad = param$use.grad, ...)
+    if (is.null(weights)) {
+      weights <- rep(1, times = nrow(x))
+    }
+    pre(
+      formula = formula,
+      data = data,
+      weights = weights,
+      sampfrac = param$sampfrac,
+      maxdepth = param$maxdepth,
+      learnrate = param$learnrate,
+      mtry = param$mtry,
+      use.grad = param$use.grad,
+      ...
+    )
   },
   predict = function(modelFit, newdata, submodels = NULL) {
     if (is.null(submodels)) {
       if (modelFit$family %in% c("gaussian", "mgaussian")) {
-        out <- pre:::predict.pre(object = modelFit,
-                                 newdata = as.data.frame(newdata))
+        out <- pre:::predict.pre(
+          object = modelFit,
+          newdata = as.data.frame(newdata)
+        )
       } else if (modelFit$family == "poisson") {
-        out <- pre:::predict.pre(object = modelFit,
-                                 newdata = as.data.frame(newdata), type = "response")
+        out <- pre:::predict.pre(
+          object = modelFit,
+          newdata = as.data.frame(newdata),
+          type = "response"
+        )
       } else {
-        out <- factor(pre:::predict.pre(object = modelFit,
-                                        newdata = as.data.frame(newdata), type = "class"))
+        out <- factor(pre:::predict.pre(
+          object = modelFit,
+          newdata = as.data.frame(newdata),
+          type = "class"
+        ))
       }
     } else {
       out <- list()
       for (i in seq(along.with = submodels$penalty.par.val)) {
         if (modelFit$family %in% c("gaussian", "mgaussian")) {
-          out[[i]] <- pre:::predict.pre(object = modelFit,
-                                        newdata = as.data.frame(newdata),
-                                        penalty.par.val = as.character(submodels$penalty.par.val[i]))
+          out[[i]] <- pre:::predict.pre(
+            object = modelFit,
+            newdata = as.data.frame(newdata),
+            penalty.par.val = as.character(submodels$penalty.par.val[i])
+          )
         } else if (modelFit$family == "poisson") {
-          out[[i]] <- pre:::predict.pre(object = modelFit,
-                                        newdata = as.data.frame(newdata),
-                                        type = "response",
-                                        penalty.par.val = as.character(submodels$penalty.par.val[i]))
+          out[[i]] <- pre:::predict.pre(
+            object = modelFit,
+            newdata = as.data.frame(newdata),
+            type = "response",
+            penalty.par.val = as.character(submodels$penalty.par.val[i])
+          )
         } else {
-          out[[i]] <- factor(pre:::predict.pre(object = modelFit,
-                                               newdata = as.data.frame(newdata),
-                                               type = "class",
-                                               penalty.par.val = as.character(submodels$penalty.par.val[i])))
+          out[[i]] <- factor(pre:::predict.pre(
+            object = modelFit,
+            newdata = as.data.frame(newdata),
+            type = "class",
+            penalty.par.val = as.character(submodels$penalty.par.val[i])
+          ))
         }
       }
     }
@@ -99,44 +160,51 @@ modelInfo <- list(
   },
   prob = function(modelFit, newdata, submodels = NULL) {
     if (is.null(submodels)) {
-      probs <- pre:::predict.pre(object = modelFit,
-                                 newdata = as.data.frame(newdata),
-                                 type = "response")
+      probs <- pre:::predict.pre(
+        object = modelFit,
+        newdata = as.data.frame(newdata),
+        type = "response"
+      )
       # For binary classification, create matrix:
       if (is.null(ncol(probs)) || ncol(probs) == 1) {
         probs <- data.frame(1 - probs, probs)
-        colnames(probs) <- levels(modelFit$data[,modelFit$y_names])
+        colnames(probs) <- levels(modelFit$data[, modelFit$y_names])
       }
     } else {
       probs <- list()
       for (i in seq(along.with = submodels$penalty.par.val)) {
-        probs[[i]] <- pre:::predict.pre(object = modelFit,
-                                   newdata = as.data.frame(newdata),
-                                   type = "response",
-                                   penalty.par.val = as.character(submodels$penalty.par.val[i]))
+        probs[[i]] <- pre:::predict.pre(
+          object = modelFit,
+          newdata = as.data.frame(newdata),
+          type = "response",
+          penalty.par.val = as.character(submodels$penalty.par.val[i])
+        )
         # For binary classification, create matrix:
         if (is.null(ncol(probs[[i]])) || ncol(probs[[i]]) == 1) {
           probs[[i]] <- data.frame(1 - probs[[i]], probs[[i]])
-          colnames(probs[[i]]) <- levels(modelFit$data[,modelFit$y_names])
+          colnames(probs[[i]]) <- levels(modelFit$data[, modelFit$y_names])
         }
       }
     }
     probs
   },
   sort = function(x) {
-    ordering <- order(x$maxdepth, # lower values are simpler
-                      x$use.grad, # TRUE employs ctree (vs ctree), so simplest
-                      max(x$mtry) - x$mtry, # higher values yield more similar tree, so simpler
-                      x$sampfrac != 1L, # subsampling yields simpler trees than bootstrap sampling
-                      x$learnrate, # lower learnrates yield more similar trees, so simpler
-                      decreasing = FALSE)
-    x[ordering,]
+    ordering <- order(
+      x$maxdepth, # lower values are simpler
+      x$use.grad, # TRUE employs ctree (vs ctree), so simplest
+      max(x$mtry) - x$mtry, # higher values yield more similar tree, so simpler
+      x$sampfrac != 1L, # subsampling yields simpler trees than bootstrap sampling
+      x$learnrate, # lower learnrates yield more similar trees, so simpler
+      decreasing = FALSE
+    )
+    x[ordering, ]
   },
   loop = function(fullGrid) {
-
     # loop should provide a grid containing models that can
     # be looped over for tuning penalty.par.val
-    loop_rows <- rownames(unique(fullGrid[,-which(names(fullGrid) == "penalty.par.val")]))
+    loop_rows <- rownames(unique(fullGrid[,
+      -which(names(fullGrid) == "penalty.par.val")
+    ]))
     loop <- fullGrid[rownames(fullGrid) %in% loop_rows, ]
 
     ## submodels should be a list and length(submodels == nrow(loop)
@@ -148,9 +216,16 @@ modelInfo <- list(
       ## check which rows in fullGrid without $penalty.par.val are equal to
       ## rows in loop without $penalty.par.val
       for (j in 1:nrow(fullGrid)) {
-        if (all(loop[i, -which(colnames(loop) == "penalty.par.val")] ==
-              fullGrid[j, -which(colnames(fullGrid) == "penalty.par.val")])) {
-          lambda_vals <- c(lambda_vals, as.character(fullGrid[j, "penalty.par.val"]))
+        if (
+          all(
+            loop[i, -which(colnames(loop) == "penalty.par.val")] ==
+              fullGrid[j, -which(colnames(fullGrid) == "penalty.par.val")]
+          )
+        ) {
+          lambda_vals <- c(
+            lambda_vals,
+            as.character(fullGrid[j, "penalty.par.val"])
+          )
         }
       }
       lambda_vals <- lambda_vals[-which(lambda_vals == loop$penalty.par.val[i])]
@@ -158,26 +233,38 @@ modelInfo <- list(
     }
     list(loop = loop, submodels = submodels)
   },
-  levels = function(x) { levels(x$data[,x$y_names]) },
-  tag = c("Rule-Based Model", "Tree-Based Model", "L1 regularization", "Bagging", "Boosting"),
+  levels = function(x) {
+    levels(x$data[, x$y_names])
+  },
+  tag = c(
+    "Rule-Based Model",
+    "Tree-Based Model",
+    "L1 regularization",
+    "Bagging",
+    "Boosting"
+  ),
   label = "Prediction Rule Ensembles",
   predictors = function(x, ...) {
     if (x$family %in% c("gaussian", "poisson", "binomial")) {
       return(suppressWarnings(importance(x, plot = FALSE, ...)$varimps$varname))
     } else {
-      warning("Reporting the predictors in the model is not yet available for multinomial and multivariate responses")
+      warning(
+        "Reporting the predictors in the model is not yet available for multinomial and multivariate responses"
+      )
       return(NULL)
     }
   },
   varImp = function(x, ...) {
-    if (x$family %in% c("gaussian","binomial","poisson")) {
+    if (x$family %in% c("gaussian", "binomial", "poisson")) {
       varImp <- pre:::importance(x, plot = FALSE, ...)$varimps
       varnames <- varImp$varname
       varImp <- data.frame(Overall = varImp$imp)
       rownames(varImp) <- varnames
       return(varImp)
     } else {
-      warning("Variable importances cannot be calculated for multinomial or mgaussian family")
+      warning(
+        "Variable importances cannot be calculated for multinomial or mgaussian family"
+      )
       return(NULL)
     }
   },

--- a/inst/model_sources/files/protoclass.R
+++ b/inst/model_sources/files/protoclass.R
@@ -1,29 +1,46 @@
-modelInfo <- list(label = "Greedy Prototype Selection",
-                  library = c("proxy", "protoclass"),
-                  loop = NULL,
-                  type = c('Classification'),
-                  parameters = data.frame(parameter = c('eps', 'Minkowski'),
-                                          class = c('numeric', 'numeric'),
-                                          label = c('Ball Size', 'Distance Order')),
-                  grid = function(x, y, len = NULL, search = "grid") data.frame(eps = 1:len, Minkowski = 2),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    out <- protoclass::protoclass(x = x, y = y,
-                                                  dxz = as.matrix(proxy:::dist(x, x,
-                                                                               method = "Minkowski",
-                                                                              p
-                  = as.double(param$Minkowski))),
-                                                  eps = param$eps, 
-                                                  ...)
-                    out$Minkowski <- 2
-                    out$training <- x
-                    out
-                  },
-                  levels = function(x) x$obsLevels,
-                  predict = function(modelFit, newdata, submodels = NULL)
-                    as.character(protoclass::predictwithd.protoclass(modelFit,
-                                                         as.matrix(proxy:::dist(newdata, modelFit$training,
-                                                                                "Minkowski", 
-                                                                                p = modelFit$Minkowski)))),
-                  prob = NULL,
-                  tags = c("Prototype Models"),
-                  sort = function(x) x[order(-x$eps),])
+modelInfo <- list(
+  label = "Greedy Prototype Selection",
+  library = c("proxy", "protoclass"),
+  loop = NULL,
+  type = c('Classification'),
+  parameters = data.frame(
+    parameter = c('eps', 'Minkowski'),
+    class = c('numeric', 'numeric'),
+    label = c('Ball Size', 'Distance Order')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(eps = 1:len, Minkowski = 2)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    out <- protoclass::protoclass(
+      x = x,
+      y = y,
+      dxz = as.matrix(proxy:::dist(
+        x,
+        x,
+        method = "Minkowski",
+        p = as.double(param$Minkowski)
+      )),
+      eps = param$eps,
+      ...
+    )
+    out$Minkowski <- 2
+    out$training <- x
+    out
+  },
+  levels = function(x) x$obsLevels,
+  predict = function(modelFit, newdata, submodels = NULL) {
+    as.character(protoclass::predictwithd.protoclass(
+      modelFit,
+      as.matrix(proxy:::dist(
+        newdata,
+        modelFit$training,
+        "Minkowski",
+        p = modelFit$Minkowski
+      ))
+    ))
+  },
+  prob = NULL,
+  tags = c("Prototype Models"),
+  sort = function(x) x[order(-x$eps), ]
+)

--- a/inst/model_sources/files/qda.R
+++ b/inst/model_sources/files/qda.R
@@ -21,7 +21,11 @@ modelInfo <- list(
     predict(modelFit, newdata)$posterior
   },
   predictors = function(x, ...) {
-    if (hasTerms(x)) predictors(x$terms) else colnames(x$means)
+    if (hasTerms(x)) {
+      predictors(x$terms)
+    } else {
+      colnames(x$means)
+    }
   },
   tags = c("Discriminant Analysis", "Polynomial Model"),
   levels = function(x) names(x$prior),

--- a/inst/model_sources/files/qda.R
+++ b/inst/model_sources/files/qda.R
@@ -1,17 +1,29 @@
-modelInfo <- list(label = "Quadratic Discriminant Analysis",
-                  library = "MASS",
-                  loop = NULL,
-                  type = "Classification",
-                  parameters = data.frame(parameter = "parameter",
-                                          class = "character",
-                                          label = "parameter"),
-                  grid = function(x, y, len = NULL, search = "grid") data.frame(parameter = "none"),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) MASS::qda(x, y, ...)  ,
-                  predict = function(modelFit, newdata, submodels = NULL)
-                    predict(modelFit, newdata)$class,
-                  prob = function(modelFit, newdata, submodels = NULL) 
-                    predict(modelFit, newdata)$posterior,
-                  predictors = function(x, ...) if(hasTerms(x)) predictors(x$terms) else colnames(x$means),
-                  tags = c("Discriminant Analysis", "Polynomial Model"),
-                  levels = function(x) names(x$prior),
-                  sort = function(x) x)
+modelInfo <- list(
+  label = "Quadratic Discriminant Analysis",
+  library = "MASS",
+  loop = NULL,
+  type = "Classification",
+  parameters = data.frame(
+    parameter = "parameter",
+    class = "character",
+    label = "parameter"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(parameter = "none")
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    MASS::qda(x, y, ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)$class
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)$posterior
+  },
+  predictors = function(x, ...) {
+    if (hasTerms(x)) predictors(x$terms) else colnames(x$means)
+  },
+  tags = c("Discriminant Analysis", "Polynomial Model"),
+  levels = function(x) names(x$prior),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/qrf.R
+++ b/inst/model_sources/files/qrf.R
@@ -1,29 +1,47 @@
-modelInfo <- list(label = "Quantile Random Forest",
-                  library = "quantregForest",
-                  loop = NULL,
-                  type = c("Regression"),
-                  parameters = data.frame(parameter = "mtry",
-                                          class = "numeric",
-                                          label = "#Randomly Selected Predictors"),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- data.frame(mtry = caret::var_seq(p = ncol(x), 
-                                                              classification = is.factor(y), 
-                                                              len = len))
-                    } else {
-                      out <- data.frame(mtry = unique(sample(1:ncol(x), size = len, replace = TRUE)))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...)
-                    quantregForest::quantregForest(x, y, mtry = min(param$mtry, ncol(x)), ...),
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata, what = 0.5)
-                    if(is.matrix(out)) out <- out[,1]
-                    out
-                  },
-                  prob = NULL,
-                  tags = c("Random Forest", "Ensemble Model", "Bagging", 
-                           "Implicit Feature Selection", "Quantile Regression",
-                           "Robust Model"),
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Quantile Random Forest",
+  library = "quantregForest",
+  loop = NULL,
+  type = c("Regression"),
+  parameters = data.frame(
+    parameter = "mtry",
+    class = "numeric",
+    label = "#Randomly Selected Predictors"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(
+        mtry = caret::var_seq(
+          p = ncol(x),
+          classification = is.factor(y),
+          len = len
+        )
+      )
+    } else {
+      out <- data.frame(
+        mtry = unique(sample(1:ncol(x), size = len, replace = TRUE))
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    quantregForest::quantregForest(x, y, mtry = min(param$mtry, ncol(x)), ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata, what = 0.5)
+    if (is.matrix(out)) {
+      out <- out[, 1]
+    }
+    out
+  },
+  prob = NULL,
+  tags = c(
+    "Random Forest",
+    "Ensemble Model",
+    "Bagging",
+    "Implicit Feature Selection",
+    "Quantile Regression",
+    "Robust Model"
+  ),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/qrnn.R
+++ b/inst/model_sources/files/qrnn.R
@@ -1,24 +1,42 @@
-modelInfo <- list(label = "Quantile Regression Neural Network",
-                  library = "qrnn",
-                  loop = NULL,
-                  type = c('Regression'),
-                  parameters = data.frame(parameter = c('n.hidden', 'penalty', 'bag'),
-                                          class = c('numeric', 'numeric', 'logical'),
-                                          label = c('#Hidden Units', ' Weight Decay', 'Bagged Models?')),
-                  grid = function(x, y, len = NULL, search = "grid") expand.grid(n.hidden = ((1:len) * 2) - 1, 
-                                                                penalty = c(0, 10 ^ seq(-1, -4, length = len - 1)),
-                                                                bag = FALSE),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    qrnn::qrnn.fit(as.matrix(x), matrix(y),
-                                   n.hidden = param$n.hidden,
-                                   print.level = 0,
-                                   penalty =  param$penalty,
-                                   bag= param$bag,
-                                   ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL)
-                    qrnn::qrnn.predict(as.matrix(newdata), modelFit)[,1],
-                  prob = NULL,
-                  tags = c("Neural Network", "L2 Regularization", "Quantile Regression", "Bagging",
-                           "Ensemble Model", "Robust Model"),
-                  sort = function(x) x[order(x$n.hidden, -x$penalty),])
+modelInfo <- list(
+  label = "Quantile Regression Neural Network",
+  library = "qrnn",
+  loop = NULL,
+  type = c('Regression'),
+  parameters = data.frame(
+    parameter = c('n.hidden', 'penalty', 'bag'),
+    class = c('numeric', 'numeric', 'logical'),
+    label = c('#Hidden Units', ' Weight Decay', 'Bagged Models?')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    expand.grid(
+      n.hidden = ((1:len) * 2) - 1,
+      penalty = c(0, 10^seq(-1, -4, length = len - 1)),
+      bag = FALSE
+    )
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    qrnn::qrnn.fit(
+      as.matrix(x),
+      matrix(y),
+      n.hidden = param$n.hidden,
+      print.level = 0,
+      penalty = param$penalty,
+      bag = param$bag,
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    qrnn::qrnn.predict(as.matrix(newdata), modelFit)[, 1]
+  },
+  prob = NULL,
+  tags = c(
+    "Neural Network",
+    "L2 Regularization",
+    "Quantile Regression",
+    "Bagging",
+    "Ensemble Model",
+    "Robust Model"
+  ),
+  sort = function(x) x[order(x$n.hidden, -x$penalty), ]
+)

--- a/inst/model_sources/files/rFerns.R
+++ b/inst/model_sources/files/rFerns.R
@@ -1,29 +1,42 @@
-modelInfo <- list(label = "Random Ferns",
-                  library = "rFerns",
-                  loop = NULL,
-                  type = c('Classification'),
-                  parameters = data.frame(parameter = c('depth'),
-                                          class = c('numeric'),
-                                          label = c('Fern Depth')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- data.frame(depth = unique(floor(seq(1, 16, length = len))))
-                    } else {
-                      out <- data.frame(depth = unique(sample(1:16, size = len, replace = TRUE)))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    if(!is.data.frame(x) | inherits(x, "tbl_df")) 
-                      x <- as.data.frame(x, stringsAsFactors = TRUE)
-                    rFerns::rFerns(x, y, depth = param$depth, ...)
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata) | inherits(newdata, "tbl_df")) 
-                      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata)
-                    },
-                  levels = function(x) x$obsLevels,
-                  prob = NULL,
-                  tags = c("Random Forest", "Ensemble Model", "Bagging", "Implicit Feature Selection"),
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Random Ferns",
+  library = "rFerns",
+  loop = NULL,
+  type = c('Classification'),
+  parameters = data.frame(
+    parameter = c('depth'),
+    class = c('numeric'),
+    label = c('Fern Depth')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(depth = unique(floor(seq(1, 16, length = len))))
+    } else {
+      out <- data.frame(
+        depth = unique(sample(1:16, size = len, replace = TRUE))
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (!is.data.frame(x) | inherits(x, "tbl_df")) {
+      x <- as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    rFerns::rFerns(x, y, depth = param$depth, ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata) | inherits(newdata, "tbl_df")) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata)
+  },
+  levels = function(x) x$obsLevels,
+  prob = NULL,
+  tags = c(
+    "Random Forest",
+    "Ensemble Model",
+    "Bagging",
+    "Implicit Feature Selection"
+  ),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/randomGLM.R
+++ b/inst/model_sources/files/randomGLM.R
@@ -1,52 +1,67 @@
-modelInfo <- list(label = "Ensembles of Generalized Linear Models",
-                  library = "randomGLM",
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = 'maxInteractionOrder',
-                                          class = "numeric",
-                                          label = 'Interaction Order'),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <-  expand.grid(maxInteractionOrder = 1:min(len, 3))
-                    } else {
-                      out <- data.frame(maxInteractionOrder = sample(1:3, length = len))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    require(randomGLM)
-                    if(!is.matrix(x)) x <- as.matrix(x)
-                    mod <- randomGLM::randomGLM(
-                      x = x, 
-                      y, 
-                      maxInteractionOrder = param$maxInteractionOrder, 
-                      ...
-                    )
-                    mod
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    out <- predict(modelFit, newdata)    
-                    if(modelFit$problemType == "Classification") 
-                      out <- modelFit$obsLevel[apply(out, 1, which.max)]
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    predict(modelFit, newdata)    
-                  },                  
-                  predictors = function(x, s = NULL, ...) {
-                    all_pred <- lapply(x$models, function(x) names(coef(x)))
-                    all_pred <- unique(unlist(all_pred))
-                    all_pred <- strsplit(all_pred, ".times.", fixed = TRUE)
-                    all_pred <- unique(unlist(all_pred))
-                    all_pred[all_pred != "(Intercept)"]
-                  },
-                  tags = c("Generalized Linear Model", "Linear Classifier",
-                           "Ensemble Model", "Bagging"),
-                  notes = paste(
-                    "Unlike other packages used by `train`, the `randomGLM`",
-                    "package is fully loaded when this model is used."
-                  ),                  
-                  prob = NULL,
-                  sort = function(x) x)
+modelInfo <- list(
+  label = "Ensembles of Generalized Linear Models",
+  library = "randomGLM",
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = 'maxInteractionOrder',
+    class = "numeric",
+    label = 'Interaction Order'
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(maxInteractionOrder = 1:min(len, 3))
+    } else {
+      out <- data.frame(maxInteractionOrder = sample(1:3, length = len))
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    require(randomGLM)
+    if (!is.matrix(x)) {
+      x <- as.matrix(x)
+    }
+    mod <- randomGLM::randomGLM(
+      x = x,
+      y,
+      maxInteractionOrder = param$maxInteractionOrder,
+      ...
+    )
+    mod
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- predict(modelFit, newdata)
+    if (modelFit$problemType == "Classification") {
+      out <- modelFit$obsLevel[apply(out, 1, which.max)]
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    predict(modelFit, newdata)
+  },
+  predictors = function(x, s = NULL, ...) {
+    all_pred <- lapply(x$models, function(x) names(coef(x)))
+    all_pred <- unique(unlist(all_pred))
+    all_pred <- strsplit(all_pred, ".times.", fixed = TRUE)
+    all_pred <- unique(unlist(all_pred))
+    all_pred[all_pred != "(Intercept)"]
+  },
+  tags = c(
+    "Generalized Linear Model",
+    "Linear Classifier",
+    "Ensemble Model",
+    "Bagging"
+  ),
+  notes = paste(
+    "Unlike other packages used by `train`, the `randomGLM`",
+    "package is fully loaded when this model is used."
+  ),
+  prob = NULL,
+  sort = function(x) x
+)

--- a/inst/model_sources/files/ranger.R
+++ b/inst/model_sources/files/ranger.R
@@ -1,111 +1,156 @@
-modelInfo <- list(label = "Random Forest",
-                  library = c("e1071", "ranger", "dplyr"),
-                  check = function(pkg) {
-                    requireNamespace("ranger")
-                    current <- packageDescription("ranger")$Version
-                    expected <- "0.8.0"
-                    if(compareVersion(current, expected) < 0)
-                      stop("This modeling workflow requires ranger version ",
-                           expected, "or greater.", call. = FALSE)
-                  },
-                  loop = NULL,
-                  type = c("Classification", "Regression"),
-                  parameters = data.frame(parameter = c("mtry", "splitrule", "min.node.size"),
-                                          class = c("numeric", "character", "numeric"),
-                                          label = c("#Randomly Selected Predictors",
-                                                    "Splitting Rule",
-                                                    "Minimal Node Size")),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      srule <-
-                        if (is.factor(y))
-                          "gini"
-                      else
-                        "variance"
-                      out <- expand.grid(mtry =
-                                           caret::var_seq(p = ncol(x),
-                                                          classification = is.factor(y),
-                                                          len = len),
-                                         min.node.size = ifelse( is.factor(y), 1, 5),
-                                         splitrule = c(srule, "extratrees")[1:min(2,len)])
-                    } else {
-                      srules <- if (is.factor(y))
-                        c("gini", "extratrees")
-                      else
-                        c("variance", "extratrees", "maxstat")
-                      out <-
-                        data.frame(
-                          min.node.size= sample(1:(min(20,nrow(x))), size = len, replace = TRUE),
-                          mtry = sample(1:ncol(x), size = len, replace = TRUE),
-                          splitrule = sample(srules, size = len, replace = TRUE)
-                        )
-                    }
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    if((!is.data.frame(x))||dplyr::is.tbl(x)) x <- as.data.frame(x, stringsAsFactors = TRUE)
-                    x$.outcome <- y
-                    if(!is.null(wts)) {
-                      out <- ranger::ranger(dependent.variable.name = ".outcome",
-                                            data = x,
-                                            mtry = min(param$mtry, ncol(x)),
-                                            min.node.size = param$min.node.size,
-                                            splitrule = as.character(param$splitrule),
-                                            write.forest = TRUE,
-                                            probability = classProbs,
-                                            case.weights = wts,
-                                            ...)
-                    } else {
-                      out <- ranger::ranger(dependent.variable.name = ".outcome",
-                                            data = x,
-                                            mtry = min(param$mtry, ncol(x)),
-                                            min.node.size = param$min.node.size,
-                                            splitrule = as.character(param$splitrule),
-                                            write.forest = TRUE,
-                                            probability = classProbs,
-                                            ...)
-                    }
-                    ## in case the resampling method is "oob"
-                    if(!last) out$y <- y
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if((!is.data.frame(newdata))||dplyr::is.tbl(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    out <- predict(modelFit, newdata)$predictions
-                    if(!is.null(modelFit$obsLevels) & modelFit$treetype == "Probability estimation") {
-                      out <- colnames(out)[apply(out, 1, which.max)]
-                    }
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata)$predictions
-                  },
-                  predictors = function(x, ...) {
-                    var_index <- sort(unique(unlist(lapply(x$forest$split.varIDs, function(x) x))))
-                    var_index <-var_index[var_index > 0]
-                    x$forest$independent.variable.names[var_index]
-                  },
-                  varImp = function(object, ...){
-                    if(length(object$variable.importance) == 0)
-                      stop("No importance values available")
-                    imps <- ranger:::importance(object)
-                    out <- data.frame(Overall = as.vector(imps))
-                    rownames(out) <- names(imps)
-                    out
-                  },
-                  levels = function(x) {
-                    if(x$treetype == "Probability estimation") {
-                      out <- colnames(x$predictions)
-                    } else {
-                      if(x$treetype == "Classification") {
-                        out <- levels(x$predictions)
-                      } else out <- NULL
-                    }
-                    out
-                  },
-                  oob = function(x) {
-                    postResample(x$predictions, x$y)
-                  },
-                  tags = c("Random Forest", "Ensemble Model", "Bagging",
-                           "Implicit Feature Selection", "Accepts Case Weights"),
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Random Forest",
+  library = c("e1071", "ranger", "dplyr"),
+  check = function(pkg) {
+    requireNamespace("ranger")
+    current <- packageDescription("ranger")$Version
+    expected <- "0.8.0"
+    if (compareVersion(current, expected) < 0) {
+      stop(
+        "This modeling workflow requires ranger version ",
+        expected,
+        "or greater.",
+        call. = FALSE
+      )
+    }
+  },
+  loop = NULL,
+  type = c("Classification", "Regression"),
+  parameters = data.frame(
+    parameter = c("mtry", "splitrule", "min.node.size"),
+    class = c("numeric", "character", "numeric"),
+    label = c(
+      "#Randomly Selected Predictors",
+      "Splitting Rule",
+      "Minimal Node Size"
+    )
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      srule <-
+        if (is.factor(y)) {
+          "gini"
+        } else {
+          "variance"
+        }
+      out <- expand.grid(
+        mtry = caret::var_seq(
+          p = ncol(x),
+          classification = is.factor(y),
+          len = len
+        ),
+        min.node.size = ifelse(is.factor(y), 1, 5),
+        splitrule = c(srule, "extratrees")[1:min(2, len)]
+      )
+    } else {
+      srules <- if (is.factor(y)) {
+        c("gini", "extratrees")
+      } else {
+        c("variance", "extratrees", "maxstat")
+      }
+      out <-
+        data.frame(
+          min.node.size = sample(
+            1:(min(20, nrow(x))),
+            size = len,
+            replace = TRUE
+          ),
+          mtry = sample(1:ncol(x), size = len, replace = TRUE),
+          splitrule = sample(srules, size = len, replace = TRUE)
+        )
+    }
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if ((!is.data.frame(x)) || dplyr::is.tbl(x)) {
+      x <- as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    x$.outcome <- y
+    if (!is.null(wts)) {
+      out <- ranger::ranger(
+        dependent.variable.name = ".outcome",
+        data = x,
+        mtry = min(param$mtry, ncol(x)),
+        min.node.size = param$min.node.size,
+        splitrule = as.character(param$splitrule),
+        write.forest = TRUE,
+        probability = classProbs,
+        case.weights = wts,
+        ...
+      )
+    } else {
+      out <- ranger::ranger(
+        dependent.variable.name = ".outcome",
+        data = x,
+        mtry = min(param$mtry, ncol(x)),
+        min.node.size = param$min.node.size,
+        splitrule = as.character(param$splitrule),
+        write.forest = TRUE,
+        probability = classProbs,
+        ...
+      )
+    }
+    ## in case the resampling method is "oob"
+    if (!last) {
+      out$y <- y
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if ((!is.data.frame(newdata)) || dplyr::is.tbl(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    out <- predict(modelFit, newdata)$predictions
+    if (
+      !is.null(modelFit$obsLevels) &
+        modelFit$treetype == "Probability estimation"
+    ) {
+      out <- colnames(out)[apply(out, 1, which.max)]
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata)$predictions
+  },
+  predictors = function(x, ...) {
+    var_index <- sort(unique(unlist(lapply(x$forest$split.varIDs, function(x) {
+      x
+    }))))
+    var_index <- var_index[var_index > 0]
+    x$forest$independent.variable.names[var_index]
+  },
+  varImp = function(object, ...) {
+    if (length(object$variable.importance) == 0) {
+      stop("No importance values available")
+    }
+    imps <- ranger:::importance(object)
+    out <- data.frame(Overall = as.vector(imps))
+    rownames(out) <- names(imps)
+    out
+  },
+  levels = function(x) {
+    if (x$treetype == "Probability estimation") {
+      out <- colnames(x$predictions)
+    } else {
+      if (x$treetype == "Classification") {
+        out <- levels(x$predictions)
+      } else {
+        out <- NULL
+      }
+    }
+    out
+  },
+  oob = function(x) {
+    postResample(x$predictions, x$y)
+  },
+  tags = c(
+    "Random Forest",
+    "Ensemble Model",
+    "Bagging",
+    "Implicit Feature Selection",
+    "Accepts Case Weights"
+  ),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/ranger.R
+++ b/inst/model_sources/files/ranger.R
@@ -27,12 +27,11 @@ modelInfo <- list(
   ),
   grid = function(x, y, len = NULL, search = "grid") {
     if (search == "grid") {
-      srule <-
-        if (is.factor(y)) {
-          "gini"
-        } else {
-          "variance"
-        }
+      if (is.factor(y)) {
+        srule <- "gini"
+      } else {
+        srule <- "variance"
+      }
       out <- expand.grid(
         mtry = caret::var_seq(
           p = ncol(x),
@@ -43,10 +42,10 @@ modelInfo <- list(
         splitrule = c(srule, "extratrees")[1:min(2, len)]
       )
     } else {
-      srules <- if (is.factor(y)) {
-        c("gini", "extratrees")
+      if (is.factor(y)) {
+        srules <- c("gini", "extratrees")
       } else {
-        c("variance", "extratrees", "maxstat")
+        srules <- c("variance", "extratrees", "maxstat")
       }
       out <-
         data.frame(

--- a/inst/model_sources/files/rbf.R
+++ b/inst/model_sources/files/rbf.R
@@ -1,61 +1,64 @@
-modelInfo <- list(label = "Radial Basis Function Network",
-                  library = "RSNNS",
-                  loop = NULL,
-                  type = c('Classification','Regression'),
-                  parameters = data.frame(parameter = c('size'),
-                                          class = c('numeric'),
-                                          label = c('#Hidden Units')),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- data.frame(size =  ((1:len) * 2) - 1)
-                    } else {
-                      out <- data.frame(size = unique(sample(1:20, size = len, replace = TRUE)))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    theDots <- list(...)
-                    theDots <- theDots[!(names(theDots) %in% c("size", "linOut"))]
-                    if(any(names(theDots) == "learnFunc"))
-                    {
-                      theDots$learnFunc <- NULL 
-                      warning("Cannot over-ride 'learnFunc' argument for this model. RadialBasisLearning is used.")
-                    }
-                    if(!any(names(theDots) == "initFuncParams"))
-                    {
-                      theDots$initFuncParams <- c(0, 1, 0, 0.02, 0.04)
-                      if(is.factor(y)) theDots$initFuncParams[1:2] <- c(-4, 4)
-                    }
-                    
-                    if(!any(names(theDots) == "learnFuncParams"))
-                    {
-                      theDots$learnFuncParams <- c(1e-8, 0, 1e-8, 0.1, 0.8)
-                    }
-                
-                    if(is.factor(y)) {
-                      y <- RSNNS:::decodeClassLabels(y)
-                      lin <- FALSE
-                    } else lin <- TRUE
-                    args <- list(x = x,
-                                 y = y,                           
-                                 size = param$size,
-                                 linOut = lin)
-                    args <- c(args, theDots)
-                    do.call(RSNNS::rbf, args)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata)
-                    if(modelFit$problemType == "Classification")
-                    {
-                      out <- modelFit$obsLevels[apply(out, 1, which.max)]
-                    } else out <- out[,1]
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata)
-                    colnames(out) <- modelFit$obsLevels
-                    out
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("Neural Network","L2 Regularization", "Radial Basis Function"),
-                  sort = function(x) x[order(x$size),])
+modelInfo <- list(
+  label = "Radial Basis Function Network",
+  library = "RSNNS",
+  loop = NULL,
+  type = c('Classification', 'Regression'),
+  parameters = data.frame(
+    parameter = c('size'),
+    class = c('numeric'),
+    label = c('#Hidden Units')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(size = ((1:len) * 2) - 1)
+    } else {
+      out <- data.frame(size = unique(sample(1:20, size = len, replace = TRUE)))
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    theDots <- list(...)
+    theDots <- theDots[!(names(theDots) %in% c("size", "linOut"))]
+    if (any(names(theDots) == "learnFunc")) {
+      theDots$learnFunc <- NULL
+      warning(
+        "Cannot over-ride 'learnFunc' argument for this model. RadialBasisLearning is used."
+      )
+    }
+    if (!any(names(theDots) == "initFuncParams")) {
+      theDots$initFuncParams <- c(0, 1, 0, 0.02, 0.04)
+      if (is.factor(y)) theDots$initFuncParams[1:2] <- c(-4, 4)
+    }
+
+    if (!any(names(theDots) == "learnFuncParams")) {
+      theDots$learnFuncParams <- c(1e-8, 0, 1e-8, 0.1, 0.8)
+    }
+
+    if (is.factor(y)) {
+      y <- RSNNS:::decodeClassLabels(y)
+      lin <- FALSE
+    } else {
+      lin <- TRUE
+    }
+    args <- list(x = x, y = y, size = param$size, linOut = lin)
+    args <- c(args, theDots)
+    do.call(RSNNS::rbf, args)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata)
+    if (modelFit$problemType == "Classification") {
+      out <- modelFit$obsLevels[apply(out, 1, which.max)]
+    } else {
+      out <- out[, 1]
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata)
+    colnames(out) <- modelFit$obsLevels
+    out
+  },
+  levels = function(x) x$obsLevels,
+  tags = c("Neural Network", "L2 Regularization", "Radial Basis Function"),
+  sort = function(x) x[order(x$size), ]
+)

--- a/inst/model_sources/files/rbf.R
+++ b/inst/model_sources/files/rbf.R
@@ -27,7 +27,9 @@ modelInfo <- list(
     }
     if (!any(names(theDots) == "initFuncParams")) {
       theDots$initFuncParams <- c(0, 1, 0, 0.02, 0.04)
-      if (is.factor(y)) theDots$initFuncParams[1:2] <- c(-4, 4)
+      if (is.factor(y)) {
+        theDots$initFuncParams[1:2] <- c(-4, 4)
+      }
     }
 
     if (!any(names(theDots) == "learnFuncParams")) {

--- a/inst/model_sources/files/rbfDDA.R
+++ b/inst/model_sources/files/rbfDDA.R
@@ -1,52 +1,56 @@
-modelInfo <- list(label = "Radial Basis Function Network",
-                  library = "RSNNS",
-                  loop = NULL,
-                  type = c('Regression', 'Classification'),
-                  parameters = data.frame(parameter = c('negativeThreshold'),
-                                          class = c('numeric'),
-                                          label = c('Activation Limit for Conflicting Classes')),
-                  grid = function(x, y, len = NULL, search = "grid") 
-                  {
-                    if(search == "grid") {
-                      out <- data.frame(negativeThreshold =  10 ^(-(1:len)))
-                    } else {
-                      out <- data.frame(negativeThreshold = runif(len, min = 0, 3))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    theDots <- list(...)
-                    
-                    if(any(names(theDots) == "learnFunc"))
-                    {
-                      theDots$learnFunc <- NULL
-                      warning("Cannot over-ride 'learnFunc' argument for this model. RBF-DDA is used.")
-                    }
-                    if(any(names(theDots) == "learnFuncParams"))
-                    {
-                      theDots$learnFuncParams[2] <- param$negativeThreshold
-                    } else theDots$learnFuncParams <-c(0.4,  param$negativeThreshold, 5)
-                    
-                    
-                    y <- RSNNS:::decodeClassLabels(y)
-                    args <- list(x = x,
-                                 y = y)
-                    args <- c(args, theDots)
-                    do.call(RSNNS::rbfDDA, args)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata)
-                    if(modelFit$problemType == "Classification")
-                    {
-                      out <- modelFit$obsLevels[apply(out, 1, which.max)]
-                    } else out <- out[,1]
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata)
-                    colnames(out) <- modelFit$obsLevels
-                    out
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("Neural Network","L2 Regularization", "Radial Basis Function"),
-                  sort = function(x) x[order(-x$negativeThreshold),])
+modelInfo <- list(
+  label = "Radial Basis Function Network",
+  library = "RSNNS",
+  loop = NULL,
+  type = c('Regression', 'Classification'),
+  parameters = data.frame(
+    parameter = c('negativeThreshold'),
+    class = c('numeric'),
+    label = c('Activation Limit for Conflicting Classes')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(negativeThreshold = 10^(-(1:len)))
+    } else {
+      out <- data.frame(negativeThreshold = runif(len, min = 0, 3))
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    theDots <- list(...)
+
+    if (any(names(theDots) == "learnFunc")) {
+      theDots$learnFunc <- NULL
+      warning(
+        "Cannot over-ride 'learnFunc' argument for this model. RBF-DDA is used."
+      )
+    }
+    if (any(names(theDots) == "learnFuncParams")) {
+      theDots$learnFuncParams[2] <- param$negativeThreshold
+    } else {
+      theDots$learnFuncParams <- c(0.4, param$negativeThreshold, 5)
+    }
+
+    y <- RSNNS:::decodeClassLabels(y)
+    args <- list(x = x, y = y)
+    args <- c(args, theDots)
+    do.call(RSNNS::rbfDDA, args)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata)
+    if (modelFit$problemType == "Classification") {
+      out <- modelFit$obsLevels[apply(out, 1, which.max)]
+    } else {
+      out <- out[, 1]
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata)
+    colnames(out) <- modelFit$obsLevels
+    out
+  },
+  levels = function(x) x$obsLevels,
+  tags = c("Neural Network", "L2 Regularization", "Radial Basis Function"),
+  sort = function(x) x[order(-x$negativeThreshold), ]
+)

--- a/inst/model_sources/files/rda.R
+++ b/inst/model_sources/files/rda.R
@@ -1,33 +1,47 @@
-modelInfo <- list(label = "Regularized Discriminant Analysis",
-                  library = "klaR",
-                  loop = NULL,
-                  type = "Classification",
-                  parameters = data.frame(parameter = c("gamma", "lambda"),
-                                          class = rep("numeric", 2),
-                                          label = c("Gamma", "Lambda")),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- expand.grid(gamma = seq(0, 1, length = len), 
-                                         lambda =  seq(0, 1, length = len))
-                    } else {
-                      out <- data.frame(gamma = runif(len, min = 0, max = 1), 
-                                        lambda = runif(len, min = 0, max = 1))
-                    }
-                    out
-                  }, 
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    klaR:::rda(x, y, gamma = param$gamma, lambda = param$lambda, ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) 
-                    klaR:::predict.rda(modelFit, newdata)$class,
-                  prob = function(modelFit, newdata, submodels = NULL)
-                    klaR:::predict.rda(modelFit, newdata)$posterior,
-                  predictors = function(x, ...) x$varnames,
-                  tags = c("Discriminant Analysis", "Polynomial Model", "Regularization",
-                           "Linear Classifier"),
-                  levels = function(x) names(x$prior),
-                  sort = function(x) {
-                    # since lds is less complex than qda, we
-                    # sort on lambda (larger are least complex)
-                    x[order(-x$lambda, x$gamma),] 
-                  })
+modelInfo <- list(
+  label = "Regularized Discriminant Analysis",
+  library = "klaR",
+  loop = NULL,
+  type = "Classification",
+  parameters = data.frame(
+    parameter = c("gamma", "lambda"),
+    class = rep("numeric", 2),
+    label = c("Gamma", "Lambda")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        gamma = seq(0, 1, length = len),
+        lambda = seq(0, 1, length = len)
+      )
+    } else {
+      out <- data.frame(
+        gamma = runif(len, min = 0, max = 1),
+        lambda = runif(len, min = 0, max = 1)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    klaR:::rda(x, y, gamma = param$gamma, lambda = param$lambda, ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    klaR:::predict.rda(modelFit, newdata)$class
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    klaR:::predict.rda(modelFit, newdata)$posterior
+  },
+  predictors = function(x, ...) x$varnames,
+  tags = c(
+    "Discriminant Analysis",
+    "Polynomial Model",
+    "Regularization",
+    "Linear Classifier"
+  ),
+  levels = function(x) names(x$prior),
+  sort = function(x) {
+    # since lds is less complex than qda, we
+    # sort on lambda (larger are least complex)
+    x[order(-x$lambda, x$gamma), ]
+  }
+)

--- a/inst/model_sources/files/regLogistic.R
+++ b/inst/model_sources/files/regLogistic.R
@@ -1,55 +1,71 @@
-modelInfo <- list(label = "Regularized Logistic Regression",
-                  library = "LiblineaR",
-                  type = c ("Classification"),
-                  parameters = data.frame(parameter = c('cost', "loss", 'epsilon'),
-                                          class = c("numeric", "character", "numeric"),
-                                          label = c("Cost", "Loss Function", "Tolerance" )),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(cost = 2 ^((1:len)- ceiling(len*0.5)),
-                                         loss = c("L1", "L2_dual", "L2_primal"),
-                                         epsilon = signif(0.01 * (10^((1:len) - ceiling(len*0.5))), 2) )
-                    } else {
-                      out <- data.frame(cost = 2^runif(len, min = -10, max = 10),
-                                        loss = sample(c("L1", "L2_dual", "L2_primal"), size = len, replace = TRUE),
-                                        epsilon = 1^runif(len, min=-10, max= 10))
-                    }
-                    out
-                  }, 
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    
-                    if( !(param$loss %in% c( "L1", "L2_dual", "L2_primal")) ) {
-                      stop("Loss function is not recognised.", call. = FALSE)
-                    }
-                    if(!is.factor(y)) {
-                      stop('y is not recognised as a factor', call. = FALSE)
-                    }
-                    model_type <-
-                      ifelse(param$loss == "L1", 6, ifelse(param$loss == "L2_primal", 0, 7))
-                    out <- LiblineaR::LiblineaR(
-                      data = as.matrix(x), 
-                      target = y,
-                      cost = param$cost, 
-                      epsilon = param$epsilon,
-                      type = model_type,
-                      ...
-                    )
-                    
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    LiblineaR:::predict.LiblineaR(modelFit, newdata)$predictions
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL){
-                    LiblineaR:::predict.LiblineaR(modelFit,newdata, proba = TRUE)$probabilities
-                  },
-                  predictors = function(x, ...) { 
-                    out <- colnames(x$W)
-                    out[out != "Bias"]
-                  },
-                  tags = c("Linear Classifier", "Robust Methods", "L1 Regularization", "L2 Regularization"),
-                  levels = function(x) x$levels,
-                  sort = function(x) {
-                    x[order(x$cost),]
-                  })
+modelInfo <- list(
+  label = "Regularized Logistic Regression",
+  library = "LiblineaR",
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = c('cost', "loss", 'epsilon'),
+    class = c("numeric", "character", "numeric"),
+    label = c("Cost", "Loss Function", "Tolerance")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        cost = 2^((1:len) - ceiling(len * 0.5)),
+        loss = c("L1", "L2_dual", "L2_primal"),
+        epsilon = signif(0.01 * (10^((1:len) - ceiling(len * 0.5))), 2)
+      )
+    } else {
+      out <- data.frame(
+        cost = 2^runif(len, min = -10, max = 10),
+        loss = sample(
+          c("L1", "L2_dual", "L2_primal"),
+          size = len,
+          replace = TRUE
+        ),
+        epsilon = 1^runif(len, min = -10, max = 10)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (!(param$loss %in% c("L1", "L2_dual", "L2_primal"))) {
+      stop("Loss function is not recognised.", call. = FALSE)
+    }
+    if (!is.factor(y)) {
+      stop('y is not recognised as a factor', call. = FALSE)
+    }
+    model_type <-
+      ifelse(param$loss == "L1", 6, ifelse(param$loss == "L2_primal", 0, 7))
+    out <- LiblineaR::LiblineaR(
+      data = as.matrix(x),
+      target = y,
+      cost = param$cost,
+      epsilon = param$epsilon,
+      type = model_type,
+      ...
+    )
+
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    LiblineaR:::predict.LiblineaR(modelFit, newdata)$predictions
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    LiblineaR:::predict.LiblineaR(modelFit, newdata, proba = TRUE)$probabilities
+  },
+  predictors = function(x, ...) {
+    out <- colnames(x$W)
+    out[out != "Bias"]
+  },
+  tags = c(
+    "Linear Classifier",
+    "Robust Methods",
+    "L1 Regularization",
+    "L2 Regularization"
+  ),
+  levels = function(x) x$levels,
+  sort = function(x) {
+    x[order(x$cost), ]
+  }
+)

--- a/inst/model_sources/files/relaxo.R
+++ b/inst/model_sources/files/relaxo.R
@@ -1,65 +1,84 @@
-modelInfo <- list(label = "Relaxed Lasso",
-                  library = c("relaxo", "plyr"),
-                  type = c('Regression'),
-                  parameters = data.frame(parameter = c('lambda', 'phi'),
-                                          class = c('numeric', 'numeric'),
-                                          label = c('Penalty Parameter', 'Relaxation Parameter')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    tmp <- relaxo::relaxo(as.matrix(x), y)
-                    lambdas <- log10(tmp$lambda)[-c(1, length(tmp$lambda))]
+modelInfo <- list(
+  label = "Relaxed Lasso",
+  library = c("relaxo", "plyr"),
+  type = c('Regression'),
+  parameters = data.frame(
+    parameter = c('lambda', 'phi'),
+    class = c('numeric', 'numeric'),
+    label = c('Penalty Parameter', 'Relaxation Parameter')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    tmp <- relaxo::relaxo(as.matrix(x), y)
+    lambdas <- log10(tmp$lambda)[-c(1, length(tmp$lambda))]
 
-                    if(search == "grid") {
-                      out <- expand.grid(phi = seq(0.1, 0.9, length = len),
-                                         lambda = 10^seq(min(lambdas), 
-                                                         quantile(lambdas, probs = .9), 
-                                                         length = len))
-                    } else {
-                      out <- data.frame(lambda = 10^runif(len, min = min(lambdas), max = max(lambdas)), 
-                                        phi = runif(len, min = 0, max = 1))
-                    }
-                    out
-                    
-                  },
-                  loop = function(grid) {
-                    loop <- plyr::ddply(grid,  plyr::`.`(phi), function(x) c(lambda = max(x$lambda)))
+    if (search == "grid") {
+      out <- expand.grid(
+        phi = seq(0.1, 0.9, length = len),
+        lambda = 10^seq(
+          min(lambdas),
+          quantile(lambdas, probs = .9),
+          length = len
+        )
+      )
+    } else {
+      out <- data.frame(
+        lambda = 10^runif(len, min = min(lambdas), max = max(lambdas)),
+        phi = runif(len, min = 0, max = 1)
+      )
+    }
+    out
+  },
+  loop = function(grid) {
+    loop <- plyr::ddply(grid, plyr::`.`(phi), function(x) {
+      c(lambda = max(x$lambda))
+    })
 
-                    submodels <- vector(mode = "list", length = nrow(loop))
-                    
-                    for(i in seq(along = submodels))
-                    {
-                      submodels[[i]] <- data.frame(lambda = subset(grid, subset = phi == loop$phi[i] 
-                                                                                 & lambda < loop$lambda[i])$lambda)
-                    } 
-                    list(loop = loop, submodels = submodels)           
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    relaxo::relaxo(as.matrix(x), y, phi = param$phi, ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit,
-                                   as.matrix(newdata),
-                                   lambda = min(max(modelFit$lambda), modelFit$tuneValue$lambda),
-                                   phi = modelFit$tuneValue$phi)
-                    
-                    if(!is.null(submodels))
-                    {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
-                      
-                      for(j in seq(along = submodels$lambda))
-                      {
-                        tmp[[j+1]] <- predict(modelFit,
-                                              as.matrix(newdata),
-                                              lambda = min(max(modelFit$lambda), submodels$lambda[j]),
-                                              phi = modelFit$tuneValue$phi)
-                      }
-                      out <- tmp
-                    }
-                    
-                    out
-                  },
-                  prob = NULL,
-                  tags = c("Implicit Feature Selection", 
-                           "L1 Regularization", "L2 Regularization",
-                           "Linear Regression"),
-                  sort = function(x) x[order(x$phi, -x$lambda),])
+    submodels <- vector(mode = "list", length = nrow(loop))
+
+    for (i in seq(along = submodels)) {
+      submodels[[i]] <- data.frame(
+        lambda = subset(
+          grid,
+          subset = phi == loop$phi[i] & lambda < loop$lambda[i]
+        )$lambda
+      )
+    }
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    relaxo::relaxo(as.matrix(x), y, phi = param$phi, ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(
+      modelFit,
+      as.matrix(newdata),
+      lambda = min(max(modelFit$lambda), modelFit$tuneValue$lambda),
+      phi = modelFit$tuneValue$phi
+    )
+
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
+
+      for (j in seq(along = submodels$lambda)) {
+        tmp[[j + 1]] <- predict(
+          modelFit,
+          as.matrix(newdata),
+          lambda = min(max(modelFit$lambda), submodels$lambda[j]),
+          phi = modelFit$tuneValue$phi
+        )
+      }
+      out <- tmp
+    }
+
+    out
+  },
+  prob = NULL,
+  tags = c(
+    "Implicit Feature Selection",
+    "L1 Regularization",
+    "L2 Regularization",
+    "Linear Regression"
+  ),
+  sort = function(x) x[order(x$phi, -x$lambda), ]
+)

--- a/inst/model_sources/files/rf.R
+++ b/inst/model_sources/files/rf.R
@@ -1,68 +1,96 @@
-modelInfo <- list(label = "Random Forest",
-                  library = "randomForest",
-                  loop = NULL,
-                  type = c("Classification", "Regression"),
-                  parameters = data.frame(parameter = "mtry",
-                                          class = "numeric",
-                                          label = "#Randomly Selected Predictors"),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- data.frame(mtry = caret::var_seq(p = ncol(x),
-                                                              classification = is.factor(y),
-                                                              len = len))
-                    } else {
-                      out <- data.frame(mtry = unique(sample(1:ncol(x), size = len, replace = TRUE)))
-                    }
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...)
-                    randomForest::randomForest(x, y, mtry = param$mtry, ...),
-                  predict = function(modelFit, newdata, submodels = NULL)
-                    if(!is.null(newdata)) predict(modelFit, newdata) else predict(modelFit),
-                  prob = function(modelFit, newdata, submodels = NULL)
-                    if(!is.null(newdata)) predict(modelFit, newdata, type = "prob") else predict(modelFit, type = "prob"),
-                  predictors = function(x, ...) {
-                    ## After doing some testing, it looks like randomForest
-                    ## will only try to split on plain main effects (instead
-                    ## of interactions or terms like I(x^2).
-                    varIndex <- as.numeric(names(table(x$forest$bestvar)))
-                    varIndex <- varIndex[varIndex > 0]
-                    varsUsed <- names(x$forest$ncat)[varIndex]
-                    varsUsed
-                  },
-                  varImp = function(object, ...){
-                    varImp <- randomForest::importance(object, ...)
-                    if(object$type == "regression") {
-                      if("%IncMSE" %in% colnames(varImp)) {
-                        varImp <- data.frame(Overall = varImp[,"%IncMSE"])
-                      } else {
-                        varImp <- data.frame(Overall = varImp[,1])
-                      }
-                    }
-                    else {
-                      retainNames <- levels(object$y)
-                      if(all(retainNames %in% colnames(varImp))) {
-                        varImp <- varImp[, retainNames]
-                      } else {
-                        varImp <- data.frame(Overall = varImp[,1])
-                      }
-                    }
+modelInfo <- list(
+  label = "Random Forest",
+  library = "randomForest",
+  loop = NULL,
+  type = c("Classification", "Regression"),
+  parameters = data.frame(
+    parameter = "mtry",
+    class = "numeric",
+    label = "#Randomly Selected Predictors"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(
+        mtry = caret::var_seq(
+          p = ncol(x),
+          classification = is.factor(y),
+          len = len
+        )
+      )
+    } else {
+      out <- data.frame(
+        mtry = unique(sample(1:ncol(x), size = len, replace = TRUE))
+      )
+    }
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    randomForest::randomForest(x, y, mtry = param$mtry, ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.null(newdata)) predict(modelFit, newdata) else predict(modelFit)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.null(newdata)) {
+      predict(modelFit, newdata, type = "prob")
+    } else {
+      predict(modelFit, type = "prob")
+    }
+  },
+  predictors = function(x, ...) {
+    ## After doing some testing, it looks like randomForest
+    ## will only try to split on plain main effects (instead
+    ## of interactions or terms like I(x^2).
+    varIndex <- as.numeric(names(table(x$forest$bestvar)))
+    varIndex <- varIndex[varIndex > 0]
+    varsUsed <- names(x$forest$ncat)[varIndex]
+    varsUsed
+  },
+  varImp = function(object, ...) {
+    varImp <- randomForest::importance(object, ...)
+    if (object$type == "regression") {
+      if ("%IncMSE" %in% colnames(varImp)) {
+        varImp <- data.frame(Overall = varImp[, "%IncMSE"])
+      } else {
+        varImp <- data.frame(Overall = varImp[, 1])
+      }
+    } else {
+      retainNames <- levels(object$y)
+      if (all(retainNames %in% colnames(varImp))) {
+        varImp <- varImp[, retainNames]
+      } else {
+        varImp <- data.frame(Overall = varImp[, 1])
+      }
+    }
 
-                    out <- as.data.frame(varImp, stringsAsFactors = TRUE)
-                    if(dim(out)[2] == 2) {
-                      tmp <- apply(out, 1, mean)
-                      out[,1] <- out[,2] <- tmp
-                    }
-                    out
-                  },
-                  levels = function(x) x$classes,
-                  tags = c("Random Forest", "Ensemble Model", "Bagging", "Implicit Feature Selection"),
-                  sort = function(x) x[order(x[,1]),],
-                  oob = function(x) {
-                    out <- switch(x$type,
-                                  regression =   c(sqrt(max(x$mse[length(x$mse)], 0)), x$rsq[length(x$rsq)]),
-                                  classification =  c(1 - x$err.rate[x$ntree, "OOB"],
-                                                      e1071::classAgreement(x$confusion[,-dim(x$confusion)[2]])[["kappa"]]))
-                    names(out) <- if(x$type == "regression") c("RMSE", "Rsquared") else c("Accuracy", "Kappa")
-                    out
-                  })
-
+    out <- as.data.frame(varImp, stringsAsFactors = TRUE)
+    if (dim(out)[2] == 2) {
+      tmp <- apply(out, 1, mean)
+      out[, 1] <- out[, 2] <- tmp
+    }
+    out
+  },
+  levels = function(x) x$classes,
+  tags = c(
+    "Random Forest",
+    "Ensemble Model",
+    "Bagging",
+    "Implicit Feature Selection"
+  ),
+  sort = function(x) x[order(x[, 1]), ],
+  oob = function(x) {
+    out <- switch(
+      x$type,
+      regression = c(sqrt(max(x$mse[length(x$mse)], 0)), x$rsq[length(x$rsq)]),
+      classification = c(
+        1 - x$err.rate[x$ntree, "OOB"],
+        e1071::classAgreement(x$confusion[, -dim(x$confusion)[2]])[["kappa"]]
+      )
+    )
+    names(out) <- if (x$type == "regression") {
+      c("RMSE", "Rsquared")
+    } else {
+      c("Accuracy", "Kappa")
+    }
+    out
+  }
+)

--- a/inst/model_sources/files/rf.R
+++ b/inst/model_sources/files/rf.R
@@ -27,7 +27,11 @@ modelInfo <- list(
     randomForest::randomForest(x, y, mtry = param$mtry, ...)
   },
   predict = function(modelFit, newdata, submodels = NULL) {
-    if (!is.null(newdata)) predict(modelFit, newdata) else predict(modelFit)
+    if (!is.null(newdata)) {
+      predict(modelFit, newdata)
+    } else {
+      predict(modelFit)
+    }
   },
   prob = function(modelFit, newdata, submodels = NULL) {
     if (!is.null(newdata)) {
@@ -86,10 +90,10 @@ modelInfo <- list(
         e1071::classAgreement(x$confusion[, -dim(x$confusion)[2]])[["kappa"]]
       )
     )
-    names(out) <- if (x$type == "regression") {
-      c("RMSE", "Rsquared")
+    if (x$type == "regression") {
+      names(out) <- c("RMSE", "Rsquared")
     } else {
-      c("Accuracy", "Kappa")
+      names(out) <- c("Accuracy", "Kappa")
     }
     out
   }

--- a/inst/model_sources/files/rfRules.R
+++ b/inst/model_sources/files/rfRules.R
@@ -1,130 +1,168 @@
-modelInfo <- list(label = "Random Forest Rule-Based Model",
-                  library = c("randomForest", "inTrees", "plyr"),
-                  type = c("Classification", "Regression"),
-                  parameters = data.frame(parameter = c("mtry","maxdepth"),
-                                          class = rep("numeric",2),
-                                          label = c("#Randomly Selected Predictors","Maximum Rule Depth")),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- data.frame(mtry = caret::var_seq(p = ncol(x),
-                                                              classification = is.factor(y),
-                                                              len = len),
-                                        maxdepth = (1:len)+1)
-                    } else {
-                      out <- data.frame(mtry = sample(1:ncol(x), size = len, replace = TRUE),
-                                        maxdepth = sample(1:15, size = len, replace = TRUE))
-                    }
-                  },
-                  loop = function(grid) {
-                    loop <- plyr::ddply(grid, c("mtry"),
-                                  function(x) c(maxdepth = max(x$maxdepth)))
-                    submodels <- vector(mode = "list", length = nrow(loop))
-                    for(i in seq(along = loop$maxdepth)) {
-                      index <- which(grid$mtry == loop$mtry[i])
-                      trees <- grid[index, "maxdepth"]
-                      submodels[[i]] <- data.frame(maxdepth = trees[trees != loop$maxdepth[i]])
-                    }
-                    list(loop = loop, submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    if(!is.data.frame(x) | inherits(x, "tbl_df"))
-                      x <- as.data.frame(x, stringsAsFactors = TRUE)
-                    RFor <- randomForest::randomForest(x, y, mtry = min(param$mtry, ncol(x)), ...)
-                    treeList <- inTrees::RF2List(RFor)
-                    exec <- inTrees::extractRules(treeList,x, maxdepth=param$maxdepth, ntree = RFor$ntree)
-                    ruleMetric <- inTrees::getRuleMetric(exec,x,y)
-                    ruleMetric <- inTrees::pruneRule(ruleMetric,x,y)
-                    ruleMetric <- inTrees::selectRuleRRF(ruleMetric,x,y)
-                    out <- list(model = inTrees::buildLearner(ruleMetric,x,y))
-                    if(!last) {
-                      out$rf <- treeList
-                      out$x <- x
-                      out$y <- y
-                      out$trees <- RFor$ntree
-                    }
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata) | inherits(newdata, "tbl_df"))
-                      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    out <- inTrees::applyLearner(modelFit$model, newdata)
-                    if(modelFit$problemType == "Regression") out <- as.numeric(out)
-                    if(!is.null(submodels)) {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- if(is.matrix(out)) out[,1] else out
-                      for(i in seq(along = submodels$maxdepth)) {
-                        exec <- inTrees::extractRules(modelFit$rf,
-                                                      modelFit$x,
-                                                      maxdepth=submodels$maxdepth[i],
-                                                      ntree = modelFit$trees)
-                        ruleMetric <- inTrees::getRuleMetric(exec,modelFit$x,modelFit$y)
-                        ruleMetric <- inTrees::pruneRule(ruleMetric,modelFit$x,modelFit$y)
-                        ruleMetric <- inTrees::selectRuleRRF(ruleMetric,modelFit$x,modelFit$y)
-                        mod <- inTrees::buildLearner(ruleMetric,modelFit$x,modelFit$y)
-                        tmp[[i+1]] <- inTrees::applyLearner(mod, newdata)
-                        if(modelFit$problemType == "Regression") tmp[[i+1]] <- as.numeric(tmp[[i+1]])
-                      }
-                      out <- tmp
-                    }
-                    out
-                  },
-                  prob = NULL,
-                  predictors = function(x, ...) {
-                    split_up <- strsplit(x$model[,"condition"], "&")
+modelInfo <- list(
+  label = "Random Forest Rule-Based Model",
+  library = c("randomForest", "inTrees", "plyr"),
+  type = c("Classification", "Regression"),
+  parameters = data.frame(
+    parameter = c("mtry", "maxdepth"),
+    class = rep("numeric", 2),
+    label = c("#Randomly Selected Predictors", "Maximum Rule Depth")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(
+        mtry = caret::var_seq(
+          p = ncol(x),
+          classification = is.factor(y),
+          len = len
+        ),
+        maxdepth = (1:len) + 1
+      )
+    } else {
+      out <- data.frame(
+        mtry = sample(1:ncol(x), size = len, replace = TRUE),
+        maxdepth = sample(1:15, size = len, replace = TRUE)
+      )
+    }
+  },
+  loop = function(grid) {
+    loop <- plyr::ddply(grid, c("mtry"), function(x) {
+      c(maxdepth = max(x$maxdepth))
+    })
+    submodels <- vector(mode = "list", length = nrow(loop))
+    for (i in seq(along = loop$maxdepth)) {
+      index <- which(grid$mtry == loop$mtry[i])
+      trees <- grid[index, "maxdepth"]
+      submodels[[i]] <- data.frame(maxdepth = trees[trees != loop$maxdepth[i]])
+    }
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (!is.data.frame(x) | inherits(x, "tbl_df")) {
+      x <- as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    RFor <- randomForest::randomForest(
+      x,
+      y,
+      mtry = min(param$mtry, ncol(x)),
+      ...
+    )
+    treeList <- inTrees::RF2List(RFor)
+    exec <- inTrees::extractRules(
+      treeList,
+      x,
+      maxdepth = param$maxdepth,
+      ntree = RFor$ntree
+    )
+    ruleMetric <- inTrees::getRuleMetric(exec, x, y)
+    ruleMetric <- inTrees::pruneRule(ruleMetric, x, y)
+    ruleMetric <- inTrees::selectRuleRRF(ruleMetric, x, y)
+    out <- list(model = inTrees::buildLearner(ruleMetric, x, y))
+    if (!last) {
+      out$rf <- treeList
+      out$x <- x
+      out$y <- y
+      out$trees <- RFor$ntree
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata) | inherits(newdata, "tbl_df")) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    out <- inTrees::applyLearner(modelFit$model, newdata)
+    if (modelFit$problemType == "Regression") {
+      out <- as.numeric(out)
+    }
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- if (is.matrix(out)) out[, 1] else out
+      for (i in seq(along = submodels$maxdepth)) {
+        exec <- inTrees::extractRules(
+          modelFit$rf,
+          modelFit$x,
+          maxdepth = submodels$maxdepth[i],
+          ntree = modelFit$trees
+        )
+        ruleMetric <- inTrees::getRuleMetric(exec, modelFit$x, modelFit$y)
+        ruleMetric <- inTrees::pruneRule(ruleMetric, modelFit$x, modelFit$y)
+        ruleMetric <- inTrees::selectRuleRRF(ruleMetric, modelFit$x, modelFit$y)
+        mod <- inTrees::buildLearner(ruleMetric, modelFit$x, modelFit$y)
+        tmp[[i + 1]] <- inTrees::applyLearner(mod, newdata)
+        if (modelFit$problemType == "Regression") {
+          tmp[[i + 1]] <- as.numeric(tmp[[i + 1]])
+        }
+      }
+      out <- tmp
+    }
+    out
+  },
+  prob = NULL,
+  predictors = function(x, ...) {
+    split_up <- strsplit(x$model[, "condition"], "&")
 
-                    isolate <- function(x) {
-                      index <- gregexpr("]", x, fixed = TRUE)
-                      out <- NULL
-                      for(i in seq_along(index)) {
-                        if(all(index[[i]] > 0)) {
-                          tmp <- substring(x[i], 1, index[[i]][1])
-                          tmp <- gsub("(X)|(\\[)|(\\])|(,)|( )", "", tmp)
-                          tmp <- tmp[tmp != ""]
-                          out <- c(out, as.numeric(tmp))
-                        }
-                      }
-                      as.numeric(unique(out))
-                    }
+    isolate <- function(x) {
+      index <- gregexpr("]", x, fixed = TRUE)
+      out <- NULL
+      for (i in seq_along(index)) {
+        if (all(index[[i]] > 0)) {
+          tmp <- substring(x[i], 1, index[[i]][1])
+          tmp <- gsub("(X)|(\\[)|(\\])|(,)|( )", "", tmp)
+          tmp <- tmp[tmp != ""]
+          out <- c(out, as.numeric(tmp))
+        }
+      }
+      as.numeric(unique(out))
+    }
 
-                    var_index <- unique(unlist(lapply(split_up, isolate)))
-                    if(length(var_index) > 0) x$xNames[var_index] else NULL
-                  },
-                  varImp = function(object, ...) {
-                    split_up <- strsplit(object$model[,"condition"], "&")
+    var_index <- unique(unlist(lapply(split_up, isolate)))
+    if (length(var_index) > 0) x$xNames[var_index] else NULL
+  },
+  varImp = function(object, ...) {
+    split_up <- strsplit(object$model[, "condition"], "&")
 
-                    isolate <- function(x) {
-                      index <- gregexpr("]", x, fixed = TRUE)
-                      out <- NULL
-                      for(i in seq_along(index)) {
-                        if(all(index[[i]] > 0)) {
-                          tmp <- substring(x[i], 1, index[[i]][1])
-                          tmp <- gsub("(X)|(\\[)|(\\])|(,)|( )", "", tmp)
-                          tmp <- tmp[tmp != ""]
-                          out <- c(out, as.numeric(tmp))
-                        }
-                      }
-                      as.numeric(unique(out))
-                    }
+    isolate <- function(x) {
+      index <- gregexpr("]", x, fixed = TRUE)
+      out <- NULL
+      for (i in seq_along(index)) {
+        if (all(index[[i]] > 0)) {
+          tmp <- substring(x[i], 1, index[[i]][1])
+          tmp <- gsub("(X)|(\\[)|(\\])|(,)|( )", "", tmp)
+          tmp <- tmp[tmp != ""]
+          out <- c(out, as.numeric(tmp))
+        }
+      }
+      as.numeric(unique(out))
+    }
 
-                    var_index <- lapply(split_up, isolate)
+    var_index <- lapply(split_up, isolate)
 
-                    vars_dat <- lapply(var_index,
-                                       function(x, p) {
-                                         out <- rep(0, p)
-                                         if(length(x) > 0) out[x] <- 1
-                                         out
-                                       },
-                                       p = length(object$xNames))
-                    vars_dat <- do.call("rbind", vars_dat)
-                    colnames(vars_dat) <- object$xNames
-                    freqs <- as.numeric(object$model[,"freq"])
-                    vars_dat <- vars_dat * freqs
-                    var_imp <- apply(vars_dat, 2, sum)
-                    out <- data.frame(Overall = as.vector(var_imp))
-                    rownames(out) <- names(var_imp)
-                    out
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("Random Forest", "Ensemble Model", "Bagging",
-                           "Implicit Feature Selection", "Rule-Based Model"),
-                  sort = function(x) x[order(x[,"maxdepth"]),])
+    vars_dat <- lapply(
+      var_index,
+      function(x, p) {
+        out <- rep(0, p)
+        if (length(x) > 0) {
+          out[x] <- 1
+        }
+        out
+      },
+      p = length(object$xNames)
+    )
+    vars_dat <- do.call("rbind", vars_dat)
+    colnames(vars_dat) <- object$xNames
+    freqs <- as.numeric(object$model[, "freq"])
+    vars_dat <- vars_dat * freqs
+    var_imp <- apply(vars_dat, 2, sum)
+    out <- data.frame(Overall = as.vector(var_imp))
+    rownames(out) <- names(var_imp)
+    out
+  },
+  levels = function(x) x$obsLevels,
+  tags = c(
+    "Random Forest",
+    "Ensemble Model",
+    "Bagging",
+    "Implicit Feature Selection",
+    "Rule-Based Model"
+  ),
+  sort = function(x) x[order(x[, "maxdepth"]), ]
+)

--- a/inst/model_sources/files/rfRules.R
+++ b/inst/model_sources/files/rfRules.R
@@ -75,7 +75,11 @@ modelInfo <- list(
     }
     if (!is.null(submodels)) {
       tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-      tmp[[1]] <- if (is.matrix(out)) out[, 1] else out
+      if (is.matrix(out)) {
+        tmp[[1]] <- out[, 1]
+      } else {
+        tmp[[1]] <- out
+      }
       for (i in seq(along = submodels$maxdepth)) {
         exec <- inTrees::extractRules(
           modelFit$rf,
@@ -115,7 +119,11 @@ modelInfo <- list(
     }
 
     var_index <- unique(unlist(lapply(split_up, isolate)))
-    if (length(var_index) > 0) x$xNames[var_index] else NULL
+    if (length(var_index) > 0) {
+      x$xNames[var_index]
+    } else {
+      NULL
+    }
   },
   varImp = function(object, ...) {
     split_up <- strsplit(object$model[, "condition"], "&")

--- a/inst/model_sources/files/ridge.R
+++ b/inst/model_sources/files/ridge.R
@@ -1,42 +1,51 @@
-modelInfo <- list(label = "Ridge Regression",
-                  library = "elasticnet",
-                  type = "Regression",
-                  parameters = data.frame(parameter = c('lambda'),
-                                          class = c("numeric"),
-                                          label = c('Weight Decay')),
-                  grid = function(x, y, len = NULL, search = "grid")  {
-                    if(search == "grid") {
-                      out <- expand.grid(lambda = c(0, 10 ^ seq(-1, -4, length = len - 1)))
-                    } else {
-                      out <- data.frame(lambda = 10^runif(len, min = -5, 1))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    elasticnet::enet(as.matrix(x), y, lambda = param$lambda)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    elasticnet::predict.enet(
-                      modelFit, newdata, 
-                      s = 1, 
-                      mode = "fraction")$fit
-                  },
-                  predictors = function(x, s = NULL, ...) {
-                    if(is.null(s)) {
-                      if(!is.null(x$tuneValue)) {
-                        s <- x$tuneValue$.fraction
-                      } else stop("must supply a vaue of s")
-                      out <- elasticnet::predict.enet(
-                        x, s = s,
-                        type = "coefficients",
-                        mode = "fraction")$coefficients
-                    } else {
-                      out <- elasticnet::predict.enet(x, s = s)$coefficients
-                      
-                    }
-                    names(out)[out != 0]
-                  },
-                  tags = c("Linear Regression", "L2 Regularization"),
-                  prob = NULL,
-                  sort = function(x) x[order(-x$lambda),])
+modelInfo <- list(
+  label = "Ridge Regression",
+  library = "elasticnet",
+  type = "Regression",
+  parameters = data.frame(
+    parameter = c('lambda'),
+    class = c("numeric"),
+    label = c('Weight Decay')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(lambda = c(0, 10^seq(-1, -4, length = len - 1)))
+    } else {
+      out <- data.frame(lambda = 10^runif(len, min = -5, 1))
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    elasticnet::enet(as.matrix(x), y, lambda = param$lambda)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    elasticnet::predict.enet(
+      modelFit,
+      newdata,
+      s = 1,
+      mode = "fraction"
+    )$fit
+  },
+  predictors = function(x, s = NULL, ...) {
+    if (is.null(s)) {
+      if (!is.null(x$tuneValue)) {
+        s <- x$tuneValue$.fraction
+      } else {
+        stop("must supply a vaue of s")
+      }
+      out <- elasticnet::predict.enet(
+        x,
+        s = s,
+        type = "coefficients",
+        mode = "fraction"
+      )$coefficients
+    } else {
+      out <- elasticnet::predict.enet(x, s = s)$coefficients
+    }
+    names(out)[out != 0]
+  },
+  tags = c("Linear Regression", "L2 Regularization"),
+  prob = NULL,
+  sort = function(x) x[order(-x$lambda), ]
+)

--- a/inst/model_sources/files/rlda.R
+++ b/inst/model_sources/files/rlda.R
@@ -1,33 +1,51 @@
-modelInfo <- list(label = "Regularized Linear Discriminant Analysis",
-                  library = "sparsediscrim",
-                  loop = NULL,
-                  type = "Classification",
-                  parameters = data.frame(parameter = "estimator",
-                                          class = "character",
-                                          label = "Regularization Method"),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    data.frame(estimator = c("Moore-Penrose Pseudo-Inverse",
-                                             "Schafer-Strimmer",
-                                             "Thomaz-Kitani-Gillies"))
-                  }, 
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    if(as.character(param$estimator == "Moore-Penrose Pseudo-Inverse")) {
-                      out <- sparsediscrim::lda_pseudo(x, y, ...)
-                    } else {
-                      if(as.character(param$estimator == "Schafer-Strimmer")) {
-                        out <- sparsediscrim::lda_schafer(x, y, ...)
-                      } else out <- sparsediscrim::lda_thomaz(x, y, ...)
-                    }
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) 
-                    predict(modelFit, newdata)$class,
-                  prob = function(modelFit, newdata, submodels = NULL){
-                    out <- predict(modelFit, newdata)$scores
-                    as.data.frame(t(apply(out, 2, function(x) exp(-x)/sum(exp(-x)))), stringsAsFactors = TRUE)
-                  },
-                  predictors = function(x, ...) x$varnames,
-                  tags = c("Discriminant Analysis", "Polynomial Model", "Regularization",
-                           "Linear Classifier"),
-                  levels = function(x) names(x$prior),
-                  sort = function(x) x)
+modelInfo <- list(
+  label = "Regularized Linear Discriminant Analysis",
+  library = "sparsediscrim",
+  loop = NULL,
+  type = "Classification",
+  parameters = data.frame(
+    parameter = "estimator",
+    class = "character",
+    label = "Regularization Method"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(
+      estimator = c(
+        "Moore-Penrose Pseudo-Inverse",
+        "Schafer-Strimmer",
+        "Thomaz-Kitani-Gillies"
+      )
+    )
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (as.character(param$estimator == "Moore-Penrose Pseudo-Inverse")) {
+      out <- sparsediscrim::lda_pseudo(x, y, ...)
+    } else {
+      if (as.character(param$estimator == "Schafer-Strimmer")) {
+        out <- sparsediscrim::lda_schafer(x, y, ...)
+      } else {
+        out <- sparsediscrim::lda_thomaz(x, y, ...)
+      }
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)$class
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata)$scores
+    as.data.frame(
+      t(apply(out, 2, function(x) exp(-x) / sum(exp(-x)))),
+      stringsAsFactors = TRUE
+    )
+  },
+  predictors = function(x, ...) x$varnames,
+  tags = c(
+    "Discriminant Analysis",
+    "Polynomial Model",
+    "Regularization",
+    "Linear Classifier"
+  ),
+  levels = function(x) names(x$prior),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/rlm.R
+++ b/inst/model_sources/files/rlm.R
@@ -15,10 +15,10 @@ modelInfo <- list(
     )
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
 

--- a/inst/model_sources/files/rlm.R
+++ b/inst/model_sources/files/rlm.R
@@ -1,51 +1,82 @@
-modelInfo <- list(label = "Robust Linear Model",
-                  library = "MASS",
-                  loop = NULL,
-                  type = "Regression",
-                  parameters = data.frame(parameter = c("intercept", "psi"),
-                                          class = c("logical", "character"),
-                                          label = c("intercept", "psi")),
-                  grid = function(x, y, len = NULL, search = "grid") 
-                    expand.grid(intercept = c(TRUE, FALSE),
-                                psi = c("psi.huber", "psi.hampel", "psi.bisquare")),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
+modelInfo <- list(
+  label = "Robust Linear Model",
+  library = "MASS",
+  loop = NULL,
+  type = "Regression",
+  parameters = data.frame(
+    parameter = c("intercept", "psi"),
+    class = c("logical", "character"),
+    label = c("intercept", "psi")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    expand.grid(
+      intercept = c(TRUE, FALSE),
+      psi = c("psi.huber", "psi.hampel", "psi.bisquare")
+    )
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
 
-                    psi <- MASS::psi.huber # default
-                    if (param$psi == "psi.bisquare")
-                      psi <- MASS::psi.bisquare else
-                    if (param$psi == "psi.hampel")
-                      psi <- MASS::psi.hampel
+    psi <- MASS::psi.huber # default
+    if (param$psi == "psi.bisquare") {
+      psi <- MASS::psi.bisquare
+    } else if (param$psi == "psi.hampel") {
+      psi <- MASS::psi.hampel
+    }
 
-                    if(!is.null(wts))
-                    {
-                      if (param$intercept)
-                        out <- MASS::rlm(.outcome ~ ., data = dat, weights = wts, psi = psi, ...)
-                      else
-                        out <- MASS::rlm(.outcome ~ 0 + ., data = dat, weights = wts, psi = psi,  ...)
-                    } else
-                    {
-                      if (param$intercept)
-                        out <- MASS::rlm(.outcome ~ ., data = dat, psi = psi,...)
-                      else
-                        out <- MASS::rlm(.outcome ~ 0 + ., data = dat, psi = psi, ...)
-                    }
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata)
-                  },
-                  prob = NULL,
-                  varImp = function(object, ...) {
-                    values <- summary(object)$coef
-                    varImps <-  abs(values[ !grepl( rownames(values), pattern = 'Intercept' ), 
-                                             grep("value$", colnames(values)), drop = FALSE])
-                    out <- data.frame(varImps)
-                    colnames(out) <- "Overall"
-                    if(!is.null(names(varImps))) rownames(out) <- names(varImps)
-                    out   
-                  },
-                  tags = c("Linear Regression", "Robust Model", "Accepts Case Weights"),
-                  sort = function(x) x)
+    if (!is.null(wts)) {
+      if (param$intercept) {
+        out <- MASS::rlm(
+          .outcome ~ .,
+          data = dat,
+          weights = wts,
+          psi = psi,
+          ...
+        )
+      } else {
+        out <- MASS::rlm(
+          .outcome ~ 0 + .,
+          data = dat,
+          weights = wts,
+          psi = psi,
+          ...
+        )
+      }
+    } else {
+      if (param$intercept) {
+        out <- MASS::rlm(.outcome ~ ., data = dat, psi = psi, ...)
+      } else {
+        out <- MASS::rlm(.outcome ~ 0 + ., data = dat, psi = psi, ...)
+      }
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata)
+  },
+  prob = NULL,
+  varImp = function(object, ...) {
+    values <- summary(object)$coef
+    varImps <- abs(values[
+      !grepl(rownames(values), pattern = 'Intercept'),
+      grep("value$", colnames(values)),
+      drop = FALSE
+    ])
+    out <- data.frame(varImps)
+    colnames(out) <- "Overall"
+    if (!is.null(names(varImps))) {
+      rownames(out) <- names(varImps)
+    }
+    out
+  },
+  tags = c("Linear Regression", "Robust Model", "Accepts Case Weights"),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/rmda.R
+++ b/inst/model_sources/files/rmda.R
@@ -42,7 +42,13 @@ modelInfo <- list(
   },
   varImp = NULL,
   predictors = function(x, ...) colnames(x$prms$data),
-  levels = function(x) if (any(names(x) == "obsLevels")) x$obsLevels else NULL,
+  levels = function(x) {
+    if (any(names(x) == "obsLevels")) {
+      x$obsLevels
+    } else {
+      NULL
+    }
+  },
   tags = c("Discriminant Analysis", "Mixture Model", "Robust Methods"),
   sort = function(x) x
 )

--- a/inst/model_sources/files/rmda.R
+++ b/inst/model_sources/files/rmda.R
@@ -1,39 +1,48 @@
-modelInfo <- list(label = "Robust Mixture Discriminant Analysis",
-                  library = "robustDA",
-                  loop = NULL,
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = c("K", "model"),
-                                          class = c("numeric", "character"),
-                                          label = c('#Subclasses Per Class', 'Model')),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    mods <- c("EII", "VII", "EEI", "EVI", "VEI", "VVI")
-                    if(search == "grid") {
-                      out <- expand.grid(K = (1:len) + 1,  model = c("VEV"))
-                    } else {
-                      out <- data.frame(K = sample(2:10, size = len, replace = TRUE), 
-                                        model = sample(mods, size = len, replace = TRUE))
-                    }
-                    out
-                  }, 
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    mod <- robustDA::rmda(x, as.numeric(y),
-                                          K = param$K,
-                                          model = as.character(param$model),
-                                          ...)
-                    mod$levels <- levels(y)
-                    mod
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata)$cls
-                    factor(modelFit$levels[out], levels = modelFit$levels)
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL){
-                    out <- predict(modelFit, newdata)$P
-                    colnames(out)<-  modelFit$obsLevels
-                    out
-                  },
-                  varImp = NULL,
-                  predictors = function(x, ...) colnames(x$prms$data),
-                  levels = function(x) if(any(names(x) == "obsLevels")) x$obsLevels else NULL,
-                  tags = c("Discriminant Analysis", "Mixture Model", "Robust Methods"),
-                  sort = function(x) x)
+modelInfo <- list(
+  label = "Robust Mixture Discriminant Analysis",
+  library = "robustDA",
+  loop = NULL,
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = c("K", "model"),
+    class = c("numeric", "character"),
+    label = c('#Subclasses Per Class', 'Model')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    mods <- c("EII", "VII", "EEI", "EVI", "VEI", "VVI")
+    if (search == "grid") {
+      out <- expand.grid(K = (1:len) + 1, model = c("VEV"))
+    } else {
+      out <- data.frame(
+        K = sample(2:10, size = len, replace = TRUE),
+        model = sample(mods, size = len, replace = TRUE)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    mod <- robustDA::rmda(
+      x,
+      as.numeric(y),
+      K = param$K,
+      model = as.character(param$model),
+      ...
+    )
+    mod$levels <- levels(y)
+    mod
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata)$cls
+    factor(modelFit$levels[out], levels = modelFit$levels)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata)$P
+    colnames(out) <- modelFit$obsLevels
+    out
+  },
+  varImp = NULL,
+  predictors = function(x, ...) colnames(x$prms$data),
+  levels = function(x) if (any(names(x) == "obsLevels")) x$obsLevels else NULL,
+  tags = c("Discriminant Analysis", "Mixture Model", "Robust Methods"),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/rocc.R
+++ b/inst/model_sources/files/rocc.R
@@ -1,31 +1,43 @@
-modelInfo <- list(label = "ROC-Based Classifier",
-                  library = "rocc",
-                  loop = NULL,
-                  type = c('Classification'),
-                  parameters = data.frame(parameter = c('xgenes'),
-                                          class = c('numeric'),
-                                          label = c('#Variables Retained')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- data.frame(xgenes = caret::var_seq(p = ncol(x), 
-                                                                classification = is.factor(y), 
-                                                                len = len))
-                    } else {
-                      out <- data.frame(xgenes = unique(sample(1:ncol(x), size = len, replace = TRUE)))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    newY <- factor(ifelse(y == levels(y)[1], 1, 0), levels = c("0", "1"))
-                    rocc::tr.rocc(g = t(as.matrix(x)), out = newY, xgenes = param$xgenes)
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    tmp <- rocc::p.rocc(modelFit, t(as.matrix(newdata)))
-                    factor(ifelse(tmp == "1",  modelFit$obsLevels[1],  modelFit$obsLevels[2]),
-                           levels =  modelFit$obsLevels)
-                  },
-                  levels = function(x) x$obsLevels,
-                  prob = NULL,
-                  predictors = function(x, ...) x$genes,
-                  tags = "ROC Curves",
-                  sort = function(x) x[order(x$xgenes),])
+modelInfo <- list(
+  label = "ROC-Based Classifier",
+  library = "rocc",
+  loop = NULL,
+  type = c('Classification'),
+  parameters = data.frame(
+    parameter = c('xgenes'),
+    class = c('numeric'),
+    label = c('#Variables Retained')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(
+        xgenes = caret::var_seq(
+          p = ncol(x),
+          classification = is.factor(y),
+          len = len
+        )
+      )
+    } else {
+      out <- data.frame(
+        xgenes = unique(sample(1:ncol(x), size = len, replace = TRUE))
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    newY <- factor(ifelse(y == levels(y)[1], 1, 0), levels = c("0", "1"))
+    rocc::tr.rocc(g = t(as.matrix(x)), out = newY, xgenes = param$xgenes)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    tmp <- rocc::p.rocc(modelFit, t(as.matrix(newdata)))
+    factor(
+      ifelse(tmp == "1", modelFit$obsLevels[1], modelFit$obsLevels[2]),
+      levels = modelFit$obsLevels
+    )
+  },
+  levels = function(x) x$obsLevels,
+  prob = NULL,
+  predictors = function(x, ...) x$genes,
+  tags = "ROC Curves",
+  sort = function(x) x[order(x$xgenes), ]
+)

--- a/inst/model_sources/files/rotationForest.R
+++ b/inst/model_sources/files/rotationForest.R
@@ -1,105 +1,134 @@
-modelInfo <- list(label = "Rotation Forest",
-                  library = "rotationForest",
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = c("K", "L"),
-                                          class = rep("numeric", 2),
-                                          label = c("#Variable Subsets", "Ensemble Size")),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    feas_k <- 1:15
-                    feas_k <- feas_k[ncol(x)%%feas_k == 0]
-                    if(search == "grid") {
-                      out <- expand.grid(K = feas_k[1:min(len, length(feas_k))], L = (1:len)*3) 
-                    } else {
-                      out <- data.frame(K = sample(feas_k, size = len, replace = TRUE), 
-                                        L = sample(1:100, size = len, replace = TRUE))
-                    }
-                    out
-                  },
-                  loop = function(grid) { 
-                    grid <- grid[order(grid$K, -grid$L, decreasing = TRUE),, drop = FALSE]
-                    unique_k <- unique(grid$K)
-                    loop <- data.frame(K = unique_k, L = NA)  
-                    submodels <- vector(mode = "list", length = length(unique_k))
-                    for(i in seq(along = unique_k)) {
-                      sub_L <- grid[grid$K == unique_k[i],"L"]
-                      loop$L[loop$K == unique_k[i]] <- sub_L[which.max(sub_L)]
-                      submodels[[i]] <- data.frame(L = sub_L[-which.max(sub_L)])
-                    }    
-                    list(loop = loop, submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    param$K <- min(param$k, floor(ncol(x)/2))
-                    if(length(lev) != 2)
-                      stop("rotationForest is only implemented for binary classification")
-                    y <- ifelse(y == lev[1], 1, 0)
-                    if(!is.data.frame(x)) x <- as.data.frame(x, stringsAsFactors = TRUE)
-                    rotationForest::rotationForest(x, y, K = param$K, L = param$L, ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    out <- predict(modelFit, newdata)
-                    out <- ifelse(out >= .5, modelFit$obsLevels[1], modelFit$obsLevels[2])
-                    
-                    if(!is.null(submodels)) {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
-                      all_L <- predict(modelFit, newdata, all = TRUE)
-                      for(j in seq(along = submodels$L)) {                        
-                        tmp_pred <- apply(all_L[, 1:submodels$L[j],drop = FALSE], 1, mean)
-                        tmp[[j+1]] <- ifelse(tmp_pred >= .5, modelFit$obsLevels[1], modelFit$obsLevels[2])
-                      }
-                      out <- tmp
-                    }
-                    out   
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    all_L <- predict(modelFit, newdata, all = TRUE)
-                    out <- apply(all_L, 1, mean)
-                    out <- data.frame(x = out, y = 1 - out)
-                    colnames(out) <- modelFit$obsLevels
-                    if(!is.null(rownames(newdata))) rownames(out) <- rownames(newdata)
-                    
-                    if(!is.null(submodels)) {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
-                      for(j in seq(along = submodels$L)) {  
-                        tmp_pred <- apply(all_L[, 1:submodels$L[j],drop = FALSE], 1, mean)
-                        tmp_pred <- data.frame(x = tmp_pred, y = 1 - tmp_pred)
-                        colnames(tmp_pred) <- modelFit$obsLevels
-                        if(!is.null(rownames(newdata))) rownames(tmp_pred) <- rownames(newdata)
-                        tmp[[j+1]] <- tmp_pred
-                      }
-                      out <- tmp
-                    }
-                    out   
-                  },
-                  predictors = function(x, ...) {
-                    non_zero <- function(x) {                      
-                      out <- apply(x, 1, function(x) any(x != 0))
-                      names(out)[out]
-                    }
-                    sort(unique(unlist(lapply(x$loadings, non_zero))))
-                  },
-                  varImp = function(object, ...) {
-                    vis <- lapply(object$models, varImp, scale = FALSE)
-                    wgt <- vector(mode = "list", length = length(vis))
-                    for(i in seq(along = vis)) {
-                      tmp <- vis[[i]]
-                      vi1 <- tmp[,1]
-                      names(vi1) <- rownames(tmp)
-                      l1 <- object$loadings[[i]]
-                      tmp2 <- vi1 %*% abs(as.matrix(l1[names(vi1),]))
-                      tmp2 <- tmp2[,sort(colnames(tmp2))]
-                      wgt[[i]] <- tmp2
-                    }
-                    wgt <- do.call("rbind", wgt)
-                    vi <- apply(wgt, 2, mean)
-                    out <- data.frame(Overall = vi)
-                    rownames(out) <- colnames(wgt)
-                    out
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("Ensemble Model", "Implicit Feature Selection", 
-                           "Feature Extraction Models", "Tree-Based Model", "Two Class Only"),
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Rotation Forest",
+  library = "rotationForest",
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = c("K", "L"),
+    class = rep("numeric", 2),
+    label = c("#Variable Subsets", "Ensemble Size")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    feas_k <- 1:15
+    feas_k <- feas_k[ncol(x) %% feas_k == 0]
+    if (search == "grid") {
+      out <- expand.grid(
+        K = feas_k[1:min(len, length(feas_k))],
+        L = (1:len) * 3
+      )
+    } else {
+      out <- data.frame(
+        K = sample(feas_k, size = len, replace = TRUE),
+        L = sample(1:100, size = len, replace = TRUE)
+      )
+    }
+    out
+  },
+  loop = function(grid) {
+    grid <- grid[order(grid$K, -grid$L, decreasing = TRUE), , drop = FALSE]
+    unique_k <- unique(grid$K)
+    loop <- data.frame(K = unique_k, L = NA)
+    submodels <- vector(mode = "list", length = length(unique_k))
+    for (i in seq(along = unique_k)) {
+      sub_L <- grid[grid$K == unique_k[i], "L"]
+      loop$L[loop$K == unique_k[i]] <- sub_L[which.max(sub_L)]
+      submodels[[i]] <- data.frame(L = sub_L[-which.max(sub_L)])
+    }
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    param$K <- min(param$k, floor(ncol(x) / 2))
+    if (length(lev) != 2) {
+      stop("rotationForest is only implemented for binary classification")
+    }
+    y <- ifelse(y == lev[1], 1, 0)
+    if (!is.data.frame(x)) {
+      x <- as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    rotationForest::rotationForest(x, y, K = param$K, L = param$L, ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    out <- predict(modelFit, newdata)
+    out <- ifelse(out >= .5, modelFit$obsLevels[1], modelFit$obsLevels[2])
+
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
+      all_L <- predict(modelFit, newdata, all = TRUE)
+      for (j in seq(along = submodels$L)) {
+        tmp_pred <- apply(all_L[, 1:submodels$L[j], drop = FALSE], 1, mean)
+        tmp[[j + 1]] <- ifelse(
+          tmp_pred >= .5,
+          modelFit$obsLevels[1],
+          modelFit$obsLevels[2]
+        )
+      }
+      out <- tmp
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    all_L <- predict(modelFit, newdata, all = TRUE)
+    out <- apply(all_L, 1, mean)
+    out <- data.frame(x = out, y = 1 - out)
+    colnames(out) <- modelFit$obsLevels
+    if (!is.null(rownames(newdata))) {
+      rownames(out) <- rownames(newdata)
+    }
+
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
+      for (j in seq(along = submodels$L)) {
+        tmp_pred <- apply(all_L[, 1:submodels$L[j], drop = FALSE], 1, mean)
+        tmp_pred <- data.frame(x = tmp_pred, y = 1 - tmp_pred)
+        colnames(tmp_pred) <- modelFit$obsLevels
+        if (!is.null(rownames(newdata))) {
+          rownames(tmp_pred) <- rownames(newdata)
+        }
+        tmp[[j + 1]] <- tmp_pred
+      }
+      out <- tmp
+    }
+    out
+  },
+  predictors = function(x, ...) {
+    non_zero <- function(x) {
+      out <- apply(x, 1, function(x) any(x != 0))
+      names(out)[out]
+    }
+    sort(unique(unlist(lapply(x$loadings, non_zero))))
+  },
+  varImp = function(object, ...) {
+    vis <- lapply(object$models, varImp, scale = FALSE)
+    wgt <- vector(mode = "list", length = length(vis))
+    for (i in seq(along = vis)) {
+      tmp <- vis[[i]]
+      vi1 <- tmp[, 1]
+      names(vi1) <- rownames(tmp)
+      l1 <- object$loadings[[i]]
+      tmp2 <- vi1 %*% abs(as.matrix(l1[names(vi1), ]))
+      tmp2 <- tmp2[, sort(colnames(tmp2))]
+      wgt[[i]] <- tmp2
+    }
+    wgt <- do.call("rbind", wgt)
+    vi <- apply(wgt, 2, mean)
+    out <- data.frame(Overall = vi)
+    rownames(out) <- colnames(wgt)
+    out
+  },
+  levels = function(x) x$obsLevels,
+  tags = c(
+    "Ensemble Model",
+    "Implicit Feature Selection",
+    "Feature Extraction Models",
+    "Tree-Based Model",
+    "Two Class Only"
+  ),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/rotationForestCp.R
+++ b/inst/model_sources/files/rotationForestCp.R
@@ -1,115 +1,151 @@
-modelInfo <- list(label = "Rotation Forest",
-                  library =  c("rpart", "plyr", "rotationForest"),
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = c("K", "L", 'cp'),
-                                          class = rep("numeric", 3),
-                                          label = c("#Variable Subsets", "Ensemble Size", "Complexity Parameter")),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    feas_k <- 1:15
-                    feas_k <- feas_k[ncol(x)%%feas_k == 0]
-                    if(search == "grid") {
-                      out <- expand.grid(K = feas_k[1:min(len, length(feas_k))], 
-                                         L = (1:len)*3,
-                                         cp = unique(seq(0, .1, length = len)))
-                    } else {
-                      out <- data.frame(K = sample(feas_k, size = len, replace = TRUE), 
-                                        L = sample(10:100, size = len, replace = TRUE),
-                                        cp = runif(len, 0, .1))
-                    }
-                    out
-                  },
-                  loop = function(grid) {
-                    loop <- plyr::ddply(grid, plyr::`.`(cp, K), function(x) c(L = max(x$L)))
-                    submodels <- vector(mode = "list", length = nrow(loop))
-                    for(i in seq(along = loop$L))  {
-                      index <- which(grid$cp == loop$cp[i] & grid$K == loop$K[i])
-                      bases <- grid[index, "L"] 
-                      submodels[[i]] <- data.frame(L = bases[bases != loop$L[i]])
-                    }     
-                    list(loop = loop, submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    param$K <- min(param$k, floor(ncol(x)/2))
-                    if(length(lev) != 2)
-                      stop("rotationForest is only implemented for binary classification")
-                    y <- ifelse(y == lev[1], 1, 0)
-                    if(!is.data.frame(x)) x <- as.data.frame(x, stringsAsFactors = TRUE)
-                    theDots <- list(...)
-                    ## From ?rotationForest, the three dots only pass rpart.control
-                    ## through so we will ignore the dots after "fixing" that object
-                    if(any(names(theDots) == "control")) {
-                      theDots$control$cp <- param$cp
-                      theDots$control$xval <- 0 
-                      rpctl <- theDots$control
-                    } else rpctl <- rpart::rpart.control(cp = param$cp, xval = 0)
+modelInfo <- list(
+  label = "Rotation Forest",
+  library = c("rpart", "plyr", "rotationForest"),
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = c("K", "L", 'cp'),
+    class = rep("numeric", 3),
+    label = c("#Variable Subsets", "Ensemble Size", "Complexity Parameter")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    feas_k <- 1:15
+    feas_k <- feas_k[ncol(x) %% feas_k == 0]
+    if (search == "grid") {
+      out <- expand.grid(
+        K = feas_k[1:min(len, length(feas_k))],
+        L = (1:len) * 3,
+        cp = unique(seq(0, .1, length = len))
+      )
+    } else {
+      out <- data.frame(
+        K = sample(feas_k, size = len, replace = TRUE),
+        L = sample(10:100, size = len, replace = TRUE),
+        cp = runif(len, 0, .1)
+      )
+    }
+    out
+  },
+  loop = function(grid) {
+    loop <- plyr::ddply(grid, plyr::`.`(cp, K), function(x) c(L = max(x$L)))
+    submodels <- vector(mode = "list", length = nrow(loop))
+    for (i in seq(along = loop$L)) {
+      index <- which(grid$cp == loop$cp[i] & grid$K == loop$K[i])
+      bases <- grid[index, "L"]
+      submodels[[i]] <- data.frame(L = bases[bases != loop$L[i]])
+    }
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    param$K <- min(param$k, floor(ncol(x) / 2))
+    if (length(lev) != 2) {
+      stop("rotationForest is only implemented for binary classification")
+    }
+    y <- ifelse(y == lev[1], 1, 0)
+    if (!is.data.frame(x)) {
+      x <- as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    theDots <- list(...)
+    ## From ?rotationForest, the three dots only pass rpart.control
+    ## through so we will ignore the dots after "fixing" that object
+    if (any(names(theDots) == "control")) {
+      theDots$control$cp <- param$cp
+      theDots$control$xval <- 0
+      rpctl <- theDots$control
+    } else {
+      rpctl <- rpart::rpart.control(cp = param$cp, xval = 0)
+    }
 
-                    rotationForest::rotationForest(x, y, K = param$K, L = param$L, control = rpctl)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    out <- predict(modelFit, newdata)
-                    out <- ifelse(out >= .5, modelFit$obsLevels[1], modelFit$obsLevels[2])
-                    
-                    if(!is.null(submodels)) {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
-                      all_L <- predict(modelFit, newdata, all = TRUE)
-                      for(j in seq(along = submodels$L)) {                        
-                        tmp_pred <- apply(all_L[, 1:submodels$L[j],drop = FALSE], 1, mean)
-                        tmp[[j+1]] <- ifelse(tmp_pred >= .5, modelFit$obsLevels[1], modelFit$obsLevels[2])
-                      }
-                      out <- tmp
-                    }
-                    out   
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    all_L <- predict(modelFit, newdata, all = TRUE)
-                    out <- apply(all_L, 1, mean)
-                    out <- data.frame(x = out, y = 1 - out)
-                    colnames(out) <- modelFit$obsLevels
-                    if(!is.null(rownames(newdata))) rownames(out) <- rownames(newdata)
-                    
-                    if(!is.null(submodels)) {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
-                      for(j in seq(along = submodels$L)) {  
-                        tmp_pred <- apply(all_L[, 1:submodels$L[j],drop = FALSE], 1, mean)
-                        tmp_pred <- data.frame(x = tmp_pred, y = 1 - tmp_pred)
-                        colnames(tmp_pred) <- modelFit$obsLevels
-                        if(!is.null(rownames(newdata))) rownames(tmp_pred) <- rownames(newdata)
-                        tmp[[j+1]] <- tmp_pred
-                      }
-                      out <- tmp
-                    }
-                    out   
-                  },
-                  predictors = function(x, ...) {
-                    non_zero <- function(x) {                      
-                      out <- apply(x, 1, function(x) any(x != 0))
-                      names(out)[out]
-                    }
-                    sort(unique(unlist(lapply(x$loadings, non_zero))))
-                  },
-                  varImp = function(object, ...) {
-                    vis <- lapply(object$models, varImp, scale = FALSE)
-                    wgt <- vector(mode = "list", length = length(vis))
-                    for(i in seq(along = vis)) {
-                      tmp <- vis[[i]]
-                      vi1 <- tmp[,1]
-                      names(vi1) <- rownames(tmp)
-                      l1 <- object$loadings[[i]]
-                      tmp2 <- vi1 %*% abs(as.matrix(l1[names(vi1),]))
-                      tmp2 <- tmp2[,sort(colnames(tmp2))]
-                      wgt[[i]] <- tmp2
-                    }
-                    wgt <- do.call("rbind", wgt)
-                    vi <- apply(wgt, 2, mean)
-                    out <- data.frame(Overall = vi)
-                    rownames(out) <- colnames(wgt)
-                    out
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("Ensemble Model", "Implicit Feature Selection", 
-                           "Feature Extraction Models", "Tree-Based Model", "Two Class Only"),
-                  sort = function(x) x[order(x[,1]),])
+    rotationForest::rotationForest(
+      x,
+      y,
+      K = param$K,
+      L = param$L,
+      control = rpctl
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    out <- predict(modelFit, newdata)
+    out <- ifelse(out >= .5, modelFit$obsLevels[1], modelFit$obsLevels[2])
+
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
+      all_L <- predict(modelFit, newdata, all = TRUE)
+      for (j in seq(along = submodels$L)) {
+        tmp_pred <- apply(all_L[, 1:submodels$L[j], drop = FALSE], 1, mean)
+        tmp[[j + 1]] <- ifelse(
+          tmp_pred >= .5,
+          modelFit$obsLevels[1],
+          modelFit$obsLevels[2]
+        )
+      }
+      out <- tmp
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    all_L <- predict(modelFit, newdata, all = TRUE)
+    out <- apply(all_L, 1, mean)
+    out <- data.frame(x = out, y = 1 - out)
+    colnames(out) <- modelFit$obsLevels
+    if (!is.null(rownames(newdata))) {
+      rownames(out) <- rownames(newdata)
+    }
+
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
+      for (j in seq(along = submodels$L)) {
+        tmp_pred <- apply(all_L[, 1:submodels$L[j], drop = FALSE], 1, mean)
+        tmp_pred <- data.frame(x = tmp_pred, y = 1 - tmp_pred)
+        colnames(tmp_pred) <- modelFit$obsLevels
+        if (!is.null(rownames(newdata))) {
+          rownames(tmp_pred) <- rownames(newdata)
+        }
+        tmp[[j + 1]] <- tmp_pred
+      }
+      out <- tmp
+    }
+    out
+  },
+  predictors = function(x, ...) {
+    non_zero <- function(x) {
+      out <- apply(x, 1, function(x) any(x != 0))
+      names(out)[out]
+    }
+    sort(unique(unlist(lapply(x$loadings, non_zero))))
+  },
+  varImp = function(object, ...) {
+    vis <- lapply(object$models, varImp, scale = FALSE)
+    wgt <- vector(mode = "list", length = length(vis))
+    for (i in seq(along = vis)) {
+      tmp <- vis[[i]]
+      vi1 <- tmp[, 1]
+      names(vi1) <- rownames(tmp)
+      l1 <- object$loadings[[i]]
+      tmp2 <- vi1 %*% abs(as.matrix(l1[names(vi1), ]))
+      tmp2 <- tmp2[, sort(colnames(tmp2))]
+      wgt[[i]] <- tmp2
+    }
+    wgt <- do.call("rbind", wgt)
+    vi <- apply(wgt, 2, mean)
+    out <- data.frame(Overall = vi)
+    rownames(out) <- colnames(wgt)
+    out
+  },
+  levels = function(x) x$obsLevels,
+  tags = c(
+    "Ensemble Model",
+    "Implicit Feature Selection",
+    "Feature Extraction Models",
+    "Tree-Based Model",
+    "Two Class Only"
+  ),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/rpart.R
+++ b/inst/model_sources/files/rpart.R
@@ -8,10 +8,10 @@ modelInfo <- list(
     label = c("Complexity Parameter")
   ),
   grid = function(x, y, len = NULL, search = "grid") {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     initialFit <- rpart::rpart(
@@ -48,7 +48,11 @@ modelInfo <- list(
     list(loop = loop, submodels = submodels)
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    cpValue <- if (!last) param$cp else 0
+    if (!last) {
+      cpValue <- param$cp
+    } else {
+      cpValue <- 0
+    }
     theDots <- list(...)
     if (any(names(theDots) == "control")) {
       theDots$control$cp <- cpValue
@@ -90,7 +94,11 @@ modelInfo <- list(
       newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
     }
 
-    pType <- if (modelFit$problemType == "Classification") "class" else "vector"
+    if (modelFit$problemType == "Classification") {
+      pType <- "class"
+    } else {
+      pType <- "vector"
+    }
     out <- predict(modelFit, newdata, type = pType)
 
     if (!is.null(submodels)) {

--- a/inst/model_sources/files/rpart.R
+++ b/inst/model_sources/files/rpart.R
@@ -1,164 +1,210 @@
-modelInfo <- list(label = "CART",
-                  library = "rpart",
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('cp'),
-                                          class = c("numeric"),
-                                          label = c("Complexity Parameter")),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    initialFit <- rpart::rpart(.outcome ~ .,
-                                               data = dat,
-                                               control = rpart::rpart.control(cp = 0))$cptable
-                    initialFit <- initialFit[order(-initialFit[,"CP"]), , drop = FALSE]
-                    if(search == "grid") {
-                      if(nrow(initialFit) < len) {
-                        tuneSeq <- data.frame(cp = seq(min(initialFit[, "CP"]),
-                                                       max(initialFit[, "CP"]),
-                                                       length = len))
-                      } else tuneSeq <-  data.frame(cp = initialFit[1:len,"CP"])
-                      colnames(tuneSeq) <- "cp"
-                    } else {
-                      tuneSeq <- data.frame(cp = unique(sample(initialFit[, "CP"], size = len, replace = TRUE)))
-                    }
+modelInfo <- list(
+  label = "CART",
+  library = "rpart",
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c('cp'),
+    class = c("numeric"),
+    label = c("Complexity Parameter")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    initialFit <- rpart::rpart(
+      .outcome ~ .,
+      data = dat,
+      control = rpart::rpart.control(cp = 0)
+    )$cptable
+    initialFit <- initialFit[order(-initialFit[, "CP"]), , drop = FALSE]
+    if (search == "grid") {
+      if (nrow(initialFit) < len) {
+        tuneSeq <- data.frame(
+          cp = seq(
+            min(initialFit[, "CP"]),
+            max(initialFit[, "CP"]),
+            length = len
+          )
+        )
+      } else {
+        tuneSeq <- data.frame(cp = initialFit[1:len, "CP"])
+      }
+      colnames(tuneSeq) <- "cp"
+    } else {
+      tuneSeq <- data.frame(
+        cp = unique(sample(initialFit[, "CP"], size = len, replace = TRUE))
+      )
+    }
 
-                    tuneSeq
-                  },
-                  loop = function(grid) {
-                    grid <- grid[order(grid$cp, decreasing = FALSE),, drop = FALSE]
-                    loop <- grid[1,,drop = FALSE]
-                    submodels <- list(grid[-1,,drop = FALSE])
-                    list(loop = loop, submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    cpValue <- if(!last) param$cp else 0
-                    theDots <- list(...)
-                    if(any(names(theDots) == "control"))
-                    {
-                      theDots$control$cp <- cpValue
-                      theDots$control$xval <- 0
-                      ctl <- theDots$control
-                      theDots$control <- NULL
-                    } else ctl <- rpart::rpart.control(cp = cpValue, xval = 0)
+    tuneSeq
+  },
+  loop = function(grid) {
+    grid <- grid[order(grid$cp, decreasing = FALSE), , drop = FALSE]
+    loop <- grid[1, , drop = FALSE]
+    submodels <- list(grid[-1, , drop = FALSE])
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    cpValue <- if (!last) param$cp else 0
+    theDots <- list(...)
+    if (any(names(theDots) == "control")) {
+      theDots$control$cp <- cpValue
+      theDots$control$xval <- 0
+      ctl <- theDots$control
+      theDots$control <- NULL
+    } else {
+      ctl <- rpart::rpart.control(cp = cpValue, xval = 0)
+    }
 
-                    ## check to see if weights were passed in (and availible)
-                    if(!is.null(wts)) theDots$weights <- wts
+    ## check to see if weights were passed in (and availible)
+    if (!is.null(wts)) {
+      theDots$weights <- wts
+    }
 
-                    modelArgs <- c(list(formula = as.formula(".outcome ~ ."),
-                                        data = if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE),
-                                        control = ctl),
-                                   theDots)
-                    modelArgs$data$.outcome <- y
+    modelArgs <- c(
+      list(
+        formula = as.formula(".outcome ~ ."),
+        data = if (is.data.frame(x)) {
+          x
+        } else {
+          as.data.frame(x, stringsAsFactors = TRUE)
+        },
+        control = ctl
+      ),
+      theDots
+    )
+    modelArgs$data$.outcome <- y
 
-                    out <- do.call(rpart::rpart, modelArgs)
+    out <- do.call(rpart::rpart, modelArgs)
 
-                    if(last) out <- rpart::prune.rpart(out, cp = param$cp)
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    if (last) {
+      out <- rpart::prune.rpart(out, cp = param$cp)
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
 
-                    pType <- if(modelFit$problemType == "Classification") "class" else "vector"
-                    out  <- predict(modelFit, newdata, type=pType)
+    pType <- if (modelFit$problemType == "Classification") "class" else "vector"
+    out <- predict(modelFit, newdata, type = pType)
 
-                    if(!is.null(submodels))
-                    {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
-                      for(j in seq(along = submodels$cp))
-                      {
-                        prunedFit <- rpart::prune.rpart(modelFit, cp = submodels$cp[j])
-                        tmp[[j+1]]  <- predict(prunedFit, newdata, type=pType)
-                      }
-                      out <- tmp
-                    }
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    out <- predict(modelFit, newdata, type = "prob")
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
+      for (j in seq(along = submodels$cp)) {
+        prunedFit <- rpart::prune.rpart(modelFit, cp = submodels$cp[j])
+        tmp[[j + 1]] <- predict(prunedFit, newdata, type = pType)
+      }
+      out <- tmp
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    out <- predict(modelFit, newdata, type = "prob")
 
-                    if(!is.null(submodels))
-                    {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
-                      for(j in seq(along = submodels$cp))
-                      {
-                        prunedFit <- rpart::prune.rpart(modelFit, cp = submodels$cp[j])
-                        tmpProb <- predict(prunedFit, newdata, type = "prob")
-                        tmp[[j+1]] <- as.data.frame(tmpProb[, modelFit$obsLevels, drop = FALSE], stringsAsFactors = TRUE)
-                      }
-                      out <- tmp
-                    }
-                    out
-                  },
-                  predictors = function(x, surrogate = TRUE, ...)  {
-                    out <- as.character(x$frame$var)
-                    out <- out[!(out %in% c("<leaf>"))]
-                    if(surrogate)
-                    {
-                      splits <- x$splits
-                      splits <- splits[splits[,"adj"] > 0,]
-                      out <- c(out, rownames(splits))
-                    }
-                    unique(out)
-                  },
-                  varImp = function(object, surrogates = FALSE, competes = TRUE, ...) {
-                    if(nrow(object$splits)>0) {
-                      tmp <- rownames(object$splits)
-                      rownames(object$splits) <- 1:nrow(object$splits)
-                      splits <- data.frame(object$splits)
-                      splits$var <- tmp
-                      splits$type <- ""
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
+      for (j in seq(along = submodels$cp)) {
+        prunedFit <- rpart::prune.rpart(modelFit, cp = submodels$cp[j])
+        tmpProb <- predict(prunedFit, newdata, type = "prob")
+        tmp[[j + 1]] <- as.data.frame(
+          tmpProb[, modelFit$obsLevels, drop = FALSE],
+          stringsAsFactors = TRUE
+        )
+      }
+      out <- tmp
+    }
+    out
+  },
+  predictors = function(x, surrogate = TRUE, ...) {
+    out <- as.character(x$frame$var)
+    out <- out[!(out %in% c("<leaf>"))]
+    if (surrogate) {
+      splits <- x$splits
+      splits <- splits[splits[, "adj"] > 0, ]
+      out <- c(out, rownames(splits))
+    }
+    unique(out)
+  },
+  varImp = function(object, surrogates = FALSE, competes = TRUE, ...) {
+    if (nrow(object$splits) > 0) {
+      tmp <- rownames(object$splits)
+      rownames(object$splits) <- 1:nrow(object$splits)
+      splits <- data.frame(object$splits)
+      splits$var <- tmp
+      splits$type <- ""
 
-                      frame <- as.data.frame(object$frame, stringsAsFactors = TRUE)
-                      index <- 0
-                      for(i in 1:nrow(frame)) {
-                        if(frame$var[i] != "<leaf>") {
-                          index <- index + 1
-                          splits$type[index] <- "primary"
-                          if(frame$ncompete[i] > 0) {
-                            for(j in 1:frame$ncompete[i]) {
-                              index <- index + 1
-                              splits$type[index] <- "competing"
-                            }
-                          }
-                          if(frame$nsurrogate[i] > 0) {
-                            for(j in 1:frame$nsurrogate[i]) {
-                              index <- index + 1
-                              splits$type[index] <- "surrogate"
-                            }
-                          }
-                        }
-                      }
-                      splits$var <- factor(as.character(splits$var))
-                      if(!surrogates) splits <- subset(splits, type != "surrogate")
-                      if(!competes) splits <- subset(splits, type != "competing")
-                      out <- aggregate(splits$improve,
-                                       list(Variable = splits$var),
-                                       sum,
-                                       na.rm = TRUE)
-                    } else {
-		      out <- data.frame(x = numeric(), Variable = character())
-		    }
-                    allVars <- colnames(attributes(object$terms)$factors)
-                    if(!all(allVars %in% out$Variable)) {
-                      missingVars <- allVars[!(allVars %in% out$Variable)]
-                      zeros <- data.frame(x = rep(0, length(missingVars)),
-                                          Variable = missingVars)
-                      out <- rbind(out, zeros)
-                    }
-                    out2 <- data.frame(Overall = out$x)
-                    rownames(out2) <- out$Variable
-                    out2
-                  },
-                  levels = function(x) x$obsLevels,
-                  trim = function(x) {
-                    x$call <- list(na.action = (x$call)$na.action)
-                    x$x <- NULL
-                    x$y <- NULL
-                    x$where <- NULL
-                    x
-                  },
-                  tags = c("Tree-Based Model", "Implicit Feature Selection", "Handle Missing Predictor Data", "Accepts Case Weights"),
-                  sort = function(x) x[order(x[,1], decreasing = TRUE),])
+      frame <- as.data.frame(object$frame, stringsAsFactors = TRUE)
+      index <- 0
+      for (i in 1:nrow(frame)) {
+        if (frame$var[i] != "<leaf>") {
+          index <- index + 1
+          splits$type[index] <- "primary"
+          if (frame$ncompete[i] > 0) {
+            for (j in 1:frame$ncompete[i]) {
+              index <- index + 1
+              splits$type[index] <- "competing"
+            }
+          }
+          if (frame$nsurrogate[i] > 0) {
+            for (j in 1:frame$nsurrogate[i]) {
+              index <- index + 1
+              splits$type[index] <- "surrogate"
+            }
+          }
+        }
+      }
+      splits$var <- factor(as.character(splits$var))
+      if (!surrogates) {
+        splits <- subset(splits, type != "surrogate")
+      }
+      if (!competes) {
+        splits <- subset(splits, type != "competing")
+      }
+      out <- aggregate(
+        splits$improve,
+        list(Variable = splits$var),
+        sum,
+        na.rm = TRUE
+      )
+    } else {
+      out <- data.frame(x = numeric(), Variable = character())
+    }
+    allVars <- colnames(attributes(object$terms)$factors)
+    if (!all(allVars %in% out$Variable)) {
+      missingVars <- allVars[!(allVars %in% out$Variable)]
+      zeros <- data.frame(
+        x = rep(0, length(missingVars)),
+        Variable = missingVars
+      )
+      out <- rbind(out, zeros)
+    }
+    out2 <- data.frame(Overall = out$x)
+    rownames(out2) <- out$Variable
+    out2
+  },
+  levels = function(x) x$obsLevels,
+  trim = function(x) {
+    x$call <- list(na.action = (x$call)$na.action)
+    x$x <- NULL
+    x$y <- NULL
+    x$where <- NULL
+    x
+  },
+  tags = c(
+    "Tree-Based Model",
+    "Implicit Feature Selection",
+    "Handle Missing Predictor Data",
+    "Accepts Case Weights"
+  ),
+  sort = function(x) x[order(x[, 1], decreasing = TRUE), ]
+)

--- a/inst/model_sources/files/rpart1SE.R
+++ b/inst/model_sources/files/rpart1SE.R
@@ -12,10 +12,10 @@ modelInfo <- list(
   },
   loop = NULL,
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
 
@@ -32,10 +32,10 @@ modelInfo <- list(
       newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
     }
 
-    out <- if (modelFit$problemType == "Classification") {
-      predict(modelFit, newdata, type = "class")
+    if (modelFit$problemType == "Classification") {
+      out <- predict(modelFit, newdata, type = "class")
     } else {
-      predict(modelFit, newdata)
+      out <- predict(modelFit, newdata)
     }
     out
   },

--- a/inst/model_sources/files/rpart1SE.R
+++ b/inst/model_sources/files/rpart1SE.R
@@ -1,100 +1,128 @@
-modelInfo <- list(label = "CART",
-                  library = "rpart",
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = "parameter",
-                                          class = "character",
-                                          label = "parameter"),
-                  grid = function(x, y, len = NULL, search = "grid") data.frame(parameter = "none"),
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    
-                    ## check to see if weights were passed in (and availible)
-                    if(!is.null(wts)){
-                      out <- rpart::rpart(.outcome ~ ., data = dat, ...)
-                    } else {
-                      out <- rpart::rpart(.outcome ~ ., data = dat, weights = wts, ...)
-                    }
-                    out           
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {                  
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    
-                    out <- if(modelFit$problemType == "Classification") 
-                      predict(modelFit, newdata, type = "class") else 
-                        predict(modelFit, newdata)
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata, type = "prob")
-                  },
-                  predictors = function(x, surrogate = TRUE, ...)  {
-                    out <- as.character(x$frame$var)
-                    out <- out[!(out %in% c("<leaf>"))]
-                    if(surrogate)
-                    {
-                      splits <- x$splits
-                      splits <- splits[splits[,"adj"] > 0,]
-                      out <- c(out, rownames(splits))
-                    }
-                    unique(out)
-                  },
-                  varImp = function(object, surrogates = FALSE, competes = TRUE, ...) {
-                    tmp <- rownames(object$splits)
-                    rownames(object$splits) <- 1:nrow(object$splits)
-                    splits <- data.frame(object$splits)
-                    splits$var <- tmp
-                    splits$type <- ""
-                    
-                    frame <- as.data.frame(object$frame, stringsAsFactors = TRUE)
-                    index <- 0
-                    for(i in 1:nrow(frame)) {
-                      if(frame$var[i] != "<leaf>") {
-                        index <- index + 1
-                        splits$type[index] <- "primary"
-                        if(frame$ncompete[i] > 0) {
-                          for(j in 1:frame$ncompete[i]) {
-                            index <- index + 1
-                            splits$type[index] <- "competing"
-                          }
-                        }
-                        if(frame$nsurrogate[i] > 0) {
-                          for(j in 1:frame$nsurrogate[i]) {
-                            index <- index + 1
-                            splits$type[index] <- "surrogate"
-                          }
-                        }
-                      }
-                    }
-                    splits$var <- factor(as.character(splits$var))
-                    if(!surrogates) splits <- subset(splits, type != "surrogate")
-                    if(!competes) splits <- subset(splits, type != "competing")
-                    out <- aggregate(splits$improve,
-                                     list(Variable = splits$var),
-                                     sum,
-                                     na.rm = TRUE)
-                    
-                    allVars <- colnames(attributes(object$terms)$factors)
-                    if(!all(allVars %in% out$Variable)) {
-                      missingVars <- allVars[!(allVars %in% out$Variable)]
-                      zeros <- data.frame(x = rep(0, length(missingVars)),
-                                          Variable = missingVars)
-                      out <- rbind(out, zeros)
-                    }
-                    out2 <- data.frame(Overall = out$x)
-                    rownames(out2) <- out$Variable
-                    out2  
-                  },
-                  levels = function(x) x$obsLevels,
-                  trim = function(x) {
-                    x$call <- list(na.action = (x$call)$na.action)
-                    x$x <- NULL
-                    x$y <- NULL
-                    x$where <- NULL
-                    x
-                  },
-                  notes = "This CART model replicates the same process used by the `rpart` function where the model complexity is determined using the one-standard error method. This procedure is replicated inside of the resampling done by `train` so that an external resampling estimate can be obtained.",
-                  tags = c("Tree-Based Model", "Implicit Feature Selection", "Handle Missing Predictor Data", "Accepts Case Weights"),
-                  sort = function(x) x[order(x[,1], decreasing = TRUE),])
+modelInfo <- list(
+  label = "CART",
+  library = "rpart",
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = "parameter",
+    class = "character",
+    label = "parameter"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(parameter = "none")
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+
+    ## check to see if weights were passed in (and availible)
+    if (!is.null(wts)) {
+      out <- rpart::rpart(.outcome ~ ., data = dat, ...)
+    } else {
+      out <- rpart::rpart(.outcome ~ ., data = dat, weights = wts, ...)
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+
+    out <- if (modelFit$problemType == "Classification") {
+      predict(modelFit, newdata, type = "class")
+    } else {
+      predict(modelFit, newdata)
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata, type = "prob")
+  },
+  predictors = function(x, surrogate = TRUE, ...) {
+    out <- as.character(x$frame$var)
+    out <- out[!(out %in% c("<leaf>"))]
+    if (surrogate) {
+      splits <- x$splits
+      splits <- splits[splits[, "adj"] > 0, ]
+      out <- c(out, rownames(splits))
+    }
+    unique(out)
+  },
+  varImp = function(object, surrogates = FALSE, competes = TRUE, ...) {
+    tmp <- rownames(object$splits)
+    rownames(object$splits) <- 1:nrow(object$splits)
+    splits <- data.frame(object$splits)
+    splits$var <- tmp
+    splits$type <- ""
+
+    frame <- as.data.frame(object$frame, stringsAsFactors = TRUE)
+    index <- 0
+    for (i in 1:nrow(frame)) {
+      if (frame$var[i] != "<leaf>") {
+        index <- index + 1
+        splits$type[index] <- "primary"
+        if (frame$ncompete[i] > 0) {
+          for (j in 1:frame$ncompete[i]) {
+            index <- index + 1
+            splits$type[index] <- "competing"
+          }
+        }
+        if (frame$nsurrogate[i] > 0) {
+          for (j in 1:frame$nsurrogate[i]) {
+            index <- index + 1
+            splits$type[index] <- "surrogate"
+          }
+        }
+      }
+    }
+    splits$var <- factor(as.character(splits$var))
+    if (!surrogates) {
+      splits <- subset(splits, type != "surrogate")
+    }
+    if (!competes) {
+      splits <- subset(splits, type != "competing")
+    }
+    out <- aggregate(
+      splits$improve,
+      list(Variable = splits$var),
+      sum,
+      na.rm = TRUE
+    )
+
+    allVars <- colnames(attributes(object$terms)$factors)
+    if (!all(allVars %in% out$Variable)) {
+      missingVars <- allVars[!(allVars %in% out$Variable)]
+      zeros <- data.frame(
+        x = rep(0, length(missingVars)),
+        Variable = missingVars
+      )
+      out <- rbind(out, zeros)
+    }
+    out2 <- data.frame(Overall = out$x)
+    rownames(out2) <- out$Variable
+    out2
+  },
+  levels = function(x) x$obsLevels,
+  trim = function(x) {
+    x$call <- list(na.action = (x$call)$na.action)
+    x$x <- NULL
+    x$y <- NULL
+    x$where <- NULL
+    x
+  },
+  notes = "This CART model replicates the same process used by the `rpart` function where the model complexity is determined using the one-standard error method. This procedure is replicated inside of the resampling done by `train` so that an external resampling estimate can be obtained.",
+  tags = c(
+    "Tree-Based Model",
+    "Implicit Feature Selection",
+    "Handle Missing Predictor Data",
+    "Accepts Case Weights"
+  ),
+  sort = function(x) x[order(x[, 1], decreasing = TRUE), ]
+)

--- a/inst/model_sources/files/rpart2.R
+++ b/inst/model_sources/files/rpart2.R
@@ -8,10 +8,10 @@ modelInfo <- list(
     label = c("Max Tree Depth")
   ),
   grid = function(x, y, len = NULL, search = "grid") {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     initialFit <- rpart::rpart(
@@ -104,7 +104,11 @@ modelInfo <- list(
       newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
     }
 
-    pType <- if (modelFit$problemType == "Classification") "class" else "vector"
+    if (modelFit$problemType == "Classification") {
+      pType <- "class"
+    } else {
+      pType <- "vector"
+    }
     out <- predict(modelFit, newdata, type = pType)
 
     if (!is.null(submodels)) {

--- a/inst/model_sources/files/rpart2.R
+++ b/inst/model_sources/files/rpart2.R
@@ -1,181 +1,229 @@
-modelInfo <- list(label = "CART",
-                  library = "rpart",
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('maxdepth'),
-                                          class = c("numeric"),
-                                          label = c("Max Tree Depth")),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    initialFit <- rpart::rpart(.outcome ~ .,
-                                               data = dat,
-                                               control = rpart::rpart.control(cp = 0))$cptable
-                    initialFit <- initialFit[order(-initialFit[,"CP"]), "nsplit", drop = FALSE]
-                    initialFit <- initialFit[initialFit[,"nsplit"] > 0 & initialFit[,"nsplit"] <= 30, , drop = FALSE]
-                    
-                    if(search == "grid") {
-                      
-                      if(dim(initialFit)[1] < len) {
-                        cat("note: only", nrow(initialFit),
-                            "possible values of the max tree depth from the initial fit.\n",
-                            "Truncating the grid to", nrow(initialFit), ".\n\n")
-                        tuneSeq <-  as.data.frame(initialFit, stringsAsFactors = TRUE)
-                      } else tuneSeq <-  as.data.frame(initialFit[1:len,], stringsAsFactors = TRUE)
-                      colnames(tuneSeq) <- "maxdepth"
-                    } else {
-                      tuneSeq <- data.frame(maxdepth = unique(sample(as.vector(initialFit[,1]), 
-                                                                     size = len, replace = TRUE)))
-                    }
-                    tuneSeq
-                  },
-                  loop = function(grid) {
-                    grid <- grid[order(grid$maxdepth, decreasing = TRUE),, drop = FALSE]
-                    loop <- grid[1,,drop = FALSE]
-                    submodels <- list(grid[-1,,drop = FALSE])
-                    list(loop = loop, submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    theDots <- list(...)
-                    if(any(names(theDots) == "control"))
-                    {
-                      theDots$control$maxdepth <- param$maxdepth
-                      theDots$control$xval <- 0 
-                      ctl <- theDots$control
-                      theDots$control <- NULL    
-                    } else ctl <- rpart::rpart.control(maxdepth = param$maxdepth, xval = 0)  
-                    
-                    ## check to see if weights were passed in (and availible)
-                    if(!is.null(wts)) theDots$weights <- wts    
-                    
-                    modelArgs <- c(list(formula = as.formula(".outcome ~ ."),
-                                        data = if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE),
-                                        control = ctl),
-                                   theDots)
-                    modelArgs$data$.outcome <- y
+modelInfo <- list(
+  label = "CART",
+  library = "rpart",
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c('maxdepth'),
+    class = c("numeric"),
+    label = c("Max Tree Depth")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    initialFit <- rpart::rpart(
+      .outcome ~ .,
+      data = dat,
+      control = rpart::rpart.control(cp = 0)
+    )$cptable
+    initialFit <- initialFit[order(-initialFit[, "CP"]), "nsplit", drop = FALSE]
+    initialFit <- initialFit[
+      initialFit[, "nsplit"] > 0 & initialFit[, "nsplit"] <= 30,
+      ,
+      drop = FALSE
+    ]
 
-                    out <- do.call(rpart::rpart, modelArgs)
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    ## Models are indexed by Cp so approximate the Cp for
-                    ## the value of maxdepth
-                    depth2cp <- function(x, depth)
-                    {
-                      out <- approx(x[,"nsplit"], x[,"CP"], depth)$y
-                      out[depth > max(x[,"nsplit"])] <- min(x[,"CP"]) * .99
-                      out
-                    }
-                    
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    
-                    pType <- if(modelFit$problemType == "Classification") "class" else "vector"
-                    out  <- predict(modelFit, newdata, type=pType)
-                    
-                    if(!is.null(submodels))
-                    {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
-                      cpValues <- depth2cp(modelFit$cptable, submodels$maxdepth)
-                      for(j in seq(along = cpValues))
-                      {
-                        prunedFit <- rpart::prune.rpart(modelFit, cp = cpValues[j])
-                        tmp[[j+1]]  <- predict(prunedFit, newdata, type=pType)
-                      }
-                      out <- tmp
-                    }
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    depth2cp <- function(x, depth)
-                    {
-                      out <- approx(x[,"nsplit"], x[,"CP"], depth)$y
-                      out[depth > max(x[,"nsplit"])] <- min(x[,"CP"]) * .99
-                      out
-                    }
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    out <- predict(modelFit, newdata, type = "prob")
-                    
-                    if(!is.null(submodels))
-                    {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
-                      cpValues <- depth2cp(modelFit$cptable, submodels$maxdepth)
-                      
-                      for(j in seq(along = cpValues))
-                      {
-                        prunedFit <- rpart::prune.rpart(modelFit, cp = cpValues[j])
-                        tmpProb <- predict(prunedFit, newdata, type = "prob")
-                        tmp[[j+1]] <- as.data.frame(tmpProb[, modelFit$obsLevels, drop = FALSE], stringsAsFactors = TRUE)
-                      }
-                      out <- tmp
-                    }                              
-                    out
-                  },
-                  predictors = function(x, surrogate = TRUE, ...) {
-                    out <- as.character(x$frame$var)
-                    out <- out[!(out %in% c("<leaf>"))]
-                    if(surrogate)
-                    {
-                      splits <- x$splits
-                      splits <- splits[splits[,"adj"] > 0,]
-                      out <- c(out, rownames(splits))
-                    }
-                    unique(out)
-                  },
-                  varImp = function(object, surrogates = FALSE, competes = TRUE, ...) {
-                    tmp <- rownames(object$splits)
-                    rownames(object$splits) <- 1:nrow(object$splits)
-                    splits <- data.frame(object$splits)
-                    splits$var <- tmp
-                    splits$type <- ""
-                    
-                    frame <- as.data.frame(object$frame, stringsAsFactors = TRUE)
-                    index <- 0
-                    for(i in 1:nrow(frame)) {
-                      if(frame$var[i] != "<leaf>") {
-                        index <- index + 1
-                        splits$type[index] <- "primary"
-                        if(frame$ncompete[i] > 0) {
-                          for(j in 1:frame$ncompete[i]) {
-                            index <- index + 1
-                            splits$type[index] <- "competing"
-                          }
-                        }
-                        if(frame$nsurrogate[i] > 0) {
-                          for(j in 1:frame$nsurrogate[i]) {
-                            index <- index + 1
-                            splits$type[index] <- "surrogate"
-                          }
-                        }
-                      }
-                    }
-                    splits$var <- factor(as.character(splits$var))
-                    if(!surrogates) splits <- subset(splits, type != "surrogate")
-                    if(!competes) splits <- subset(splits, type != "competing")
-                    out <- aggregate(splits$improve,
-                                     list(Variable = splits$var),
-                                     sum,
-                                     na.rm = TRUE)
-                    
-                    allVars <- colnames(attributes(object$terms)$factors)
-                    if(!all(allVars %in% out$Variable)) {
-                      missingVars <- allVars[!(allVars %in% out$Variable)]
-                      zeros <- data.frame(x = rep(0, length(missingVars)),
-                                          Variable = missingVars)
-                      out <- rbind(out, zeros)
-                    }
-                    out2 <- data.frame(Overall = out$x)
-                    rownames(out2) <- out$Variable
-                    out2  
-                  },
-                  levels = function(x) x$obsLevels,
-                  trim = function(x) {
-                    x$call <- list(na.action = (x$call)$na.action)
-                    x$x <- NULL
-                    x$y <- NULL
-                    x$where <- NULL
-                    x
-                  },
-                  tags = c("Tree-Based Model", "Implicit Feature Selection", 
-                           "Handle Missing Predictor Data", "Accepts Case Weights"),
-                  sort = function(x) x[order(x[,1]),])
+    if (search == "grid") {
+      if (dim(initialFit)[1] < len) {
+        cat(
+          "note: only",
+          nrow(initialFit),
+          "possible values of the max tree depth from the initial fit.\n",
+          "Truncating the grid to",
+          nrow(initialFit),
+          ".\n\n"
+        )
+        tuneSeq <- as.data.frame(initialFit, stringsAsFactors = TRUE)
+      } else {
+        tuneSeq <- as.data.frame(initialFit[1:len, ], stringsAsFactors = TRUE)
+      }
+      colnames(tuneSeq) <- "maxdepth"
+    } else {
+      tuneSeq <- data.frame(
+        maxdepth = unique(sample(
+          as.vector(initialFit[, 1]),
+          size = len,
+          replace = TRUE
+        ))
+      )
+    }
+    tuneSeq
+  },
+  loop = function(grid) {
+    grid <- grid[order(grid$maxdepth, decreasing = TRUE), , drop = FALSE]
+    loop <- grid[1, , drop = FALSE]
+    submodels <- list(grid[-1, , drop = FALSE])
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    theDots <- list(...)
+    if (any(names(theDots) == "control")) {
+      theDots$control$maxdepth <- param$maxdepth
+      theDots$control$xval <- 0
+      ctl <- theDots$control
+      theDots$control <- NULL
+    } else {
+      ctl <- rpart::rpart.control(maxdepth = param$maxdepth, xval = 0)
+    }
+
+    ## check to see if weights were passed in (and availible)
+    if (!is.null(wts)) {
+      theDots$weights <- wts
+    }
+
+    modelArgs <- c(
+      list(
+        formula = as.formula(".outcome ~ ."),
+        data = if (is.data.frame(x)) {
+          x
+        } else {
+          as.data.frame(x, stringsAsFactors = TRUE)
+        },
+        control = ctl
+      ),
+      theDots
+    )
+    modelArgs$data$.outcome <- y
+
+    out <- do.call(rpart::rpart, modelArgs)
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    ## Models are indexed by Cp so approximate the Cp for
+    ## the value of maxdepth
+    depth2cp <- function(x, depth) {
+      out <- approx(x[, "nsplit"], x[, "CP"], depth)$y
+      out[depth > max(x[, "nsplit"])] <- min(x[, "CP"]) * .99
+      out
+    }
+
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+
+    pType <- if (modelFit$problemType == "Classification") "class" else "vector"
+    out <- predict(modelFit, newdata, type = pType)
+
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
+      cpValues <- depth2cp(modelFit$cptable, submodels$maxdepth)
+      for (j in seq(along = cpValues)) {
+        prunedFit <- rpart::prune.rpart(modelFit, cp = cpValues[j])
+        tmp[[j + 1]] <- predict(prunedFit, newdata, type = pType)
+      }
+      out <- tmp
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    depth2cp <- function(x, depth) {
+      out <- approx(x[, "nsplit"], x[, "CP"], depth)$y
+      out[depth > max(x[, "nsplit"])] <- min(x[, "CP"]) * .99
+      out
+    }
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    out <- predict(modelFit, newdata, type = "prob")
+
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
+      cpValues <- depth2cp(modelFit$cptable, submodels$maxdepth)
+
+      for (j in seq(along = cpValues)) {
+        prunedFit <- rpart::prune.rpart(modelFit, cp = cpValues[j])
+        tmpProb <- predict(prunedFit, newdata, type = "prob")
+        tmp[[j + 1]] <- as.data.frame(
+          tmpProb[, modelFit$obsLevels, drop = FALSE],
+          stringsAsFactors = TRUE
+        )
+      }
+      out <- tmp
+    }
+    out
+  },
+  predictors = function(x, surrogate = TRUE, ...) {
+    out <- as.character(x$frame$var)
+    out <- out[!(out %in% c("<leaf>"))]
+    if (surrogate) {
+      splits <- x$splits
+      splits <- splits[splits[, "adj"] > 0, ]
+      out <- c(out, rownames(splits))
+    }
+    unique(out)
+  },
+  varImp = function(object, surrogates = FALSE, competes = TRUE, ...) {
+    tmp <- rownames(object$splits)
+    rownames(object$splits) <- 1:nrow(object$splits)
+    splits <- data.frame(object$splits)
+    splits$var <- tmp
+    splits$type <- ""
+
+    frame <- as.data.frame(object$frame, stringsAsFactors = TRUE)
+    index <- 0
+    for (i in 1:nrow(frame)) {
+      if (frame$var[i] != "<leaf>") {
+        index <- index + 1
+        splits$type[index] <- "primary"
+        if (frame$ncompete[i] > 0) {
+          for (j in 1:frame$ncompete[i]) {
+            index <- index + 1
+            splits$type[index] <- "competing"
+          }
+        }
+        if (frame$nsurrogate[i] > 0) {
+          for (j in 1:frame$nsurrogate[i]) {
+            index <- index + 1
+            splits$type[index] <- "surrogate"
+          }
+        }
+      }
+    }
+    splits$var <- factor(as.character(splits$var))
+    if (!surrogates) {
+      splits <- subset(splits, type != "surrogate")
+    }
+    if (!competes) {
+      splits <- subset(splits, type != "competing")
+    }
+    out <- aggregate(
+      splits$improve,
+      list(Variable = splits$var),
+      sum,
+      na.rm = TRUE
+    )
+
+    allVars <- colnames(attributes(object$terms)$factors)
+    if (!all(allVars %in% out$Variable)) {
+      missingVars <- allVars[!(allVars %in% out$Variable)]
+      zeros <- data.frame(
+        x = rep(0, length(missingVars)),
+        Variable = missingVars
+      )
+      out <- rbind(out, zeros)
+    }
+    out2 <- data.frame(Overall = out$x)
+    rownames(out2) <- out$Variable
+    out2
+  },
+  levels = function(x) x$obsLevels,
+  trim = function(x) {
+    x$call <- list(na.action = (x$call)$na.action)
+    x$x <- NULL
+    x$y <- NULL
+    x$where <- NULL
+    x
+  },
+  tags = c(
+    "Tree-Based Model",
+    "Implicit Feature Selection",
+    "Handle Missing Predictor Data",
+    "Accepts Case Weights"
+  ),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/rpartCost.R
+++ b/inst/model_sources/files/rpartCost.R
@@ -8,10 +8,10 @@ modelInfo <- list(
     label = c("Complexity Parameter", "Cost")
   ),
   grid = function(x, y, len = NULL, search = "grid") {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     initialFit <- rpart::rpart(
@@ -102,7 +102,11 @@ modelInfo <- list(
       newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
     }
 
-    pType <- if (modelFit$problemType == "Classification") "class" else "vector"
+    if (modelFit$problemType == "Classification") {
+      pType <- "class"
+    } else {
+      pType <- "vector"
+    }
     out <- predict(modelFit, newdata, type = pType)
 
     if (!is.null(submodels)) {

--- a/inst/model_sources/files/rpartCost.R
+++ b/inst/model_sources/files/rpartCost.R
@@ -1,90 +1,130 @@
-modelInfo <- list(label = "Cost-Sensitive CART",
-                  library = c("rpart", "plyr"),
-                  type = "Classification",
-                  parameters = data.frame(parameter = c('cp', 'Cost'),
-                                          class = c("numeric", "numeric"),
-                                          label = c("Complexity Parameter", "Cost")),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    initialFit <- rpart::rpart(.outcome ~ .,
-                                               data = dat,
-                                               control = rpart::rpart.control(cp = 0))$cptable
-                    initialFit <- initialFit[order(-initialFit[,"CP"]), , drop = FALSE] 
-                    if(search == "grid") {
-                      if(nrow(initialFit) < len) {
-                        tuneSeq <- expand.grid(cp = seq(min(initialFit[, "CP"]), 
-                                                        max(initialFit[, "CP"]), 
-                                                        length = len),
-                                               Cost = 1:len)
-                      } else tuneSeq <-  data.frame(cp = initialFit[1:len,"CP"], Cost = 1:len)
-                      colnames(tuneSeq) <- c("cp", "Cost")
-                    } else {
-                      tuneSeq <- data.frame(cp = 10^runif(len, min = -8, max = -1),
-                                            Cost = runif(len, min = 1, max = 30))
-                    }
-                    
-                    tuneSeq
-                  },
-                  loop = function(grid) {
-                    loop <- plyr::ddply(grid,  plyr::`.`(Cost), function(x) c(cp = min(x$cp)))
-                    submodels <- vector(mode = "list", length = nrow(loop))
-                    
-                    for(i in seq(along = submodels)) {
-                      larger_cp <- subset(grid, subset = Cost == loop$Cost[i] & cp > loop$cp[i])
-                      submodels[[i]] <- 
-                        data.frame(cp = sort(larger_cp$cp))
-                    }
-                    
-                    list(loop = loop, submodels = submodels)    
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    theDots <- list(...)
-                    if(any(names(theDots) == "control")) {
-                      theDots$control$cp <- param$cp
-                      theDots$control$xval <- 0 
-                      ctl <- theDots$control
-                      theDots$control <- NULL
-                    } else ctl <- rpart::rpart.control(cp = param$cp, xval = 0)   
-                    
-                    lmat <-matrix(c(0, 1, param$Cost, 0), ncol = 2)
-                    rownames(lmat) <- colnames(lmat) <- levels(y)
-                    if(any(names(theDots) == "parms")) {
-                      theDots$parms$loss <- lmat
-                    } else parms <- list(loss = lmat)
-                    
-                    ## check to see if weights were passed in (and availible)
-                    if(!is.null(wts)) theDots$weights <- wts    
-                    
-                    modelArgs <- c(list(formula = as.formula(".outcome ~ ."),
-                                        data = if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE),
-                                        parms = parms,
-                                        control = ctl),
-                                   theDots)
-                    modelArgs$data$.outcome <- y
+modelInfo <- list(
+  label = "Cost-Sensitive CART",
+  library = c("rpart", "plyr"),
+  type = "Classification",
+  parameters = data.frame(
+    parameter = c('cp', 'Cost'),
+    class = c("numeric", "numeric"),
+    label = c("Complexity Parameter", "Cost")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    initialFit <- rpart::rpart(
+      .outcome ~ .,
+      data = dat,
+      control = rpart::rpart.control(cp = 0)
+    )$cptable
+    initialFit <- initialFit[order(-initialFit[, "CP"]), , drop = FALSE]
+    if (search == "grid") {
+      if (nrow(initialFit) < len) {
+        tuneSeq <- expand.grid(
+          cp = seq(
+            min(initialFit[, "CP"]),
+            max(initialFit[, "CP"]),
+            length = len
+          ),
+          Cost = 1:len
+        )
+      } else {
+        tuneSeq <- data.frame(cp = initialFit[1:len, "CP"], Cost = 1:len)
+      }
+      colnames(tuneSeq) <- c("cp", "Cost")
+    } else {
+      tuneSeq <- data.frame(
+        cp = 10^runif(len, min = -8, max = -1),
+        Cost = runif(len, min = 1, max = 30)
+      )
+    }
 
-                    out <- do.call(rpart::rpart, modelArgs)
-                    out
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    
-                    pType <- if(modelFit$problemType == "Classification") "class" else "vector"
-                    out  <- predict(modelFit, newdata, type = pType)
-                    
-                    if(!is.null(submodels)) {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
-                      for(j in seq(along = submodels$cp)) {
-                        prunedFit <- rpart::prune.rpart(modelFit, cp = submodels$cp[j])
-                        tmp[[j+1]]  <- predict(prunedFit, newdata, type=pType)
-                      }
-                      out <- tmp
-                    }
-                    out
-                  },
-                  levels = function(x) x$obsLevels,
-                  prob = NULL,
-                  tags = c("Tree-Based Model", "Implicit Feature Selection", "Cost Sensitive Learning", 
-                           "Two Class Only", "Handle Missing Predictor Data", "Accepts Case Weights"),
-                  sort = function(x) x[order(-x$cp, -x$Cost),])
+    tuneSeq
+  },
+  loop = function(grid) {
+    loop <- plyr::ddply(grid, plyr::`.`(Cost), function(x) c(cp = min(x$cp)))
+    submodels <- vector(mode = "list", length = nrow(loop))
+
+    for (i in seq(along = submodels)) {
+      larger_cp <- subset(grid, subset = Cost == loop$Cost[i] & cp > loop$cp[i])
+      submodels[[i]] <-
+        data.frame(cp = sort(larger_cp$cp))
+    }
+
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    theDots <- list(...)
+    if (any(names(theDots) == "control")) {
+      theDots$control$cp <- param$cp
+      theDots$control$xval <- 0
+      ctl <- theDots$control
+      theDots$control <- NULL
+    } else {
+      ctl <- rpart::rpart.control(cp = param$cp, xval = 0)
+    }
+
+    lmat <- matrix(c(0, 1, param$Cost, 0), ncol = 2)
+    rownames(lmat) <- colnames(lmat) <- levels(y)
+    if (any(names(theDots) == "parms")) {
+      theDots$parms$loss <- lmat
+    } else {
+      parms <- list(loss = lmat)
+    }
+
+    ## check to see if weights were passed in (and availible)
+    if (!is.null(wts)) {
+      theDots$weights <- wts
+    }
+
+    modelArgs <- c(
+      list(
+        formula = as.formula(".outcome ~ ."),
+        data = if (is.data.frame(x)) {
+          x
+        } else {
+          as.data.frame(x, stringsAsFactors = TRUE)
+        },
+        parms = parms,
+        control = ctl
+      ),
+      theDots
+    )
+    modelArgs$data$.outcome <- y
+
+    out <- do.call(rpart::rpart, modelArgs)
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+
+    pType <- if (modelFit$problemType == "Classification") "class" else "vector"
+    out <- predict(modelFit, newdata, type = pType)
+
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
+      for (j in seq(along = submodels$cp)) {
+        prunedFit <- rpart::prune.rpart(modelFit, cp = submodels$cp[j])
+        tmp[[j + 1]] <- predict(prunedFit, newdata, type = pType)
+      }
+      out <- tmp
+    }
+    out
+  },
+  levels = function(x) x$obsLevels,
+  prob = NULL,
+  tags = c(
+    "Tree-Based Model",
+    "Implicit Feature Selection",
+    "Cost Sensitive Learning",
+    "Two Class Only",
+    "Handle Missing Predictor Data",
+    "Accepts Case Weights"
+  ),
+  sort = function(x) x[order(-x$cp, -x$Cost), ]
+)

--- a/inst/model_sources/files/rpartScore.R
+++ b/inst/model_sources/files/rpartScore.R
@@ -8,10 +8,10 @@ modelInfo <- list(
     label = c("Complexity Parameter", "Split Function", "Pruning Measure")
   ),
   grid = function(x, y, len = NULL, search = "grid") {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     initialFit <- rpart::rpart(
@@ -62,7 +62,11 @@ modelInfo <- list(
   #                     list(loop = loop, submodels = submodels)
   #                   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    cpValue <- if (!last) param$cp else 0
+    if (!last) {
+      cpValue <- param$cp
+    } else {
+      cpValue <- 0
+    }
     theDots <- list(...)
     if (any(names(theDots) == "control")) {
       theDots$control$cp <- cpValue

--- a/inst/model_sources/files/rpartScore.R
+++ b/inst/model_sources/files/rpartScore.R
@@ -1,124 +1,169 @@
-modelInfo <- list(label = "CART or Ordinal Responses",
-                  library = c("rpartScore", "plyr"),
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = c('cp', "split", "prune"),
-                                          class = c("numeric", "character", "character"),
-                                          label = c("Complexity Parameter", "Split Function", "Pruning Measure")),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    initialFit <- rpart::rpart(.outcome ~ .,
-                                               data = dat,
-                                               control = rpart::rpart.control(cp = 0))$cptable
-                    initialFit <- initialFit[order(-initialFit[,"CP"]), , drop = FALSE] 
-                    if(search == "grid") {
-                      if(nrow(initialFit) < len) {
-                        tuneSeq <- expand.grid(cp = seq(min(initialFit[, "CP"]), 
-                                                       max(initialFit[, "CP"]), 
-                                                       length = len),
-                                               split = c("abs", "quad"),
-                                               prune = c("mr", "mc"))
-                      } else tuneSeq <-  expand.grid(cp = initialFit[1:len,"CP"],
-                                                     split = c("abs", "quad"),
-                                                     prune = c("mr", "mc"))
-                      colnames(tuneSeq)[1] <- "cp"
-                    } else {
-                      tuneSeq <- expand.grid(cp = unique(sample(initialFit[, "CP"], size = len, replace = TRUE)),
-                                             split = c("abs", "quad"),
-                                             prune = c("mr", "mc"))
-                    }
-                    
-                    tuneSeq
-                  },
-#                   loop = function(grid) {
-#                     loop <- ddply(grid, c("split", "prune"),
-#                                   function(x) c(cp = max(x$cp)))
-#                     submodels <- vector(mode = "list", length = nrow(loop))
-#                     for(i in seq(along = loop$cp)) {
-#                       index <- which(grid$prune == loop$prune[i] & 
-#                                        grid$split == loop$split[i])
-#                       trees <- grid[index, "cp"] 
-#                       submodels[[i]] <- data.frame(cp = trees[trees != loop$cp[i]])
-#                     }    
-#                     list(loop = loop, submodels = submodels)
-#                   },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    cpValue <- if(!last) param$cp else 0
-                    theDots <- list(...)
-                    if(any(names(theDots) == "control")) {
-                      theDots$control$cp <- cpValue
-                      theDots$control$xval <- 0 
-                      ctl <- theDots$control
-                      theDots$control <- NULL
-                    } else ctl <- rpart::rpart.control(cp = cpValue, xval = 0)
+modelInfo <- list(
+  label = "CART or Ordinal Responses",
+  library = c("rpartScore", "plyr"),
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = c('cp', "split", "prune"),
+    class = c("numeric", "character", "character"),
+    label = c("Complexity Parameter", "Split Function", "Pruning Measure")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    initialFit <- rpart::rpart(
+      .outcome ~ .,
+      data = dat,
+      control = rpart::rpart.control(cp = 0)
+    )$cptable
+    initialFit <- initialFit[order(-initialFit[, "CP"]), , drop = FALSE]
+    if (search == "grid") {
+      if (nrow(initialFit) < len) {
+        tuneSeq <- expand.grid(
+          cp = seq(
+            min(initialFit[, "CP"]),
+            max(initialFit[, "CP"]),
+            length = len
+          ),
+          split = c("abs", "quad"),
+          prune = c("mr", "mc")
+        )
+      } else {
+        tuneSeq <- expand.grid(
+          cp = initialFit[1:len, "CP"],
+          split = c("abs", "quad"),
+          prune = c("mr", "mc")
+        )
+      }
+      colnames(tuneSeq)[1] <- "cp"
+    } else {
+      tuneSeq <- expand.grid(
+        cp = unique(sample(initialFit[, "CP"], size = len, replace = TRUE)),
+        split = c("abs", "quad"),
+        prune = c("mr", "mc")
+      )
+    }
 
-                    ## check to see if weights were passed in (and availible)
-                    if(!is.null(wts)) theDots$weights <- wts    
-                    
-                    modelArgs <- c(list(formula = as.formula(".outcome ~ ."),
-                                        data = if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE),
-                                        split = as.character(param$split),
-                                        prune = as.character(param$prune),
-                                        control = ctl),
-                                   theDots)
-                    modelArgs$data$.outcome <- as.numeric(y)
+    tuneSeq
+  },
+  #                   loop = function(grid) {
+  #                     loop <- ddply(grid, c("split", "prune"),
+  #                                   function(x) c(cp = max(x$cp)))
+  #                     submodels <- vector(mode = "list", length = nrow(loop))
+  #                     for(i in seq(along = loop$cp)) {
+  #                       index <- which(grid$prune == loop$prune[i] &
+  #                                        grid$split == loop$split[i])
+  #                       trees <- grid[index, "cp"]
+  #                       submodels[[i]] <- data.frame(cp = trees[trees != loop$cp[i]])
+  #                     }
+  #                     list(loop = loop, submodels = submodels)
+  #                   },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    cpValue <- if (!last) param$cp else 0
+    theDots <- list(...)
+    if (any(names(theDots) == "control")) {
+      theDots$control$cp <- cpValue
+      theDots$control$xval <- 0
+      ctl <- theDots$control
+      theDots$control <- NULL
+    } else {
+      ctl <- rpart::rpart.control(cp = cpValue, xval = 0)
+    }
 
-                    out <- do.call(rpartScore::rpartScore, modelArgs)
+    ## check to see if weights were passed in (and availible)
+    if (!is.null(wts)) {
+      theDots$weights <- wts
+    }
 
-                    if(last) out <- rpart::prune.rpart(out, cp = param$cp)
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {    
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    out  <-  modelFit$obsLevels[predict(modelFit, newdata)]
-                    
-                    if(!is.null(submodels)) {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
-                      for(j in seq(along = submodels$cp)) {
-                        prunedFit <- rpart::prune.rpart(modelFit, cp = submodels$cp[j])
-                        tmp[[j+1]]  <- modelFit$obsLevels[predict(prunedFit, newdata)]
-                      }
-                      out <- tmp
-                    }
-                    out
-                  },
-                  prob = NULL,
-                  predictors = function(x, surrogate = TRUE, ...)  {
-                    out <- as.character(x$frame$var)
-                    out <- out[!(out %in% c("<leaf>"))]
-                    if(surrogate) {
-                      splits <- x$splits
-                      splits <- splits[splits[,"adj"] > 0,]
-                      out <- c(out, rownames(splits))
-                    }
-                    unique(out)
-                  },
-                  varImp = function(object, surrogates = FALSE, competes = TRUE, ...) {
-                    allVars <- all.vars(object$terms)
-                    allVars <- allVars[allVars != ".outcome"]
-                    out <- data.frame(Overall = object$variable.importance,
-                                      Variable = names(object$variable.importance))
-                    rownames(out) <- names(object$variable.importance)
-                    
-                    if(!all(allVars %in% out$Variable)) {
-                      missingVars <- allVars[!(allVars %in% out$Variable)]
-                      zeros <- data.frame(Overall = rep(0, length(missingVars)),
-                                          Variable = missingVars)
-                      out <- rbind(out, zeros)
-                    }
-                    rownames(out) <- out$Variable
-                    out$Variable <- NULL
-                    out  
-                  },
-                  levels = function(x) x$obsLevels,
-                  trim = function(x) {
-                    x$call <- list(na.action = (x$call)$na.action)
-                    x$x <- NULL
-                    x$y <- NULL
-                    x$where <- NULL
-                    x
-                  },
-                  tags = c("Tree-Based Model", "Implicit Feature Selection", "Handle Missing Predictor Data", 
-                           "Accepts Case Weights", "Ordinal Outcomes"),
-                  sort = function(x) x[order(x[,1], decreasing = TRUE),])
+    modelArgs <- c(
+      list(
+        formula = as.formula(".outcome ~ ."),
+        data = if (is.data.frame(x)) {
+          x
+        } else {
+          as.data.frame(x, stringsAsFactors = TRUE)
+        },
+        split = as.character(param$split),
+        prune = as.character(param$prune),
+        control = ctl
+      ),
+      theDots
+    )
+    modelArgs$data$.outcome <- as.numeric(y)
+
+    out <- do.call(rpartScore::rpartScore, modelArgs)
+
+    if (last) {
+      out <- rpart::prune.rpart(out, cp = param$cp)
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    out <- modelFit$obsLevels[predict(modelFit, newdata)]
+
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
+      for (j in seq(along = submodels$cp)) {
+        prunedFit <- rpart::prune.rpart(modelFit, cp = submodels$cp[j])
+        tmp[[j + 1]] <- modelFit$obsLevels[predict(prunedFit, newdata)]
+      }
+      out <- tmp
+    }
+    out
+  },
+  prob = NULL,
+  predictors = function(x, surrogate = TRUE, ...) {
+    out <- as.character(x$frame$var)
+    out <- out[!(out %in% c("<leaf>"))]
+    if (surrogate) {
+      splits <- x$splits
+      splits <- splits[splits[, "adj"] > 0, ]
+      out <- c(out, rownames(splits))
+    }
+    unique(out)
+  },
+  varImp = function(object, surrogates = FALSE, competes = TRUE, ...) {
+    allVars <- all.vars(object$terms)
+    allVars <- allVars[allVars != ".outcome"]
+    out <- data.frame(
+      Overall = object$variable.importance,
+      Variable = names(object$variable.importance)
+    )
+    rownames(out) <- names(object$variable.importance)
+
+    if (!all(allVars %in% out$Variable)) {
+      missingVars <- allVars[!(allVars %in% out$Variable)]
+      zeros <- data.frame(
+        Overall = rep(0, length(missingVars)),
+        Variable = missingVars
+      )
+      out <- rbind(out, zeros)
+    }
+    rownames(out) <- out$Variable
+    out$Variable <- NULL
+    out
+  },
+  levels = function(x) x$obsLevels,
+  trim = function(x) {
+    x$call <- list(na.action = (x$call)$na.action)
+    x$x <- NULL
+    x$y <- NULL
+    x$where <- NULL
+    x
+  },
+  tags = c(
+    "Tree-Based Model",
+    "Implicit Feature Selection",
+    "Handle Missing Predictor Data",
+    "Accepts Case Weights",
+    "Ordinal Outcomes"
+  ),
+  sort = function(x) x[order(x[, 1], decreasing = TRUE), ]
+)

--- a/inst/model_sources/files/rqlasso.R
+++ b/inst/model_sources/files/rqlasso.R
@@ -1,29 +1,38 @@
-modelInfo <- list(label = "Quantile Regression with LASSO penalty",
-                  library = "rqPen",
-                  type = "Regression",
-                  parameters = data.frame(parameter = 'lambda',
-                                          class = "numeric",
-                                          label = 'L1 Penalty'),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- expand.grid(lambda = c(10 ^ seq(-1, -4, length = len)))
-                    } else {
-                      out <- data.frame(lambda = 10^runif(len, min = -5, 1))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    rqPen::rq.lasso.fit(as.matrix(x), y, lambda = param$lambda, ...)
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    predict(modelFit, newx = as.matrix(newdata))[,1]
-                  },
-                  predictors = function(x, ...) {
-                    out <- coef(x)
-                    out <- out[names(out) != "intercept"]
-                    names(out)[out != 0]
-                  },
-                  tags = c("Linear Regression", "Quantile Regression", "Implicit Feature Selection", "L1 Regularization"),
-                  prob = NULL,
-                  sort = function(x) x[order(-x$lambda),])
+modelInfo <- list(
+  label = "Quantile Regression with LASSO penalty",
+  library = "rqPen",
+  type = "Regression",
+  parameters = data.frame(
+    parameter = 'lambda',
+    class = "numeric",
+    label = 'L1 Penalty'
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(lambda = c(10^seq(-1, -4, length = len)))
+    } else {
+      out <- data.frame(lambda = 10^runif(len, min = -5, 1))
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    rqPen::rq.lasso.fit(as.matrix(x), y, lambda = param$lambda, ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newx = as.matrix(newdata))[, 1]
+  },
+  predictors = function(x, ...) {
+    out <- coef(x)
+    out <- out[names(out) != "intercept"]
+    names(out)[out != 0]
+  },
+  tags = c(
+    "Linear Regression",
+    "Quantile Regression",
+    "Implicit Feature Selection",
+    "L1 Regularization"
+  ),
+  prob = NULL,
+  sort = function(x) x[order(-x$lambda), ]
+)

--- a/inst/model_sources/files/rqnc.R
+++ b/inst/model_sources/files/rqnc.R
@@ -1,33 +1,50 @@
-modelInfo <- list(label = "Non-Convex Penalized Quantile Regression",
-                  library = "rqPen",
-                  type = "Regression",
-                  parameters = data.frame(parameter = c('lambda', 'penalty'),
-                                          class = c("numeric", "character"),
-                                          label =  c('L1 Penalty', 'Penalty Type')),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- expand.grid(lambda = c(10 ^ seq(-1, -4, length = len)),
-                                         penalty = c("MCP", "SCAD"))
-                    } else {
-                      out <- data.frame(lambda = 10^runif(len, min = -5, 1),
-                                        penalty = sample(c("MCP", "SCAD"), size = len, replace = TRUE))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    rqPen::rq.nc.fit(as.matrix(x), y,
-                                     lambda = param$lambda,
-                                     penalty = as.character(param$penalty), ...)
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    predict(modelFit, newx = as.matrix(newdata))[,1]
-                  },
-                  predictors = function(x, ...) {
-                    out <- coef(x)
-                    out <- out[names(out) != "intercept"]
-                    names(out)[out != 0]
-                  },
-                  tags = c("Linear Regression", "Quantile Regression", "Implicit Feature Selection", "L1 Regularization"),
-                  prob = NULL,
-                  sort = function(x) x[order(-x$lambda),])
+modelInfo <- list(
+  label = "Non-Convex Penalized Quantile Regression",
+  library = "rqPen",
+  type = "Regression",
+  parameters = data.frame(
+    parameter = c('lambda', 'penalty'),
+    class = c("numeric", "character"),
+    label = c('L1 Penalty', 'Penalty Type')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        lambda = c(10^seq(-1, -4, length = len)),
+        penalty = c("MCP", "SCAD")
+      )
+    } else {
+      out <- data.frame(
+        lambda = 10^runif(len, min = -5, 1),
+        penalty = sample(c("MCP", "SCAD"), size = len, replace = TRUE)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    rqPen::rq.nc.fit(
+      as.matrix(x),
+      y,
+      lambda = param$lambda,
+      penalty = as.character(param$penalty),
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newx = as.matrix(newdata))[, 1]
+  },
+  predictors = function(x, ...) {
+    out <- coef(x)
+    out <- out[names(out) != "intercept"]
+    names(out)[out != 0]
+  },
+  tags = c(
+    "Linear Regression",
+    "Quantile Regression",
+    "Implicit Feature Selection",
+    "L1 Regularization"
+  ),
+  prob = NULL,
+  sort = function(x) x[order(-x$lambda), ]
+)

--- a/inst/model_sources/files/rrlda.R
+++ b/inst/model_sources/files/rrlda.R
@@ -1,40 +1,59 @@
-modelInfo <- list(label = "Robust Regularized Linear Discriminant Analysis",
-                  library = "rrlda",
-                  loop = NULL,
-                  type = c('Classification'),
-                  parameters = data.frame(parameter = c('lambda', 'hp', 'penalty'),
-                                          class = c('numeric', 'numeric', 'character'),
-                                          label = c('Penalty Parameter', 'Robustness Parameter', 'Penalty Type')),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- expand.grid(lambda = (1:len)*.25,
-                                         hp = seq(.5, 1, length = len),
-                                         penalty = "L2")
-                    } else {
-                      out <- data.frame(lambda = 10^runif(len, min = -5, 1),
-                                        hp = runif(len, min = 0, 1),
-                                        penalty = sample(c("L1", "L2"), size = len, replace = TRUE))
-                    }
-                    out
-                  }, 
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    require("rrlda")
-                    rrlda:::rrlda(x, as.numeric(y), lambda = param$lambda,
-                                  hp = param$hp, penalty = as.character(param$penalty), ...)    
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata)$class
-                    modelFit$obsLevels[as.numeric(out)]
-                    },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata)$posterior
-                    colnames(out) <- modelFit$obsLevels
-                    out
-                    },
-                  levels = function(x) x$obsLevels,
-                  notes = paste(
-                    "Unlike other packages used by `train`, the `rrlda`",
-                    "package is fully loaded when this model is used."
-                  ),
-                  tags = c("Discriminant Analysis", "Robust Model", "Regularization", "Linear Classifier"),
-                  sort = function(x) x[order(-x$lambda),])
+modelInfo <- list(
+  label = "Robust Regularized Linear Discriminant Analysis",
+  library = "rrlda",
+  loop = NULL,
+  type = c('Classification'),
+  parameters = data.frame(
+    parameter = c('lambda', 'hp', 'penalty'),
+    class = c('numeric', 'numeric', 'character'),
+    label = c('Penalty Parameter', 'Robustness Parameter', 'Penalty Type')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        lambda = (1:len) * .25,
+        hp = seq(.5, 1, length = len),
+        penalty = "L2"
+      )
+    } else {
+      out <- data.frame(
+        lambda = 10^runif(len, min = -5, 1),
+        hp = runif(len, min = 0, 1),
+        penalty = sample(c("L1", "L2"), size = len, replace = TRUE)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    require("rrlda")
+    rrlda:::rrlda(
+      x,
+      as.numeric(y),
+      lambda = param$lambda,
+      hp = param$hp,
+      penalty = as.character(param$penalty),
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata)$class
+    modelFit$obsLevels[as.numeric(out)]
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata)$posterior
+    colnames(out) <- modelFit$obsLevels
+    out
+  },
+  levels = function(x) x$obsLevels,
+  notes = paste(
+    "Unlike other packages used by `train`, the `rrlda`",
+    "package is fully loaded when this model is used."
+  ),
+  tags = c(
+    "Discriminant Analysis",
+    "Robust Model",
+    "Regularization",
+    "Linear Classifier"
+  ),
+  sort = function(x) x[order(-x$lambda), ]
+)

--- a/inst/model_sources/files/rvmLinear.R
+++ b/inst/model_sources/files/rvmLinear.R
@@ -1,30 +1,42 @@
-modelInfo <- list(label = "Relevance Vector Machines with Linear Kernel",
-                  library = "kernlab",
-                  loop = NULL,
-                  type = "Regression",
-                  parameters = data.frame(parameter = "parameter",
-                                          class = "character",
-                                          label = "parameter"),
-                  grid = function(x, y, len = NULL, search = "grid") data.frame(parameter = "none"),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    kernlab:::rvm(x = as.matrix(x), y = y,
-                                  kernel = kernlab::vanilladot(),
-                                  ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) 
-                    kernlab::predict(modelFit, newdata),
-                  prob = NULL,
-                  predictors = function(x, ...) {
-                    if(hasTerms(x) & !is.null(x@terms))
-                    {
-                      out <- predictors.terms(x@terms)
-                    } else {
-                      out <- colnames(attr(x, "xmatrix"))
-                    }
-                    if(is.null(out)) out <- names(attr(x, "scaling")$x.scale$`scaled:center`)
-                    if(is.null(out)) out <-NA
-                    out
-                  },
-                  tags = c("Kernel Method", "Relevance Vector Machines", "Linear Regression",
-                           "Robust Methods"),
-                  sort = function(x) x)
+modelInfo <- list(
+  label = "Relevance Vector Machines with Linear Kernel",
+  library = "kernlab",
+  loop = NULL,
+  type = "Regression",
+  parameters = data.frame(
+    parameter = "parameter",
+    class = "character",
+    label = "parameter"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(parameter = "none")
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    kernlab:::rvm(x = as.matrix(x), y = y, kernel = kernlab::vanilladot(), ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    kernlab::predict(modelFit, newdata)
+  },
+  prob = NULL,
+  predictors = function(x, ...) {
+    if (hasTerms(x) & !is.null(x@terms)) {
+      out <- predictors.terms(x@terms)
+    } else {
+      out <- colnames(attr(x, "xmatrix"))
+    }
+    if (is.null(out)) {
+      out <- names(attr(x, "scaling")$x.scale$`scaled:center`)
+    }
+    if (is.null(out)) {
+      out <- NA
+    }
+    out
+  },
+  tags = c(
+    "Kernel Method",
+    "Relevance Vector Machines",
+    "Linear Regression",
+    "Robust Methods"
+  ),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/rvmPoly.R
+++ b/inst/model_sources/files/rvmPoly.R
@@ -1,42 +1,59 @@
-modelInfo <- list(label = "Relevance Vector Machines with Polynomial Kernel",
-                  library = "kernlab",
-                  loop = NULL,
-                  type = "Regression",
-                  parameters = data.frame(parameter = c("scale", "degree"),
-                                          class = c("numeric", "numeric"),
-                                          label = c("Scale", "Polynomial Degree")),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- expand.grid(degree = seq(1, min(len, 3)),      
-                                         scale = 10 ^((1:len) - 4))
-                    } else {
-                      out <- data.frame(degree = sample(1:3, size = len, replace = TRUE),
-                                        scale = 10^runif(len, min = -5, 0))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    kernlab:::rvm(x = as.matrix(x), y = y,
-                                  kernel = kernlab::polydot(
-                                    degree = param$degree,
-                                    scale = param$scale,
-                                    offset = 1),
-                                  ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) 
-                    kernlab::predict(modelFit, newdata),
-                  prob = NULL,
-                  predictors = function(x, ...) {
-                    if(hasTerms(x) & !is.null(x@terms))
-                    {
-                      out <- predictors.terms(x@terms)
-                    } else {
-                      out <- colnames(attr(x, "xmatrix"))
-                    }
-                    if(is.null(out)) out <- names(attr(x, "scaling")$xscale$`scaled:center`)
-                    if(is.null(out)) out <-NA
-                    out
-                  },
-                  tags = c("Kernel Method", "Relevance Vector Machines", "Polynomial Model",
-                           "Robust Methods"),
-                  sort = function(x) x[order(x$degree, x$scale),])
+modelInfo <- list(
+  label = "Relevance Vector Machines with Polynomial Kernel",
+  library = "kernlab",
+  loop = NULL,
+  type = "Regression",
+  parameters = data.frame(
+    parameter = c("scale", "degree"),
+    class = c("numeric", "numeric"),
+    label = c("Scale", "Polynomial Degree")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(degree = seq(1, min(len, 3)), scale = 10^((1:len) - 4))
+    } else {
+      out <- data.frame(
+        degree = sample(1:3, size = len, replace = TRUE),
+        scale = 10^runif(len, min = -5, 0)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    kernlab:::rvm(
+      x = as.matrix(x),
+      y = y,
+      kernel = kernlab::polydot(
+        degree = param$degree,
+        scale = param$scale,
+        offset = 1
+      ),
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    kernlab::predict(modelFit, newdata)
+  },
+  prob = NULL,
+  predictors = function(x, ...) {
+    if (hasTerms(x) & !is.null(x@terms)) {
+      out <- predictors.terms(x@terms)
+    } else {
+      out <- colnames(attr(x, "xmatrix"))
+    }
+    if (is.null(out)) {
+      out <- names(attr(x, "scaling")$xscale$`scaled:center`)
+    }
+    if (is.null(out)) {
+      out <- NA
+    }
+    out
+  },
+  tags = c(
+    "Kernel Method",
+    "Relevance Vector Machines",
+    "Polynomial Model",
+    "Robust Methods"
+  ),
+  sort = function(x) x[order(x$degree, x$scale), ]
+)

--- a/inst/model_sources/files/rvmRadial.R
+++ b/inst/model_sources/files/rvmRadial.R
@@ -1,40 +1,55 @@
-modelInfo <- list(label = "Relevance Vector Machines with Radial Basis Function Kernel",
-                  library = "kernlab",
-                  loop = NULL,
-                  type = "Regression",
-                  parameters = data.frame(parameter = c("sigma"),
-                                          class = "numeric",
-                                          label = "Sigma"),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    sigmas <- kernlab::sigest(as.matrix(x), na.action = na.omit, scaled = TRUE)
-                    if(search == "grid") {
-                      out <- expand.grid(sigma = mean(as.vector(sigmas[-2])))
-                    } else {
-                      rng <- extendrange(log(sigmas), f = .75)
-                      out <- data.frame(sigma = exp(runif(len, min = rng[1], max = rng[2])))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last,classProbs, ...) {
-                    kernlab:::rvm(x = as.matrix(x), y = y,
-                                  kernel = "rbfdot",
-                                  kpar = list(sigma = param$sigma),
-                                  ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL)
-                    kernlab::predict(modelFit, newdata),
-                  prob = NULL,
-                  predictors = function(x, ...) {
-                    if(hasTerms(x) & !is.null(x@terms))
-                    {
-                      out <- predictors.terms(x@terms)
-                    } else {
-                      out <- colnames(attr(x, "xmatrix"))
-                    }
-                    if(is.null(out)) out <- names(attr(x, "scaling")$x.scale$`scaled:center`)
-                    if(is.null(out)) out <-NA
-                    out
-                  },
-                  tags = c("Kernel Method", "Relevance Vector Machines", "Radial Basis Function",
-                           "Robust Methods"),
-                  sort = function(x) x[order(-x$sigma),])
+modelInfo <- list(
+  label = "Relevance Vector Machines with Radial Basis Function Kernel",
+  library = "kernlab",
+  loop = NULL,
+  type = "Regression",
+  parameters = data.frame(
+    parameter = c("sigma"),
+    class = "numeric",
+    label = "Sigma"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    sigmas <- kernlab::sigest(as.matrix(x), na.action = na.omit, scaled = TRUE)
+    if (search == "grid") {
+      out <- expand.grid(sigma = mean(as.vector(sigmas[-2])))
+    } else {
+      rng <- extendrange(log(sigmas), f = .75)
+      out <- data.frame(sigma = exp(runif(len, min = rng[1], max = rng[2])))
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    kernlab:::rvm(
+      x = as.matrix(x),
+      y = y,
+      kernel = "rbfdot",
+      kpar = list(sigma = param$sigma),
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    kernlab::predict(modelFit, newdata)
+  },
+  prob = NULL,
+  predictors = function(x, ...) {
+    if (hasTerms(x) & !is.null(x@terms)) {
+      out <- predictors.terms(x@terms)
+    } else {
+      out <- colnames(attr(x, "xmatrix"))
+    }
+    if (is.null(out)) {
+      out <- names(attr(x, "scaling")$x.scale$`scaled:center`)
+    }
+    if (is.null(out)) {
+      out <- NA
+    }
+    out
+  },
+  tags = c(
+    "Kernel Method",
+    "Relevance Vector Machines",
+    "Radial Basis Function",
+    "Robust Methods"
+  ),
+  sort = function(x) x[order(-x$sigma), ]
+)

--- a/inst/model_sources/files/sda.R
+++ b/inst/model_sources/files/sda.R
@@ -1,32 +1,43 @@
-modelInfo <- list(label = "Shrinkage Discriminant Analysis",
-                  library = c("sda"),
-                  loop = NULL,
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = c('diagonal','lambda'),
-                                          class = c("logical", "numeric"),
-                                          label = c('Diagonalize','shrinkage')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- data.frame(diagonal = FALSE, lambda = seq(0, 1, length = len))
-                    } else {
-                      out <- data.frame(lambda = runif(len, min = 0, 1),
-                                        diagonal = sample(c(TRUE, FALSE), size = len, replace = TRUE))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...)
-                    sda::sda(as.matrix(x), 
-                             y, 
-                             diagonal = param$diagonal, 
-                             lambda = param$lambda, 
-                             ...),
-                  predict = function(modelFit, newdata, submodels = NULL)
-                    sda::predict.sda(modelFit, as.matrix(newdata))$class,
-                  prob = function(modelFit, newdata, submodels = NULL)
-                    sda::predict.sda(modelFit, as.matrix(newdata))$posterior,
-                  predictors = function(x, ...) {
-                    colnames(x$beta)
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("Discriminant Analysis", "Regularization", "Linear Classifier"),
-                  sort = function(x) x[order(x$diagonal, x$lambda),])
+modelInfo <- list(
+  label = "Shrinkage Discriminant Analysis",
+  library = c("sda"),
+  loop = NULL,
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = c('diagonal', 'lambda'),
+    class = c("logical", "numeric"),
+    label = c('Diagonalize', 'shrinkage')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(diagonal = FALSE, lambda = seq(0, 1, length = len))
+    } else {
+      out <- data.frame(
+        lambda = runif(len, min = 0, 1),
+        diagonal = sample(c(TRUE, FALSE), size = len, replace = TRUE)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    sda::sda(
+      as.matrix(x),
+      y,
+      diagonal = param$diagonal,
+      lambda = param$lambda,
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    sda::predict.sda(modelFit, as.matrix(newdata))$class
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    sda::predict.sda(modelFit, as.matrix(newdata))$posterior
+  },
+  predictors = function(x, ...) {
+    colnames(x$beta)
+  },
+  levels = function(x) x$obsLevels,
+  tags = c("Discriminant Analysis", "Regularization", "Linear Classifier"),
+  sort = function(x) x[order(x$diagonal, x$lambda), ]
+)

--- a/inst/model_sources/files/sdwd.R
+++ b/inst/model_sources/files/sdwd.R
@@ -62,7 +62,13 @@ modelInfo <- list(
     colnames(out) <- "Overall"
     out
   },
-  levels = function(x) if (any(names(x) == "obsLevels")) x$obsLevels else NULL,
+  levels = function(x) {
+    if (any(names(x) == "obsLevels")) {
+      x$obsLevels
+    } else {
+      NULL
+    }
+  },
   tags = c(
     "Discriminant Analysis Models",
     "Implicit Feature Selection",

--- a/inst/model_sources/files/sdwd.R
+++ b/inst/model_sources/files/sdwd.R
@@ -1,64 +1,79 @@
-modelInfo <- list(label = "Sparse Distance Weighted Discrimination",
-                  library = "sdwd",
-                  type = "Classification",
-                  parameters = data.frame(parameter = c('lambda', 'lambda2'),
-                                          class = c("numeric", "numeric"),
-                                          label = c('L1 Penalty', 'L2 Penalty')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    lev <- levels(y)
-                    y <- ifelse(y == lev[1], 1, -1)
-                    init <- sdwd::sdwd(as.matrix(x), y,
-                                       nlambda = len + 2,
-                                       lambda2 = 0)
-                    lambda <- unique(init$lambda)
-                    lambda <- lambda[-c(1, length(lambda))]
+modelInfo <- list(
+  label = "Sparse Distance Weighted Discrimination",
+  library = "sdwd",
+  type = "Classification",
+  parameters = data.frame(
+    parameter = c('lambda', 'lambda2'),
+    class = c("numeric", "numeric"),
+    label = c('L1 Penalty', 'L2 Penalty')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    lev <- levels(y)
+    y <- ifelse(y == lev[1], 1, -1)
+    init <- sdwd::sdwd(as.matrix(x), y, nlambda = len + 2, lambda2 = 0)
+    lambda <- unique(init$lambda)
+    lambda <- lambda[-c(1, length(lambda))]
 
-                    if(search == "grid") {
-                      lambda <- lambda[1:min(length(lambda), len)]
-                      out <- expand.grid(lambda = lambda,
-                                         lambda2 = seq(0.1, 1, length = len))
-                    } else {
-                      out <- data.frame(lambda = runif(len, min = min(lambda), max(lambda)),
-                                        lambda2 = 10^runif(len, min = -5, 0))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    y <- ifelse(y == lev[1], 1, -1)
-                    sdwd::sdwd(as.matrix(x), y = y,
-                               lambda = param$lambda,
-                               lambda2 = param$lambda2, 
-                               ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    out <- predict(modelFit, newx = newdata, type = "class")
-                    ifelse(out == 1, modelFit$obsLevels[1], modelFit$obsLevels[2])
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    out <- predict(modelFit, newx = newdata, type = "link")
-                    out <- binomial()$linkinv(out)
-                    out <- data.frame(c1 = out, c2 = 1 - out)
-                    colnames(out) <- modelFit$obsLevels
-                    out
-                  },
-                  predictors = function(x, ...) {
-                    out <- apply(x$beta, 1, function(x) any(x != 0))
-                    names(out)[out]
-                  },
-                  varImp = function(object, lambda = NULL, ...) {
-                    out <- as.data.frame(as.matrix(abs(object$beta)), stringsAsFactors = TRUE)
-                    colnames(out) <- "Overall"
-                    out
-                  },
-                  levels = function(x) if(any(names(x) == "obsLevels")) x$obsLevels else NULL,
-                  tags = c("Discriminant Analysis Models", "Implicit Feature Selection", 
-                           "L1 Regularization", "L2 Regularization", "Linear Classifier",
-                           "Distance Weighted Discrimination"),
-                  sort = function(x) x[order(-x$lambda, -x$lambda2),],
-                  trim = function(x) {
-                    x$call <- NULL
-                    x
-                  })
+    if (search == "grid") {
+      lambda <- lambda[1:min(length(lambda), len)]
+      out <- expand.grid(lambda = lambda, lambda2 = seq(0.1, 1, length = len))
+    } else {
+      out <- data.frame(
+        lambda = runif(len, min = min(lambda), max(lambda)),
+        lambda2 = 10^runif(len, min = -5, 0)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    y <- ifelse(y == lev[1], 1, -1)
+    sdwd::sdwd(
+      as.matrix(x),
+      y = y,
+      lambda = param$lambda,
+      lambda2 = param$lambda2,
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- predict(modelFit, newx = newdata, type = "class")
+    ifelse(out == 1, modelFit$obsLevels[1], modelFit$obsLevels[2])
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- predict(modelFit, newx = newdata, type = "link")
+    out <- binomial()$linkinv(out)
+    out <- data.frame(c1 = out, c2 = 1 - out)
+    colnames(out) <- modelFit$obsLevels
+    out
+  },
+  predictors = function(x, ...) {
+    out <- apply(x$beta, 1, function(x) any(x != 0))
+    names(out)[out]
+  },
+  varImp = function(object, lambda = NULL, ...) {
+    out <- as.data.frame(as.matrix(abs(object$beta)), stringsAsFactors = TRUE)
+    colnames(out) <- "Overall"
+    out
+  },
+  levels = function(x) if (any(names(x) == "obsLevels")) x$obsLevels else NULL,
+  tags = c(
+    "Discriminant Analysis Models",
+    "Implicit Feature Selection",
+    "L1 Regularization",
+    "L2 Regularization",
+    "Linear Classifier",
+    "Distance Weighted Discrimination"
+  ),
+  sort = function(x) x[order(-x$lambda, -x$lambda2), ],
+  trim = function(x) {
+    x$call <- NULL
+    x
+  }
+)

--- a/inst/model_sources/files/simpls.R
+++ b/inst/model_sources/files/simpls.R
@@ -1,130 +1,168 @@
-modelInfo <- list(label = "Partial Least Squares",
-                  library = "pls",
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = 'ncomp',
-                                          class = "numeric",
-                                          label = '#Components'),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- data.frame(ncomp = seq(1, min(ncol(x) - 1, len), by = 1))
-                    } else {
-                      out <- data.frame(ncomp = unique(sample(1:(ncol(x)-1), size = len, replace = TRUE)))
-                    }
-                    out
-                  },
-                  loop = function(grid) {
-                    grid <- grid[order(grid$ncomp, decreasing = TRUE),, drop = FALSE]
-                    loop <- grid[1,,drop = FALSE]
-                    submodels <- list(grid[-1,,drop = FALSE])
-                    list(loop = loop, submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    ncomp <- min(ncol(x), param$ncomp)
-                    out <- if(is.factor(y))
-                    {
-                      plsda(x, y, method = "simpls", ncomp = ncomp, ...)
-                    } else {
-                      dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                      dat$.outcome <- y
-                      pls::plsr(.outcome ~ ., data = dat, method = "simpls", ncomp = ncomp, ...)
-                    }
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- if(modelFit$problemType == "Classification")
-                    {
-                      if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                      out <- predict(modelFit, newdata, type="class")
+modelInfo <- list(
+  label = "Partial Least Squares",
+  library = "pls",
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = 'ncomp',
+    class = "numeric",
+    label = '#Components'
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(ncomp = seq(1, min(ncol(x) - 1, len), by = 1))
+    } else {
+      out <- data.frame(
+        ncomp = unique(sample(1:(ncol(x) - 1), size = len, replace = TRUE))
+      )
+    }
+    out
+  },
+  loop = function(grid) {
+    grid <- grid[order(grid$ncomp, decreasing = TRUE), , drop = FALSE]
+    loop <- grid[1, , drop = FALSE]
+    submodels <- list(grid[-1, , drop = FALSE])
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    ncomp <- min(ncol(x), param$ncomp)
+    out <- if (is.factor(y)) {
+      plsda(x, y, method = "simpls", ncomp = ncomp, ...)
+    } else {
+      dat <- if (is.data.frame(x)) {
+        x
+      } else {
+        as.data.frame(x, stringsAsFactors = TRUE)
+      }
+      dat$.outcome <- y
+      pls::plsr(.outcome ~ ., data = dat, method = "simpls", ncomp = ncomp, ...)
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- if (modelFit$problemType == "Classification") {
+      if (!is.matrix(newdata)) {
+        newdata <- as.matrix(newdata)
+      }
+      out <- predict(modelFit, newdata, type = "class")
+    } else {
+      as.vector(pls:::predict.mvr(
+        modelFit,
+        newdata,
+        ncomp = max(modelFit$ncomp)
+      ))
+    }
 
-                    } else as.vector(pls:::predict.mvr(modelFit, newdata, ncomp = max(modelFit$ncomp)))
+    if (!is.null(submodels)) {
+      ## We'll merge the first set of predictions below
+      tmp <- vector(mode = "list", length = nrow(submodels))
 
-                    if(!is.null(submodels))
-                    {
-                      ## We'll merge the first set of predictions below
-                      tmp <- vector(mode = "list", length = nrow(submodels))
+      if (modelFit$problemType == "Classification") {
+        if (length(submodels$ncomp) > 1) {
+          tmp <- as.list(predict(modelFit, newdata, ncomp = submodels$ncomp))
+        } else {
+          tmp <- list(predict(modelFit, newdata, ncomp = submodels$ncomp))
+        }
+      } else {
+        tmp <- as.list(
+          as.data.frame(
+            apply(
+              predict(modelFit, newdata, ncomp = submodels$ncomp),
+              3,
+              function(x) list(x)
+            )
+          )
+        )
+      }
 
-                      if(modelFit$problemType == "Classification")
-                      {
-                        if(length(submodels$ncomp) > 1)
-                        {
-                          tmp <- as.list(predict(modelFit, newdata, ncomp = submodels$ncomp))
-                        } else tmp <- list(predict(modelFit, newdata, ncomp = submodels$ncomp))
+      out <- c(list(out), tmp)
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- predict(
+      modelFit,
+      newdata,
+      type = "prob",
+      ncomp = modelFit$tuneValue$ncomp
+    )
+    if (length(dim(out)) == 3) {
+      if (dim(out)[1] > 1) {
+        out <- out[,, 1]
+      } else {
+        out <- as.data.frame(t(out[,, 1]), stringsAsFactors = TRUE)
+      }
+    }
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
 
-                      } else {
-                        tmp <- as.list(
-                          as.data.frame(
-                            apply(predict(modelFit, newdata, ncomp = submodels$ncomp), 3, function(x) list(x))))
-                      }
+      for (j in seq(along = submodels$ncomp)) {
+        tmpProb <- predict(
+          modelFit,
+          newdata,
+          type = "prob",
+          ncomp = submodels$ncomp[j]
+        )
+        if (length(dim(tmpProb)) == 3) {
+          if (dim(tmpProb)[1] > 1) {
+            tmpProb <- tmpProb[,, 1]
+          } else {
+            tmpProb <- as.data.frame(t(tmpProb[,, 1]), stringsAsFactors = TRUE)
+          }
+        }
+        tmp[[j + 1]] <- as.data.frame(
+          tmpProb[, modelFit$obsLevels, drop = FALSE],
+          stringsAsFactors = TRUE
+        )
+      }
+      out <- tmp
+    }
+    out
+  },
+  varImp = function(object, estimate = NULL, ...) {
+    library(pls)
+    modelCoef <- coef(object, intercept = FALSE, comps = 1:object$ncomp)
+    perf <- pls:::MSEP.mvr(object)$val
 
-                      out <- c(list(out), tmp)
-                    }
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    out <- predict(modelFit, newdata, type = "prob",  ncomp = modelFit$tuneValue$ncomp)
-                    if(length(dim(out)) == 3){
-                      if(dim(out)[1] > 1) {
-                        out <- out[,,1]
-                      } else {
-                        out <- as.data.frame(t(out[,,1]), stringsAsFactors = TRUE)
-                      }
-                    }
-                    if(!is.null(submodels))
-                    {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
+    nms <- dimnames(perf)
+    if (length(nms$estimate) > 1) {
+      pIndex <- if (is.null(estimate)) 1 else which(nms$estimate == estimate)
+      perf <- perf[pIndex, , , drop = FALSE]
+    }
+    numResp <- dim(modelCoef)[2]
 
-                      for(j in seq(along = submodels$ncomp))
-                      {
-                        tmpProb <- predict(modelFit, newdata, type = "prob",  ncomp = submodels$ncomp[j])
-                        if(length(dim(tmpProb)) == 3){
-                          if(dim(tmpProb)[1] > 1) {
-                            tmpProb <- tmpProb[,,1]
-                          } else {
-                            tmpProb <- as.data.frame(t(tmpProb[,,1]), stringsAsFactors = TRUE)
-                          }
-                        }
-                        tmp[[j+1]] <- as.data.frame(tmpProb[, modelFit$obsLevels, drop = FALSE], stringsAsFactors = TRUE)
-                      }
-                      out <- tmp
-                    }
-                    out
-                  },
-                  varImp = function(object, estimate = NULL, ...) {
-                  	library(pls)
-                    modelCoef <- coef(object, intercept = FALSE, comps = 1:object$ncomp)
-                    perf <- pls:::MSEP.mvr(object)$val
+    if (numResp <= 2) {
+      modelCoef <- modelCoef[, 1, , drop = FALSE]
+      perf <- perf[, 1, ]
+      delta <- -diff(perf)
+      delta <- delta / sum(delta)
+      out <- data.frame(
+        Overall = apply(abs(modelCoef), 1, weighted.mean, w = delta)
+      )
+    } else {
+      perf <- -t(apply(perf[1, , ], 1, diff))
+      perf <- t(apply(perf, 1, function(u) u / sum(u)))
+      out <- matrix(NA, ncol = numResp, nrow = dim(modelCoef)[1])
 
-                    nms <- dimnames(perf)
-                    if(length(nms$estimate) > 1) {
-                      pIndex <- if(is.null(estimate)) 1 else which(nms$estimate == estimate)
-                      perf <- perf[pIndex,,,drop = FALSE]
-                    }
-                    numResp <- dim(modelCoef)[2]
-
-                    if(numResp <= 2) {
-                      modelCoef <- modelCoef[,1,,drop = FALSE]
-                      perf <- perf[,1,]
-                      delta <- -diff(perf)
-                      delta <- delta/sum(delta)
-                      out <- data.frame(Overall = apply(abs(modelCoef), 1,
-                                                        weighted.mean, w = delta))
-                    } else {
-                      perf <- -t(apply(perf[1,,], 1, diff))
-                      perf <- t(apply(perf, 1, function(u) u/sum(u)))
-                      out <- matrix(NA, ncol = numResp, nrow = dim(modelCoef)[1])
-
-                      for(i in 1:numResp) {
-                        tmp <- abs(modelCoef[,i,, drop = FALSE])
-                        out[,i] <- apply(tmp, 1,  weighted.mean, w = perf[i,])
-                      }
-                      colnames(out) <- dimnames(modelCoef)[[2]]
-                      rownames(out) <- dimnames(modelCoef)[[1]]
-                    }
-                    as.data.frame(out, stringsAsFactors = TRUE)
-                  },
-                  levels = function(x) x$obsLevels,
-                  predictors = function(x, ...) rownames(x$projection),
-                  tags = c("Partial Least Squares", "Feature Extraction", "Linear Classifier", "Linear Regression"),
-                  sort = function(x) x[order(x[,1]),])
+      for (i in 1:numResp) {
+        tmp <- abs(modelCoef[, i, , drop = FALSE])
+        out[, i] <- apply(tmp, 1, weighted.mean, w = perf[i, ])
+      }
+      colnames(out) <- dimnames(modelCoef)[[2]]
+      rownames(out) <- dimnames(modelCoef)[[1]]
+    }
+    as.data.frame(out, stringsAsFactors = TRUE)
+  },
+  levels = function(x) x$obsLevels,
+  predictors = function(x, ...) rownames(x$projection),
+  tags = c(
+    "Partial Least Squares",
+    "Feature Extraction",
+    "Linear Classifier",
+    "Linear Regression"
+  ),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/simpls.R
+++ b/inst/model_sources/files/simpls.R
@@ -25,27 +25,33 @@ modelInfo <- list(
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
     ncomp <- min(ncol(x), param$ncomp)
-    out <- if (is.factor(y)) {
-      plsda(x, y, method = "simpls", ncomp = ncomp, ...)
+    if (is.factor(y)) {
+      out <- plsda(x, y, method = "simpls", ncomp = ncomp, ...)
     } else {
-      dat <- if (is.data.frame(x)) {
-        x
+      if (is.data.frame(x)) {
+        dat <- x
       } else {
-        as.data.frame(x, stringsAsFactors = TRUE)
+        dat <- as.data.frame(x, stringsAsFactors = TRUE)
       }
       dat$.outcome <- y
-      pls::plsr(.outcome ~ ., data = dat, method = "simpls", ncomp = ncomp, ...)
+      out <- pls::plsr(
+        .outcome ~ .,
+        data = dat,
+        method = "simpls",
+        ncomp = ncomp,
+        ...
+      )
     }
     out
   },
   predict = function(modelFit, newdata, submodels = NULL) {
-    out <- if (modelFit$problemType == "Classification") {
+    if (modelFit$problemType == "Classification") {
       if (!is.matrix(newdata)) {
         newdata <- as.matrix(newdata)
       }
       out <- predict(modelFit, newdata, type = "class")
     } else {
-      as.vector(pls:::predict.mvr(
+      out <- as.vector(pls:::predict.mvr(
         modelFit,
         newdata,
         ncomp = max(modelFit$ncomp)
@@ -129,7 +135,11 @@ modelInfo <- list(
 
     nms <- dimnames(perf)
     if (length(nms$estimate) > 1) {
-      pIndex <- if (is.null(estimate)) 1 else which(nms$estimate == estimate)
+      if (is.null(estimate)) {
+        pIndex <- 1
+      } else {
+        pIndex <- which(nms$estimate == estimate)
+      }
       perf <- perf[pIndex, , , drop = FALSE]
     }
     numResp <- dim(modelCoef)[2]

--- a/inst/model_sources/files/slda.R
+++ b/inst/model_sources/files/slda.R
@@ -1,26 +1,41 @@
-modelInfo <- list(label = "Stabilized Linear Discriminant Analysis",
-                  library = c("ipred"),
-                  loop = NULL,
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = c('parameter'),
-                                          class = c("character"),
-                                          label = c('none')),
-                  grid = function(x, y, len = NULL, search = "grid") 
-                    data.frame(parameter = "none"),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    ipred::slda(.outcome ~ ., data = dat, ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata)$class
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata)$posterior
-                  },
-                  levels = function(x) x$obsLevels,
-                  predictors = function(x, ...) if(hasTerms(x)) predictors(x$terms) else predictors(x$mylda),
-                  tags = c("Discriminant Analysis", "Linear Classifier"),
-                  sort = function(x) x)
+modelInfo <- list(
+  label = "Stabilized Linear Discriminant Analysis",
+  library = c("ipred"),
+  loop = NULL,
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = c('parameter'),
+    class = c("character"),
+    label = c('none')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(parameter = "none")
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    ipred::slda(.outcome ~ ., data = dat, ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata)$class
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata)$posterior
+  },
+  levels = function(x) x$obsLevels,
+  predictors = function(x, ...) {
+    if (hasTerms(x)) predictors(x$terms) else predictors(x$mylda)
+  },
+  tags = c("Discriminant Analysis", "Linear Classifier"),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/slda.R
+++ b/inst/model_sources/files/slda.R
@@ -12,10 +12,10 @@ modelInfo <- list(
     data.frame(parameter = "none")
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     ipred::slda(.outcome ~ ., data = dat, ...)
@@ -34,7 +34,11 @@ modelInfo <- list(
   },
   levels = function(x) x$obsLevels,
   predictors = function(x, ...) {
-    if (hasTerms(x)) predictors(x$terms) else predictors(x$mylda)
+    if (hasTerms(x)) {
+      predictors(x$terms)
+    } else {
+      predictors(x$mylda)
+    }
   },
   tags = c("Discriminant Analysis", "Linear Classifier"),
   sort = function(x) x

--- a/inst/model_sources/files/smda.R
+++ b/inst/model_sources/files/smda.R
@@ -1,38 +1,55 @@
-modelInfo <- list(label = "Sparse Mixture Discriminant Analysis",
-                  library = c("sparseLDA"),
-                  loop = NULL,
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = c('NumVars', 'lambda', "R"),
-                                          class = c("numeric", "numeric", "numeric"),
-                                          label = c('# Predictors', 'Lambda', '# Subclasses')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(NumVars = caret::var_seq(p = ncol(x), 
-                                                                  classification = is.factor(y), 
-                                                                  len = len),
-                                         R = (1:len) + 1,
-                                         lambda = c(0, 10 ^ seq(-1, -4, length = len - 1)))
-                    } else {
-                      out <- data.frame(NumVars = sample(1:ncol(x), size = len, replace = TRUE),
-                                        lambda = 10^runif(len, min = -5, 1),
-                                        R = sample(2:5, size = len, replace = TRUE))
-                    }
-                    out
-                  },
-                  {
-                    
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...)
-                    sparseLDA::smda(x, y,
-                                    Rj = param$R,
-                                    lambda = param$lambda,
-                                    stop = -param$NumVars,
-                                    ...),
-                  predict = function(modelFit, newdata, submodels = NULL)
-                    predict(modelFit, newdata)$class,
-                  prob = NULL,
-                  levels = function(x) x$obsLevels,
-                  predictors = function(x, ...) x$varNames,
-                  tags = c("Discriminant Analysis", "L1 Regularization", 
-                           "Implicit Feature Selection", "Mixture Model"),
-                  sort = function(x) x[order(x$NumVars, x$R, -x$lambda),])
+modelInfo <- list(
+  label = "Sparse Mixture Discriminant Analysis",
+  library = c("sparseLDA"),
+  loop = NULL,
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = c('NumVars', 'lambda', "R"),
+    class = c("numeric", "numeric", "numeric"),
+    label = c('# Predictors', 'Lambda', '# Subclasses')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        NumVars = caret::var_seq(
+          p = ncol(x),
+          classification = is.factor(y),
+          len = len
+        ),
+        R = (1:len) + 1,
+        lambda = c(0, 10^seq(-1, -4, length = len - 1))
+      )
+    } else {
+      out <- data.frame(
+        NumVars = sample(1:ncol(x), size = len, replace = TRUE),
+        lambda = 10^runif(len, min = -5, 1),
+        R = sample(2:5, size = len, replace = TRUE)
+      )
+    }
+    out
+  },
+  {},
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    sparseLDA::smda(
+      x,
+      y,
+      Rj = param$R,
+      lambda = param$lambda,
+      stop = -param$NumVars,
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)$class
+  },
+  prob = NULL,
+  levels = function(x) x$obsLevels,
+  predictors = function(x, ...) x$varNames,
+  tags = c(
+    "Discriminant Analysis",
+    "L1 Regularization",
+    "Implicit Feature Selection",
+    "Mixture Model"
+  ),
+  sort = function(x) x[order(x$NumVars, x$R, -x$lambda), ]
+)

--- a/inst/model_sources/files/snn.R
+++ b/inst/model_sources/files/snn.R
@@ -1,35 +1,46 @@
-modelInfo <- list(label = "Stabilized Nearest Neighbor Classifier",
-                  library = "snn",
-                  loop = NULL,
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = "lambda",
-                                          class = "numeric",
-                                          label = "Stabilization Parameter"),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- expand.grid(lambda = c(0, 2 ^ seq(-5, 5, length = len - 1)))
-                    } else {
-                      out <- data.frame(lambda = 2^runif(len, min = -5, 5))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    if(!is.matrix(x)) x <- as.matrix(x)
-                    if(!(class(x[1,1]) %in% c("integer", "numeric")))
-                      stop("predictors should be all numeric")
-                    x <- cbind(x, as.numeric(y))
-                    colnames(x)[ncol(x)] <- ".outcome"
-                    list(dat = x, lambda = param$lambda)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    out <- snn::mysnn(train = modelFit$dat,
-                                      test = newdata,
-                                      lambda = modelFit$lambda)
-                    modelFit$obsLevels[out]
-                  },
-                  predictors = function(x, ...) x$xNames,
-                  tags = "Prototype Models",
-                  prob = NULL,
-                  levels = function(x) x$obsLevels,
-                  sort = function(x) x[order(-x[,1]),])
+modelInfo <- list(
+  label = "Stabilized Nearest Neighbor Classifier",
+  library = "snn",
+  loop = NULL,
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = "lambda",
+    class = "numeric",
+    label = "Stabilization Parameter"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(lambda = c(0, 2^seq(-5, 5, length = len - 1)))
+    } else {
+      out <- data.frame(lambda = 2^runif(len, min = -5, 5))
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (!is.matrix(x)) {
+      x <- as.matrix(x)
+    }
+    if (!(class(x[1, 1]) %in% c("integer", "numeric"))) {
+      stop("predictors should be all numeric")
+    }
+    x <- cbind(x, as.numeric(y))
+    colnames(x)[ncol(x)] <- ".outcome"
+    list(dat = x, lambda = param$lambda)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- snn::mysnn(
+      train = modelFit$dat,
+      test = newdata,
+      lambda = modelFit$lambda
+    )
+    modelFit$obsLevels[out]
+  },
+  predictors = function(x, ...) x$xNames,
+  tags = "Prototype Models",
+  prob = NULL,
+  levels = function(x) x$obsLevels,
+  sort = function(x) x[order(-x[, 1]), ]
+)

--- a/inst/model_sources/files/sparseLDA.R
+++ b/inst/model_sources/files/sparseLDA.R
@@ -1,34 +1,47 @@
-modelInfo <- list(label = "Sparse Linear Discriminant Analysis",
-                  library = c("sparseLDA"),
-                  loop = NULL,
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = c('NumVars', 'lambda'),
-                                          class = c("numeric", "numeric"),
-                                          label = c('# Predictors', 'Lambda')),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- expand.grid(NumVars = caret::var_seq(p = ncol(x), 
-                                                                  classification = is.factor(y), 
-                                                                  len = len),
-                                         lambda = c(0, 10 ^ seq(-1, -4, length = len - 1)))
-                    } else {
-                      out <- data.frame(lambda = 10^runif(len, min = -5, 1),
-                                        NumVars = sample(1:ncol(x), size = len, replace = TRUE))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) 
-                    sparseLDA:::sda(x, y, 
-                                    lambda = param$lambda, 
-                                    stop = -param$NumVars, 
-                                    ...)
-                  ,
-                  predictors = function(x) x$xNames[x$varIndex],
-                  predict = function(modelFit, newdata, submodels = NULL)
-                    sparseLDA:::predict.sda(modelFit, newdata)$class,
-                  prob = function(modelFit, newdata, submodels = NULL)
-                    sparseLDA:::predict.sda(modelFit, newdata)$posterior,
-                  levels = function(x) x$obsLevels,
-                  tags = c("Discriminant Analysis", "L1 Regularization", 
-                           "Implicit Feature Selection", "Linear Classifier"),
-                  sort = function(x) x[order(x$NumVars, -x$lambda),])
+modelInfo <- list(
+  label = "Sparse Linear Discriminant Analysis",
+  library = c("sparseLDA"),
+  loop = NULL,
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = c('NumVars', 'lambda'),
+    class = c("numeric", "numeric"),
+    label = c('# Predictors', 'Lambda')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        NumVars = caret::var_seq(
+          p = ncol(x),
+          classification = is.factor(y),
+          len = len
+        ),
+        lambda = c(0, 10^seq(-1, -4, length = len - 1))
+      )
+    } else {
+      out <- data.frame(
+        lambda = 10^runif(len, min = -5, 1),
+        NumVars = sample(1:ncol(x), size = len, replace = TRUE)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    sparseLDA:::sda(x, y, lambda = param$lambda, stop = -param$NumVars, ...)
+  },
+  predictors = function(x) x$xNames[x$varIndex],
+  predict = function(modelFit, newdata, submodels = NULL) {
+    sparseLDA:::predict.sda(modelFit, newdata)$class
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    sparseLDA:::predict.sda(modelFit, newdata)$posterior
+  },
+  levels = function(x) x$obsLevels,
+  tags = c(
+    "Discriminant Analysis",
+    "L1 Regularization",
+    "Implicit Feature Selection",
+    "Linear Classifier"
+  ),
+  sort = function(x) x[order(x$NumVars, -x$lambda), ]
+)

--- a/inst/model_sources/files/spikeslab.R
+++ b/inst/model_sources/files/spikeslab.R
@@ -1,69 +1,90 @@
-modelInfo <- list(label = "Spike and Slab Regression",
-                  library = c("spikeslab", "plyr"),
-                  type = "Regression",
-                  parameters = data.frame(parameter = 'vars',
-                                          class = "numeric",
-                                          label = 'Variables Retained'),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- data.frame(vars = caret::var_seq(p = ncol(x), 
-                                                              classification = is.factor(y), 
-                                                              len = len))
-                    } else {
-                      out <- data.frame(vars = unique(sample(1:ncol(x), size = len, replace = TRUE)))
-                    }
-                    out
-                  },
-                  loop = function(grid) {   
-                    grid <- grid[order(grid$vars, decreasing = TRUE),, drop = FALSE]
-                    loop <- grid[1,,drop = FALSE]
-                    submodels <- list(grid[-1,,drop = FALSE])     
-                    list(loop = loop, submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    require(spikeslab)
-                    mod <- spikeslab::spikeslab(x = as.matrix(x), y = y, max.var = param$vars, ...)
-                    ## Get a key to go between the column of the path matrix and the 
-                    ## number of non-zero coefficients. There can be multiple path 
-                    ## values that have the same number of nonzero betas and, 
-                    ## in some cases, no solution that has k non-zero values. In 
-                    ## this case, we will impute using the next adjacent value. 
-                    path <- data.frame(k = apply(mod$gnet.path$path, 1, function(x) sum(x != 0)))
-                    path$index <- 1:nrow(path)
-                    path <- plyr::ddply(path, plyr::`.`(k), function(x) x[which.min(x$index),])
-                    if(all(path$k != ncol(x)))
-                      path <- rbind(path, data.frame(k = ncol(x), index = max(path$index)))
-                    mod$.path <- path
-                    mod$.size <- param$vars
-                    mod
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    out <- spikeslab::predict.spikeslab(modelFit, newdata)$yhat.gnet.path
-                    if(is.vector(out)) out <- matrix(out, nrow = 1)
-                    if(!is.null(submodels)) {
-                      vars <- data.frame(k = c(modelFit$.size, submodels$vars))
-                      vars$order <- 1:nrow(vars)
-                      vars <- merge(vars, modelFit$.path, all.x = TRUE)
-                      vars <- vars[order(vars$order),]
-                      
-                      out <- out[,vars$index]
-                      out <- as.list(as.data.frame(out, stringsAsFactors = TRUE))
-                    } else {
-                      index <- modelFit$.path$index[modelFit$.path$k == modelFit$.size]
-                      out <- out[,index]
-                    }
-                    out        
-                  },
-                  predictors = function(x, s = NULL, ...) {
-                    coefs <- x$gnet
-                    names(coefs)[coefs != 0]
-                  },
-                  notes = paste(
-                    "Unlike other packages used by `train`, the `spikeslab`",
-                    "package is fully loaded when this model is used."
-                  ),
-                  tags = c("Linear Regression", "Bayesian Model", 
-                           "Implicit Feature Selection"),
-                  prob = NULL,
-                  sort = function(x) x)
+modelInfo <- list(
+  label = "Spike and Slab Regression",
+  library = c("spikeslab", "plyr"),
+  type = "Regression",
+  parameters = data.frame(
+    parameter = 'vars',
+    class = "numeric",
+    label = 'Variables Retained'
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(
+        vars = caret::var_seq(
+          p = ncol(x),
+          classification = is.factor(y),
+          len = len
+        )
+      )
+    } else {
+      out <- data.frame(
+        vars = unique(sample(1:ncol(x), size = len, replace = TRUE))
+      )
+    }
+    out
+  },
+  loop = function(grid) {
+    grid <- grid[order(grid$vars, decreasing = TRUE), , drop = FALSE]
+    loop <- grid[1, , drop = FALSE]
+    submodels <- list(grid[-1, , drop = FALSE])
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    require(spikeslab)
+    mod <- spikeslab::spikeslab(
+      x = as.matrix(x),
+      y = y,
+      max.var = param$vars,
+      ...
+    )
+    ## Get a key to go between the column of the path matrix and the
+    ## number of non-zero coefficients. There can be multiple path
+    ## values that have the same number of nonzero betas and,
+    ## in some cases, no solution that has k non-zero values. In
+    ## this case, we will impute using the next adjacent value.
+    path <- data.frame(
+      k = apply(mod$gnet.path$path, 1, function(x) sum(x != 0))
+    )
+    path$index <- 1:nrow(path)
+    path <- plyr::ddply(path, plyr::`.`(k), function(x) x[which.min(x$index), ])
+    if (all(path$k != ncol(x))) {
+      path <- rbind(path, data.frame(k = ncol(x), index = max(path$index)))
+    }
+    mod$.path <- path
+    mod$.size <- param$vars
+    mod
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- spikeslab::predict.spikeslab(modelFit, newdata)$yhat.gnet.path
+    if (is.vector(out)) {
+      out <- matrix(out, nrow = 1)
+    }
+    if (!is.null(submodels)) {
+      vars <- data.frame(k = c(modelFit$.size, submodels$vars))
+      vars$order <- 1:nrow(vars)
+      vars <- merge(vars, modelFit$.path, all.x = TRUE)
+      vars <- vars[order(vars$order), ]
+
+      out <- out[, vars$index]
+      out <- as.list(as.data.frame(out, stringsAsFactors = TRUE))
+    } else {
+      index <- modelFit$.path$index[modelFit$.path$k == modelFit$.size]
+      out <- out[, index]
+    }
+    out
+  },
+  predictors = function(x, s = NULL, ...) {
+    coefs <- x$gnet
+    names(coefs)[coefs != 0]
+  },
+  notes = paste(
+    "Unlike other packages used by `train`, the `spikeslab`",
+    "package is fully loaded when this model is used."
+  ),
+  tags = c("Linear Regression", "Bayesian Model", "Implicit Feature Selection"),
+  prob = NULL,
+  sort = function(x) x
+)

--- a/inst/model_sources/files/spls.R
+++ b/inst/model_sources/files/spls.R
@@ -1,45 +1,65 @@
-modelInfo <- list(label = "Sparse Partial Least Squares",
-                  library = "spls",
-                  type = c('Regression', 'Classification'),
-                  parameters = data.frame(parameter = c('K', 'eta', 'kappa'),
-                                          class = c('numeric', 'numeric', 'numeric'),
-                                          label = c('#Components', 'Threshold', 'Kappa')),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- expand.grid(K = 1:min(nrow(x), ncol(x)), 
-                                         eta = seq(.1, .9, length = len), 
-                                         kappa = .5)
-                    } else {
-                      out <- data.frame(kappa = runif(len, min = 0, max = .5),
-                                        eta  = runif(len, min = 0, max = 1),
-                                        K = sample(1:min(nrow(x), ncol(x)), size = len, replace = TRUE))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    param$K <- min(param$K, length(y))
-                    if(is.factor(y)) {
-                      caret:::splsda(x, y, K = param$K, eta = param$eta,
-                                     kappa = param$kappa, ...)
-                    } else {
-                      spls::spls(x, y, K = param$K, eta = param$eta,
-                                 kappa = param$kappa, ...)
-                    }          
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(length(modelFit$obsLevels) < 2) {
-                      spls::predict.spls(modelFit, newdata)
-                    } else {
-                      as.character(caret:::predict.splsda(modelFit, newdata, type = "class"))
-                    }
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    caret:::predict.splsda(modelFit, newdata, type = "prob")
-                  },
-                  predictors = function(x, ...) colnames(x$x)[x$A],
-                  tags = c("Partial Least Squares", "Feature Extraction", "Linear Classifier", "Linear Regression",
-                           "L1 Regularization"),
-                  levels = function(x) x$obsLevels,
-                  sort = function(x) x[order(-x$eta, x$K),])
+modelInfo <- list(
+  label = "Sparse Partial Least Squares",
+  library = "spls",
+  type = c('Regression', 'Classification'),
+  parameters = data.frame(
+    parameter = c('K', 'eta', 'kappa'),
+    class = c('numeric', 'numeric', 'numeric'),
+    label = c('#Components', 'Threshold', 'Kappa')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        K = 1:min(nrow(x), ncol(x)),
+        eta = seq(.1, .9, length = len),
+        kappa = .5
+      )
+    } else {
+      out <- data.frame(
+        kappa = runif(len, min = 0, max = .5),
+        eta = runif(len, min = 0, max = 1),
+        K = sample(1:min(nrow(x), ncol(x)), size = len, replace = TRUE)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    param$K <- min(param$K, length(y))
+    if (is.factor(y)) {
+      caret:::splsda(
+        x,
+        y,
+        K = param$K,
+        eta = param$eta,
+        kappa = param$kappa,
+        ...
+      )
+    } else {
+      spls::spls(x, y, K = param$K, eta = param$eta, kappa = param$kappa, ...)
+    }
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (length(modelFit$obsLevels) < 2) {
+      spls::predict.spls(modelFit, newdata)
+    } else {
+      as.character(caret:::predict.splsda(modelFit, newdata, type = "class"))
+    }
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    caret:::predict.splsda(modelFit, newdata, type = "prob")
+  },
+  predictors = function(x, ...) colnames(x$x)[x$A],
+  tags = c(
+    "Partial Least Squares",
+    "Feature Extraction",
+    "Linear Classifier",
+    "Linear Regression",
+    "L1 Regularization"
+  ),
+  levels = function(x) x$obsLevels,
+  sort = function(x) x[order(-x$eta, x$K), ]
+)

--- a/inst/model_sources/files/stepLDA.R
+++ b/inst/model_sources/files/stepLDA.R
@@ -1,41 +1,58 @@
-modelInfo <- list(label = "Linear Discriminant Analysis with Stepwise Feature Selection",
-                  library = c("klaR", "MASS"),
-                  loop = NULL,
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = c("maxvar", "direction"),
-                                          class = c("numeric", "character"),
-                                          label = c('Maximum #Variables', 'Search Direction')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- data.frame(maxvar = Inf, direction = "both")
-                    } else {
-                      out <- data.frame(direction  = sample(c("both", "forward", "backward"), size = len, replace = TRUE),
-                                        maxvar = sample(1:ncol(x), size = len, replace = TRUE))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...){
-                    out <- klaR::stepclass(x, y,
-                                           method = "lda",
-                                           maxvar = param$maxvar,
-                                           direction = as.character(param$direction),
-                                           ...)
-                    out$fit <- MASS::lda(x[, out$model$name, drop = FALSE], y, ...)
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    code <- getModelInfo("lda", regex = FALSE)[[1]]$predictors
-                    predict(modelFit$fit, newdata[,  code(modelFit$fit), drop = FALSE])$class
-                    },
-                  prob = function(modelFit, newdata, submodels = NULL){
-                    code <- getModelInfo("lda", regex = FALSE)[[1]]$predictors
-                    predict(modelFit$fit, newdata[, code(modelFit$fit), drop = FALSE])$posterior
-                  },
-                  predictors = function(x, ...) {
-                    form <- x$formula
-                    form[[2]] <- NULL
-                    all.vars(form)
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("Discriminant Analysis", "Feature Selection Wrapper", "Linear Classifier"),
-                  sort = function(x) x)
+modelInfo <- list(
+  label = "Linear Discriminant Analysis with Stepwise Feature Selection",
+  library = c("klaR", "MASS"),
+  loop = NULL,
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = c("maxvar", "direction"),
+    class = c("numeric", "character"),
+    label = c('Maximum #Variables', 'Search Direction')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(maxvar = Inf, direction = "both")
+    } else {
+      out <- data.frame(
+        direction = sample(
+          c("both", "forward", "backward"),
+          size = len,
+          replace = TRUE
+        ),
+        maxvar = sample(1:ncol(x), size = len, replace = TRUE)
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    out <- klaR::stepclass(
+      x,
+      y,
+      method = "lda",
+      maxvar = param$maxvar,
+      direction = as.character(param$direction),
+      ...
+    )
+    out$fit <- MASS::lda(x[, out$model$name, drop = FALSE], y, ...)
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    code <- getModelInfo("lda", regex = FALSE)[[1]]$predictors
+    predict(modelFit$fit, newdata[, code(modelFit$fit), drop = FALSE])$class
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    code <- getModelInfo("lda", regex = FALSE)[[1]]$predictors
+    predict(modelFit$fit, newdata[, code(modelFit$fit), drop = FALSE])$posterior
+  },
+  predictors = function(x, ...) {
+    form <- x$formula
+    form[[2]] <- NULL
+    all.vars(form)
+  },
+  levels = function(x) x$obsLevels,
+  tags = c(
+    "Discriminant Analysis",
+    "Feature Selection Wrapper",
+    "Linear Classifier"
+  ),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/stepQDA.R
+++ b/inst/model_sources/files/stepQDA.R
@@ -1,34 +1,46 @@
-modelInfo <- list(label = "Quadratic Discriminant Analysis with Stepwise Feature Selection",
-                  library = c("klaR", "MASS"),
-                  loop = NULL,
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = c("maxvar", "direction"),
-                                          class = c("numeric", "character"),
-                                          label = c('Maximum #Variables', 'Search Direction')),
-                  grid = function(x, y, len = NULL, search = "grid") 
-                    data.frame(maxvar = Inf, direction = "both"),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...){
-                    out <- klaR::stepclass(x, y,
-                                           method = "qda",
-                                           maxvar = param$maxvar,
-                                           direction = as.character(param$direction),
-                                           ...)
-                    out$fit <- MASS::qda(x[, out$model$name, drop = FALSE], y, ...)
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    code <- getModelInfo("qda", regex = FALSE)[[1]]$predictors
-                    predict(modelFit$fit, newdata[,  code(modelFit$fit), drop = FALSE])$class
-                    },
-                  prob = function(modelFit, newdata, submodels = NULL){
-                    code <- getModelInfo("qda", regex = FALSE)[[1]]$predictors
-                    predict(modelFit$fit, newdata[, code(modelFit$fit), drop = FALSE])$posterior
-                  },
-                  predictors = function(x, ...) {
-                    form <- x$formula
-                    form[[2]] <- NULL
-                    all.vars(form)
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("Discriminant Analysis", "Feature Selection Wrapper", "Polynomial Model"),
-                  sort = function(x) x)
+modelInfo <- list(
+  label = "Quadratic Discriminant Analysis with Stepwise Feature Selection",
+  library = c("klaR", "MASS"),
+  loop = NULL,
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = c("maxvar", "direction"),
+    class = c("numeric", "character"),
+    label = c('Maximum #Variables', 'Search Direction')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(maxvar = Inf, direction = "both")
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    out <- klaR::stepclass(
+      x,
+      y,
+      method = "qda",
+      maxvar = param$maxvar,
+      direction = as.character(param$direction),
+      ...
+    )
+    out$fit <- MASS::qda(x[, out$model$name, drop = FALSE], y, ...)
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    code <- getModelInfo("qda", regex = FALSE)[[1]]$predictors
+    predict(modelFit$fit, newdata[, code(modelFit$fit), drop = FALSE])$class
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    code <- getModelInfo("qda", regex = FALSE)[[1]]$predictors
+    predict(modelFit$fit, newdata[, code(modelFit$fit), drop = FALSE])$posterior
+  },
+  predictors = function(x, ...) {
+    form <- x$formula
+    form[[2]] <- NULL
+    all.vars(form)
+  },
+  levels = function(x) x$obsLevels,
+  tags = c(
+    "Discriminant Analysis",
+    "Feature Selection Wrapper",
+    "Polynomial Model"
+  ),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/superpc.R
+++ b/inst/model_sources/files/superpc.R
@@ -1,61 +1,78 @@
-modelInfo <- list(label = "Supervised Principal Component Analysis",
-                  library = "superpc",
-                  type = c('Regression'),
-                  parameters = data.frame(parameter = c('threshold', 'n.components'),
-                                          class = c('numeric', 'numeric'),
-                                          label = c('Threshold', '#Components')),
-                  grid = function(x, y, len = NULL, search = "grid"){
-                    if(search == "grid") {
-                      out <- expand.grid(n.components = 1:3, threshold = seq(.1, .9, length = len))
-                    } else {
-                      out <- data.frame(threshold  = runif(len, min = 0, max = 1),
-                                        n.components = sample(1:3, size = len, replace = TRUE))
-                    }
-                    out
-                  }, 
-                  loop = function(grid) {
-                    ## The prediction function can make predictions for multiple values
-                    ## of `n.components` and `threshold`. We will loop over the largest
-                    ## values of those parameters and add the remainder to the submodel
-                    
-                    ordering <- order(-grid$n.components, -grid$threshold)
-                    loop <- grid[ordering[1],, drop = FALSE]
-                    submodels <- list(grid[ordering[-1],, drop = FALSE])
-                    list(loop = loop, submodels = submodels)           
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    out <- superpc::superpc.train(list(x = t(x), y = y),
-                                                  type = "regression",
-                                                   ...)
-                    ## prediction will need to source data, so save that too
-                    out$data <- list(x = t(x), y = y)
-                    out$tuneValue <- list(n.components = param$n.components, 
-                                          threshold = param$threshold)
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- superpc::superpc.predict(modelFit,
-                                           modelFit$data,
-                                           newdata = list(x=t(newdata)),
-                                           n.components = modelFit$tuneValue$n.components,
-                                           threshold = modelFit$tuneValue$threshold)$v.pred.1df
-                    
-                    if(!is.null(submodels)) {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
-                      
-                      for(j in seq(along = submodels$threshold)) {
-                        tmp[[j+1]] <- superpc::superpc.predict(modelFit,
-                                                      modelFit$data,
-                                                      newdata = list(x=t(newdata)),
-                                                      threshold = submodels$threshold[j],
-                                                      n.components = submodels$n.components[j])$v.pred.1df
-                      }
-                      out <- tmp
-                    }
-                    
-                    out
-                  },
-                  prob = NULL,
-                  tags = c("Feature Extraction", "Linear Regression"),
-                  sort = function(x) x[order(x$threshold, x$n.components),])
+modelInfo <- list(
+  label = "Supervised Principal Component Analysis",
+  library = "superpc",
+  type = c('Regression'),
+  parameters = data.frame(
+    parameter = c('threshold', 'n.components'),
+    class = c('numeric', 'numeric'),
+    label = c('Threshold', '#Components')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        n.components = 1:3,
+        threshold = seq(.1, .9, length = len)
+      )
+    } else {
+      out <- data.frame(
+        threshold = runif(len, min = 0, max = 1),
+        n.components = sample(1:3, size = len, replace = TRUE)
+      )
+    }
+    out
+  },
+  loop = function(grid) {
+    ## The prediction function can make predictions for multiple values
+    ## of `n.components` and `threshold`. We will loop over the largest
+    ## values of those parameters and add the remainder to the submodel
+
+    ordering <- order(-grid$n.components, -grid$threshold)
+    loop <- grid[ordering[1], , drop = FALSE]
+    submodels <- list(grid[ordering[-1], , drop = FALSE])
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    out <- superpc::superpc.train(
+      list(x = t(x), y = y),
+      type = "regression",
+      ...
+    )
+    ## prediction will need to source data, so save that too
+    out$data <- list(x = t(x), y = y)
+    out$tuneValue <- list(
+      n.components = param$n.components,
+      threshold = param$threshold
+    )
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- superpc::superpc.predict(
+      modelFit,
+      modelFit$data,
+      newdata = list(x = t(newdata)),
+      n.components = modelFit$tuneValue$n.components,
+      threshold = modelFit$tuneValue$threshold
+    )$v.pred.1df
+
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
+
+      for (j in seq(along = submodels$threshold)) {
+        tmp[[j + 1]] <- superpc::superpc.predict(
+          modelFit,
+          modelFit$data,
+          newdata = list(x = t(newdata)),
+          threshold = submodels$threshold[j],
+          n.components = submodels$n.components[j]
+        )$v.pred.1df
+      }
+      out <- tmp
+    }
+
+    out
+  },
+  prob = NULL,
+  tags = c("Feature Extraction", "Linear Regression"),
+  sort = function(x) x[order(x$threshold, x$n.components), ]
+)

--- a/inst/model_sources/files/svmBoundrangeString.R
+++ b/inst/model_sources/files/svmBoundrangeString.R
@@ -1,98 +1,117 @@
-modelInfo <- list(label = "Support Vector Machines with Boundrange String Kernel",
-                  library = "kernlab",
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('length', 'C'),
-                                          class = c("numeric", "numeric"),
-                                          label = c('length', "Cost")),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(length = 2:(len+1),
-                                         C = 2 ^((1:len) - 3))
-                    } else {
-                      out <- data.frame(length = sample(1:20, size = len, replace = TRUE),
-                                        C = 2^runif(len, min = -5, max = 10))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    if(any(names(list(...)) == "prob.model") | is.numeric(y))
-                    {
-                      out <- kernlab::ksvm(x = x[,1], y = y,
-                                           kernel = "stringdot",
-                                           kpar = list(type = "boundrange",
-                                                       length = param$length),
-                                           C = param$C, ...)
-                    } else {
-                      out <- kernlab::ksvm(x = x[,1], y = y,
-                                           kernel = "stringdot",
-                                           kpar = list(type = "boundrange",
-                                                       length = param$length),
-                                           C = param$C,
-                                           prob.model = classProbs,
-                                           ...)
-                    }
-                    
-                    out            
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    svmPred <- function(obj, x)
-                    {
-                      hasPM <- !is.null(unlist(obj@prob.model))
-                      if(hasPM) {
-                        pred <- kernlab::lev(obj)[apply(kernlab::predict(obj, x, type = "probabilities"),
-                                               1, which.max)]
-                      } else pred <- kernlab::predict(obj, x)
-                      pred
-                    }
-                    out <- try(svmPred(modelFit, newdata[,1]), silent = TRUE)
-                    if(is.character(kernlab::lev(modelFit)))
-                    {
-                      if(class(out)[1] == "try-error")
-                      {
-                        warning("kernlab class prediction calculations failed; returning NAs")
-                        out <- rep("", nrow(newdata))
-                        out[seq(along = out)] <- NA
-                      }
-                    } else {
-                      if(class(out)[1] == "try-error")
-                      {
-                        warning("kernlab prediction calculations failed; returning NAs")
-                        out <- rep(NA, nrow(newdata))
-                      } 
-                    }
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- try(kernlab::predict(modelFit, newdata[,1], type="probabilities"),
-                               silent = TRUE)
-                    if(class(out)[1] != "try-error")
-                    {
-                      ## There are times when the SVM probability model will
-                      ## produce negative class probabilities, so we
-                      ## induce vlaues between 0 and 1
-                      if(any(out < 0))
-                      {
-                        out[out < 0] <- 0
-                        out <- t(apply(out, 1, function(x) x/sum(x)))
-                      }
-                      out <- out[, kernlab::lev(modelFit), drop = FALSE]
-                    } else {
-                      warning("kernlab class probability calculations failed; returning NAs")
-                      out <- matrix(NA, nrow(newdata) * length(kernlab::lev(modelFit)), ncol = length(kernlab::lev(modelFit)))
-                      colnames(out) <- kernlab::lev(modelFit)
-                    }
-                    out
-                  },
-                  predictors = function(x, ...){
-                    iNA
-                  },
-                  tags = c("Kernel Method", "Support Vector Machines", "String Kernel",
-                           "Robust Methods", "Text Mining"),
-                  levels = function(x) kernlab::lev(x),
-                  sort = function(x) {
-                    # If the cost is high, the decision boundary will work hard to
-                    # adapt. Also, if C is fixed, smaller values of sigma yeild more
-                    # complex boundaries
-                    x[order(x$C, -x$length),]
-                  })
+modelInfo <- list(
+  label = "Support Vector Machines with Boundrange String Kernel",
+  library = "kernlab",
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c('length', 'C'),
+    class = c("numeric", "numeric"),
+    label = c('length', "Cost")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(length = 2:(len + 1), C = 2^((1:len) - 3))
+    } else {
+      out <- data.frame(
+        length = sample(1:20, size = len, replace = TRUE),
+        C = 2^runif(len, min = -5, max = 10)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (any(names(list(...)) == "prob.model") | is.numeric(y)) {
+      out <- kernlab::ksvm(
+        x = x[, 1],
+        y = y,
+        kernel = "stringdot",
+        kpar = list(type = "boundrange", length = param$length),
+        C = param$C,
+        ...
+      )
+    } else {
+      out <- kernlab::ksvm(
+        x = x[, 1],
+        y = y,
+        kernel = "stringdot",
+        kpar = list(type = "boundrange", length = param$length),
+        C = param$C,
+        prob.model = classProbs,
+        ...
+      )
+    }
+
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    svmPred <- function(obj, x) {
+      hasPM <- !is.null(unlist(obj@prob.model))
+      if (hasPM) {
+        pred <- kernlab::lev(obj)[apply(
+          kernlab::predict(obj, x, type = "probabilities"),
+          1,
+          which.max
+        )]
+      } else {
+        pred <- kernlab::predict(obj, x)
+      }
+      pred
+    }
+    out <- try(svmPred(modelFit, newdata[, 1]), silent = TRUE)
+    if (is.character(kernlab::lev(modelFit))) {
+      if (class(out)[1] == "try-error") {
+        warning("kernlab class prediction calculations failed; returning NAs")
+        out <- rep("", nrow(newdata))
+        out[seq(along = out)] <- NA
+      }
+    } else {
+      if (class(out)[1] == "try-error") {
+        warning("kernlab prediction calculations failed; returning NAs")
+        out <- rep(NA, nrow(newdata))
+      }
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- try(
+      kernlab::predict(modelFit, newdata[, 1], type = "probabilities"),
+      silent = TRUE
+    )
+    if (class(out)[1] != "try-error") {
+      ## There are times when the SVM probability model will
+      ## produce negative class probabilities, so we
+      ## induce vlaues between 0 and 1
+      if (any(out < 0)) {
+        out[out < 0] <- 0
+        out <- t(apply(out, 1, function(x) x / sum(x)))
+      }
+      out <- out[, kernlab::lev(modelFit), drop = FALSE]
+    } else {
+      warning("kernlab class probability calculations failed; returning NAs")
+      out <- matrix(
+        NA,
+        nrow(newdata) * length(kernlab::lev(modelFit)),
+        ncol = length(kernlab::lev(modelFit))
+      )
+      colnames(out) <- kernlab::lev(modelFit)
+    }
+    out
+  },
+  predictors = function(x, ...) {
+    iNA
+  },
+  tags = c(
+    "Kernel Method",
+    "Support Vector Machines",
+    "String Kernel",
+    "Robust Methods",
+    "Text Mining"
+  ),
+  levels = function(x) kernlab::lev(x),
+  sort = function(x) {
+    # If the cost is high, the decision boundary will work hard to
+    # adapt. Also, if C is fixed, smaller values of sigma yeild more
+    # complex boundaries
+    x[order(x$C, -x$length), ]
+  }
+)

--- a/inst/model_sources/files/svmExpoString.R
+++ b/inst/model_sources/files/svmExpoString.R
@@ -1,98 +1,117 @@
-modelInfo <- list(label = "Support Vector Machines with Exponential String Kernel",
-                  library = "kernlab",
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('lambda', 'C'),
-                                          class = c("numeric", "numeric"),
-                                          label = c('lambda', "Cost")),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(lambda = .25 + 2 ^((1:len) - 1),
-                                         C = 2 ^((1:len) - 3))
-                    } else {
-                      out <- data.frame(lambda = 2^runif(len, min = -5, max = 6),
-                                        C = 2^runif(len, min = -5, max = 10))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    if(any(names(list(...)) == "prob.model") | is.numeric(y))
-                    {
-                      out <- kernlab::ksvm(x = x[,1], y = y,
-                                           kernel = "stringdot",
-                                           kpar = list(type = "exponential", 
-                                                       lambda = param$lambda),
-                                           C = param$C, ...)
-                    } else {
-                      out <- kernlab::ksvm(x = x[,1], y = y,
-                                           kernel = "stringdot",
-                                           kpar = list(type = "exponential", 
-                                                       lambda = param$lambda),
-                                           C = param$C,
-                                           prob.model = classProbs,
-                                           ...)
-                    }
-                    
-                    out            
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    svmPred <- function(obj, x)
-                    {
-                      hasPM <- !is.null(unlist(obj@prob.model))
-                      if(hasPM) {
-                        pred <- lev(obj)[apply(kernlab::predict(obj, x, type = "probabilities"), 
-                                               1, which.max)]
-                      } else pred <- kernlab::predict(obj, x)
-                      pred
-                    }
-                    out <- try(svmPred(modelFit, newdata[,1]), silent = TRUE)
-                    if(is.character(kernlab::lev(modelFit)))
-                    {
-                      if(class(out)[1] == "try-error")
-                      {
-                        warning("kernlab class prediction calculations failed; returning NAs")
-                        out <- rep("", nrow(newdata))
-                        out[seq(along = out)] <- NA
-                      }
-                    } else {
-                      if(class(out)[1] == "try-error")
-                      {
-                        warning("kernlab prediction calculations failed; returning NAs")
-                        out <- rep(NA, nrow(newdata))
-                      } 
-                    }
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- try(kernlab::predict(modelFit, newdata[,1], type="probabilities"),
-                               silent = TRUE)
-                    if(class(out)[1] != "try-error")
-                    {
-                      ## There are times when the SVM probability model will
-                      ## produce negative class probabilities, so we
-                      ## induce vlaues between 0 and 1
-                      if(any(out < 0))
-                      {
-                        out[out < 0] <- 0
-                        out <- t(apply(out, 1, function(x) x/sum(x)))
-                      }
-                      out <- out[, kernlab::lev(modelFit), drop = FALSE]
-                    } else {
-                      warning("kernlab class probability calculations failed; returning NAs")
-                      out <- matrix(NA, nrow(newdata) * length(kernlab::lev(modelFit)), ncol = length(kernlab::lev(modelFit)))
-                      colnames(out) <- kernlab::lev(modelFit)
-                    }
-                    out
-                  },
-                  predictors = function(x, ...){
-                    iNA
-                  },
-                  tags = c("Kernel Method", "Support Vector Machines", "String Kernel",
-                           "Robust Methods", "Text Mining"),
-                  levels = function(x) kernlab::lev(x),
-                  sort = function(x) {
-                    # If the cost is high, the decision boundary will work hard to
-                    # adapt. Also, if C is fixed, smaller values of sigma yeild more
-                    # complex boundaries
-                    x[order(x$C, -x$lambda),]
-                  })
+modelInfo <- list(
+  label = "Support Vector Machines with Exponential String Kernel",
+  library = "kernlab",
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c('lambda', 'C'),
+    class = c("numeric", "numeric"),
+    label = c('lambda', "Cost")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(lambda = .25 + 2^((1:len) - 1), C = 2^((1:len) - 3))
+    } else {
+      out <- data.frame(
+        lambda = 2^runif(len, min = -5, max = 6),
+        C = 2^runif(len, min = -5, max = 10)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (any(names(list(...)) == "prob.model") | is.numeric(y)) {
+      out <- kernlab::ksvm(
+        x = x[, 1],
+        y = y,
+        kernel = "stringdot",
+        kpar = list(type = "exponential", lambda = param$lambda),
+        C = param$C,
+        ...
+      )
+    } else {
+      out <- kernlab::ksvm(
+        x = x[, 1],
+        y = y,
+        kernel = "stringdot",
+        kpar = list(type = "exponential", lambda = param$lambda),
+        C = param$C,
+        prob.model = classProbs,
+        ...
+      )
+    }
+
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    svmPred <- function(obj, x) {
+      hasPM <- !is.null(unlist(obj@prob.model))
+      if (hasPM) {
+        pred <- lev(obj)[apply(
+          kernlab::predict(obj, x, type = "probabilities"),
+          1,
+          which.max
+        )]
+      } else {
+        pred <- kernlab::predict(obj, x)
+      }
+      pred
+    }
+    out <- try(svmPred(modelFit, newdata[, 1]), silent = TRUE)
+    if (is.character(kernlab::lev(modelFit))) {
+      if (class(out)[1] == "try-error") {
+        warning("kernlab class prediction calculations failed; returning NAs")
+        out <- rep("", nrow(newdata))
+        out[seq(along = out)] <- NA
+      }
+    } else {
+      if (class(out)[1] == "try-error") {
+        warning("kernlab prediction calculations failed; returning NAs")
+        out <- rep(NA, nrow(newdata))
+      }
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- try(
+      kernlab::predict(modelFit, newdata[, 1], type = "probabilities"),
+      silent = TRUE
+    )
+    if (class(out)[1] != "try-error") {
+      ## There are times when the SVM probability model will
+      ## produce negative class probabilities, so we
+      ## induce vlaues between 0 and 1
+      if (any(out < 0)) {
+        out[out < 0] <- 0
+        out <- t(apply(out, 1, function(x) x / sum(x)))
+      }
+      out <- out[, kernlab::lev(modelFit), drop = FALSE]
+    } else {
+      warning("kernlab class probability calculations failed; returning NAs")
+      out <- matrix(
+        NA,
+        nrow(newdata) * length(kernlab::lev(modelFit)),
+        ncol = length(kernlab::lev(modelFit))
+      )
+      colnames(out) <- kernlab::lev(modelFit)
+    }
+    out
+  },
+  predictors = function(x, ...) {
+    iNA
+  },
+  tags = c(
+    "Kernel Method",
+    "Support Vector Machines",
+    "String Kernel",
+    "Robust Methods",
+    "Text Mining"
+  ),
+  levels = function(x) kernlab::lev(x),
+  sort = function(x) {
+    # If the cost is high, the decision boundary will work hard to
+    # adapt. Also, if C is fixed, smaller values of sigma yeild more
+    # complex boundaries
+    x[order(x$C, -x$lambda), ]
+  }
+)

--- a/inst/model_sources/files/svmLinear.R
+++ b/inst/model_sources/files/svmLinear.R
@@ -1,94 +1,125 @@
-modelInfo <- list(label = "Support Vector Machines with Linear Kernel",
-                  library = "kernlab",
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('C'),
-                                          class = c("numeric"),
-                                          label = c("Cost")),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- data.frame(C = 1)
-                    } else {
-                      out <- data.frame(C = 2^runif(len, min = -5, max = 10))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    if(any(names(list(...)) == "prob.model") | is.numeric(y)) {
-                      out <- kernlab::ksvm(x = as.matrix(x), y = y,
-                                          kernel = kernlab::vanilladot(),
-                                          C = param$C, ...)
-                    } else {
-                      out <- kernlab::ksvm(x = as.matrix(x), y = y,
-                                           kernel = kernlab::vanilladot(),
-                                           C = param$C,
-                                           prob.model = classProbs,
-                                           ...)
-                    }
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    svmPred <- function(obj, x) {
-                      hasPM <- !is.null(unlist(obj@prob.model))
-                      if(hasPM) {
-                        pred <- kernlab::lev(obj)[apply(kernlab::predict(obj, x, type = "probabilities"),
-                                               1, which.max)]
-                      } else pred <- kernlab::predict(obj, x)
-                      pred
-                    }
-                    out <- try(svmPred(modelFit, newdata), silent = TRUE)
-                    if(is.character(kernlab::lev(modelFit))) {
-                      if(class(out)[1] == "try-error")
-                      {
-                        warning("kernlab class prediction calculations failed; returning NAs")
-                        out <- rep("", nrow(newdata))
-                        out[seq(along = out)] <- NA
-                      }
-                    } else {
-                      if(class(out)[1] == "try-error") {
-                        warning("kernlab prediction calculations failed; returning NAs")
-                        out <- rep(NA, nrow(newdata))
-                      }
-                    }
-                    if(is.matrix(out)) out <- out[,1]
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- try(kernlab::predict(modelFit, newdata, type="probabilities"),
-                               silent = TRUE)
-                    if(class(out)[1] != "try-error") {
-                      ## There are times when the SVM probability model will
-                      ## produce negative class probabilities, so we
-                      ## induce vlaues between 0 and 1
-                      if(any(out < 0))
-                      {
-                        out[out < 0] <- 0
-                        out <- t(apply(out, 1, function(x) x/sum(x)))
-                      }
-                      out <- out[, kernlab::lev(modelFit), drop = FALSE]
-                    } else {
-                      warning("kernlab class probability calculations failed; returning NAs")
-                      out <- matrix(NA, nrow(newdata) * length(kernlab::lev(modelFit)), ncol = length(kernlab::lev(modelFit)))
-                      colnames(out) <- kernlab::lev(modelFit)
-                    }
-                    out
-                  },
-                  predictors = function(x, ...){
-                    if(hasTerms(x) & !is.null(x@terms)) {
-                      out <- predictors.terms(x@terms)
-                    } else {
-                      out <- colnames(attr(x, "xmatrix"))
-                    }
-                    if(is.null(out)) out <- names(attr(x, "scaling")$x.scale$`scaled:center`)
-                    if(is.null(out)) out <-NA
-                    out
-                  },
-                  tags = c("Kernel Method", "Support Vector Machines","Linear Regression", "Linear Classifier",
-                           "Robust Methods"),
-                  levels = function(x) kernlab::lev(x),
-                  sort = function(x) {
-                    # If the cost is high, the decision boundary will work hard to
-                    # adapt. Also, if C is fixed, smaller values of sigma yeild more
-                    # complex boundaries
-                    x[order(x$C),]
-                  })
+modelInfo <- list(
+  label = "Support Vector Machines with Linear Kernel",
+  library = "kernlab",
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c('C'),
+    class = c("numeric"),
+    label = c("Cost")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(C = 1)
+    } else {
+      out <- data.frame(C = 2^runif(len, min = -5, max = 10))
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (any(names(list(...)) == "prob.model") | is.numeric(y)) {
+      out <- kernlab::ksvm(
+        x = as.matrix(x),
+        y = y,
+        kernel = kernlab::vanilladot(),
+        C = param$C,
+        ...
+      )
+    } else {
+      out <- kernlab::ksvm(
+        x = as.matrix(x),
+        y = y,
+        kernel = kernlab::vanilladot(),
+        C = param$C,
+        prob.model = classProbs,
+        ...
+      )
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    svmPred <- function(obj, x) {
+      hasPM <- !is.null(unlist(obj@prob.model))
+      if (hasPM) {
+        pred <- kernlab::lev(obj)[apply(
+          kernlab::predict(obj, x, type = "probabilities"),
+          1,
+          which.max
+        )]
+      } else {
+        pred <- kernlab::predict(obj, x)
+      }
+      pred
+    }
+    out <- try(svmPred(modelFit, newdata), silent = TRUE)
+    if (is.character(kernlab::lev(modelFit))) {
+      if (class(out)[1] == "try-error") {
+        warning("kernlab class prediction calculations failed; returning NAs")
+        out <- rep("", nrow(newdata))
+        out[seq(along = out)] <- NA
+      }
+    } else {
+      if (class(out)[1] == "try-error") {
+        warning("kernlab prediction calculations failed; returning NAs")
+        out <- rep(NA, nrow(newdata))
+      }
+    }
+    if (is.matrix(out)) {
+      out <- out[, 1]
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- try(
+      kernlab::predict(modelFit, newdata, type = "probabilities"),
+      silent = TRUE
+    )
+    if (class(out)[1] != "try-error") {
+      ## There are times when the SVM probability model will
+      ## produce negative class probabilities, so we
+      ## induce vlaues between 0 and 1
+      if (any(out < 0)) {
+        out[out < 0] <- 0
+        out <- t(apply(out, 1, function(x) x / sum(x)))
+      }
+      out <- out[, kernlab::lev(modelFit), drop = FALSE]
+    } else {
+      warning("kernlab class probability calculations failed; returning NAs")
+      out <- matrix(
+        NA,
+        nrow(newdata) * length(kernlab::lev(modelFit)),
+        ncol = length(kernlab::lev(modelFit))
+      )
+      colnames(out) <- kernlab::lev(modelFit)
+    }
+    out
+  },
+  predictors = function(x, ...) {
+    if (hasTerms(x) & !is.null(x@terms)) {
+      out <- predictors.terms(x@terms)
+    } else {
+      out <- colnames(attr(x, "xmatrix"))
+    }
+    if (is.null(out)) {
+      out <- names(attr(x, "scaling")$x.scale$`scaled:center`)
+    }
+    if (is.null(out)) {
+      out <- NA
+    }
+    out
+  },
+  tags = c(
+    "Kernel Method",
+    "Support Vector Machines",
+    "Linear Regression",
+    "Linear Classifier",
+    "Robust Methods"
+  ),
+  levels = function(x) kernlab::lev(x),
+  sort = function(x) {
+    # If the cost is high, the decision boundary will work hard to
+    # adapt. Also, if C is fixed, smaller values of sigma yeild more
+    # complex boundaries
+    x[order(x$C), ]
+  }
+)

--- a/inst/model_sources/files/svmLinear2.R
+++ b/inst/model_sources/files/svmLinear2.R
@@ -46,7 +46,11 @@ modelInfo <- list(
     attr(out, "probabilities")
   },
   predictors = function(x, ...) {
-    out <- if (!is.null(x$terms)) predictors.terms(x$terms) else x$xNames
+    if (!is.null(x$terms)) {
+      out <- predictors.terms(x$terms)
+    } else {
+      out <- x$xNames
+    }
     if (is.null(out)) {
       out <- names(attr(x, "scaling")$x.scale$`scaled:center`)
     }

--- a/inst/model_sources/files/svmLinear2.R
+++ b/inst/model_sources/files/svmLinear2.R
@@ -1,54 +1,72 @@
-modelInfo <- list(label = "Support Vector Machines with Linear Kernel",
-                  library = "e1071",
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('cost'),
-                                          class = c("numeric"),
-                                          label = c("Cost")),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(cost = 2 ^((1:len) - 3))
-                    } else {
-                      out <- data.frame(cost = 2^runif(len, min = -5, max = 10))
-                    }
-                    out
-                  }, 
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    if(any(names(list(...)) == "probability") | is.numeric(y))
-                    {
-                      out <- e1071::svm(x = as.matrix(x), y = y,
-                                        kernel = "linear",
-                                        cost = param$cost,
-                                        ...)
-                    } else {
-                      out <- e1071::svm(x = as.matrix(x), y = y,
-                                        kernel = "linear",
-                                        cost = param$cost,
-                                        probability = classProbs,
-                                        ...)
-                    }
+modelInfo <- list(
+  label = "Support Vector Machines with Linear Kernel",
+  library = "e1071",
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c('cost'),
+    class = c("numeric"),
+    label = c("Cost")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(cost = 2^((1:len) - 3))
+    } else {
+      out <- data.frame(cost = 2^runif(len, min = -5, max = 10))
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (any(names(list(...)) == "probability") | is.numeric(y)) {
+      out <- e1071::svm(
+        x = as.matrix(x),
+        y = y,
+        kernel = "linear",
+        cost = param$cost,
+        ...
+      )
+    } else {
+      out <- e1071::svm(
+        x = as.matrix(x),
+        y = y,
+        kernel = "linear",
+        cost = param$cost,
+        probability = classProbs,
+        ...
+      )
+    }
 
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    predict(modelFit, newdata)
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata, probability = TRUE)
-                    attr(out, "probabilities")
-                  },
-                  predictors = function(x, ...){
-                    out <- if(!is.null(x$terms)) predictors.terms(x$terms) else x$xNames
-                    if(is.null(out)) out <- names(attr(x, "scaling")$x.scale$`scaled:center`)
-                    if(is.null(out)) out <-NA
-                    out
-                  },
-                  tags = c("Kernel Method", "Support Vector Machines","Linear Regression", "Linear Classifier",
-                           "Robust Methods"),
-                  levels = function(x) x$levels,
-                  sort = function(x) {
-                    # If the cost is high, the decision boundary will work hard to
-                    # adapt. Also, if C is fixed, smaller values of sigma yeild more
-                    # complex boundaries
-                    x[order(x$cost),]
-                  })
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata, probability = TRUE)
+    attr(out, "probabilities")
+  },
+  predictors = function(x, ...) {
+    out <- if (!is.null(x$terms)) predictors.terms(x$terms) else x$xNames
+    if (is.null(out)) {
+      out <- names(attr(x, "scaling")$x.scale$`scaled:center`)
+    }
+    if (is.null(out)) {
+      out <- NA
+    }
+    out
+  },
+  tags = c(
+    "Kernel Method",
+    "Support Vector Machines",
+    "Linear Regression",
+    "Linear Classifier",
+    "Robust Methods"
+  ),
+  levels = function(x) x$levels,
+  sort = function(x) {
+    # If the cost is high, the decision boundary will work hard to
+    # adapt. Also, if C is fixed, smaller values of sigma yeild more
+    # complex boundaries
+    x[order(x$cost), ]
+  }
+)

--- a/inst/model_sources/files/svmLinear3.R
+++ b/inst/model_sources/files/svmLinear3.R
@@ -28,9 +28,17 @@ modelInfo <- list(
     # 13 - L2-regularized L1-loss support vector regression (dual)
 
     if (param$Loss == "L2") {
-      model_type <- if (is.factor(y)) 2 else 12
+      if (is.factor(y)) {
+        model_type <- 2
+      } else {
+        model_type <- 12
+      }
     } else {
-      model_type <- if (is.factor(y)) 3 else 13
+      if (is.factor(y)) {
+        model_type <- 3
+      } else {
+        model_type <- 13
+      }
     }
 
     out <- LiblineaR::LiblineaR(

--- a/inst/model_sources/files/svmLinear3.R
+++ b/inst/model_sources/files/svmLinear3.R
@@ -1,50 +1,65 @@
-modelInfo <- list(label = "L2 Regularized Support Vector Machine (dual) with Linear Kernel",
-                  library = "LiblineaR",
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('cost', "Loss"),
-                                          class = c("numeric", "character"),
-                                          label = c("Cost", "Loss Function")),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(cost = 2 ^((1:len) - 3),
-                                         Loss = c("L1", "L2"))
-                    } else {
-                      out <- data.frame(cost = 2^runif(len, min = -10, max = 10),
-                                        Loss = sample(c("L1", "L2"), size = len, replace = TRUE))
-                    }
-                    out
-                  }, 
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    # LiblineaR lists the following models 
-                    # 
-                    #  2 - L2-regularized L2-loss support vector classification (primal) 
-                    #  3 - L2-regularized L1-loss support vector classification (dual) 
-                    # 12 - L2-regularized L2-loss support vector regression (dual)
-                    # 13 - L2-regularized L1-loss support vector regression (dual) 
-                    
-                    if(param$Loss == "L2") {
-                      model_type <- if(is.factor(y)) 2 else 12
-                    } else model_type <- if(is.factor(y)) 3 else 13
+modelInfo <- list(
+  label = "L2 Regularized Support Vector Machine (dual) with Linear Kernel",
+  library = "LiblineaR",
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c('cost', "Loss"),
+    class = c("numeric", "character"),
+    label = c("Cost", "Loss Function")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(cost = 2^((1:len) - 3), Loss = c("L1", "L2"))
+    } else {
+      out <- data.frame(
+        cost = 2^runif(len, min = -10, max = 10),
+        Loss = sample(c("L1", "L2"), size = len, replace = TRUE)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    # LiblineaR lists the following models
+    #
+    #  2 - L2-regularized L2-loss support vector classification (primal)
+    #  3 - L2-regularized L1-loss support vector classification (dual)
+    # 12 - L2-regularized L2-loss support vector regression (dual)
+    # 13 - L2-regularized L1-loss support vector regression (dual)
 
-                    out <- LiblineaR::LiblineaR(data = as.matrix(x), target = y,
-                                                cost = param$cost,
-                                                type = model_type,
-                                                ...)
+    if (param$Loss == "L2") {
+      model_type <- if (is.factor(y)) 2 else 12
+    } else {
+      model_type <- if (is.factor(y)) 3 else 13
+    }
 
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    predict(modelFit, newdata)$predictions
-                  },
-                  prob = NULL,
-                  predictors = function(x, ...) { 
-                    out <- colnames(x$W)
-                    out[out != "Bias"]
-                    },
-                  tags = c("Kernel Method", "Support Vector Machines","Linear Regression", "Linear Classifier",
-                           "Robust Methods"),
-                  levels = function(x) x$levels,
-                  sort = function(x) {
-                    x[order(x$cost),]
-                  })
+    out <- LiblineaR::LiblineaR(
+      data = as.matrix(x),
+      target = y,
+      cost = param$cost,
+      type = model_type,
+      ...
+    )
+
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)$predictions
+  },
+  prob = NULL,
+  predictors = function(x, ...) {
+    out <- colnames(x$W)
+    out[out != "Bias"]
+  },
+  tags = c(
+    "Kernel Method",
+    "Support Vector Machines",
+    "Linear Regression",
+    "Linear Classifier",
+    "Robust Methods"
+  ),
+  levels = function(x) x$levels,
+  sort = function(x) {
+    x[order(x$cost), ]
+  }
+)

--- a/inst/model_sources/files/svmLinearWeights.R
+++ b/inst/model_sources/files/svmLinearWeights.R
@@ -1,52 +1,72 @@
-modelInfo <- list(label = "Linear Support Vector Machines with Class Weights",
-                  library = "e1071",
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = c('cost','weight'),
-                                          class = c("numeric",'numeric'),
-                                          label = c("Cost",'Class Weight')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(cost = 2 ^((1:len) - 3), weight = 1:len)
-                    } else {
-                      out <- data.frame(cost = 2^runif(len, min = -5, max = 10),
-                                        weight = runif(len, min = 1, max = 25))
-                    }
-                    out
-                  }, 
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    if(length(levels(y)) != 2)
-                      stop("Currently implemented for 2-class problems")
-                    cwts <- c(1, param$weight)
-                    names(cwts) <- levels(y)
-                    out <- e1071::svm(x = as.matrix(x), y = y,
-                                      kernel = "linear",
-                                      cost = param$cost,
-                                      probability = classProbs,
-                                      class.weights = cwts,
-                                      ...)
+modelInfo <- list(
+  label = "Linear Support Vector Machines with Class Weights",
+  library = "e1071",
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = c('cost', 'weight'),
+    class = c("numeric", 'numeric'),
+    label = c("Cost", 'Class Weight')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(cost = 2^((1:len) - 3), weight = 1:len)
+    } else {
+      out <- data.frame(
+        cost = 2^runif(len, min = -5, max = 10),
+        weight = runif(len, min = 1, max = 25)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (length(levels(y)) != 2) {
+      stop("Currently implemented for 2-class problems")
+    }
+    cwts <- c(1, param$weight)
+    names(cwts) <- levels(y)
+    out <- e1071::svm(
+      x = as.matrix(x),
+      y = y,
+      kernel = "linear",
+      cost = param$cost,
+      probability = classProbs,
+      class.weights = cwts,
+      ...
+    )
 
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    predict(modelFit, newdata)
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, newdata, probability = TRUE)
-                    attr(out, "probabilities")
-                  },
-                  predictors = function(x, ...){
-                    out <- if(!is.null(x$terms)) predictors.terms(x$terms) else x$xNames
-                    if(is.null(out)) out <- names(attr(x, "scaling")$x.scale$`scaled:center`)
-                    if(is.null(out)) out <-NA
-                    out
-                  },
-                  tags = c("Kernel Method", "Support Vector Machines","Linear Classifier",
-                           "Robust Methods", "Cost Sensitive Learning", "Two Class Only"),
-                  levels = function(x) x$levels,
-                  sort = function(x) {
-                    # If the cost is high, the decision boundary will work hard to
-                    # adapt. Also, if C is fixed, smaller values of sigma yeild more
-                    # complex boundaries
-                    x[order(x$cost, x$weight),]
-                  })
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(modelFit, newdata, probability = TRUE)
+    attr(out, "probabilities")
+  },
+  predictors = function(x, ...) {
+    out <- if (!is.null(x$terms)) predictors.terms(x$terms) else x$xNames
+    if (is.null(out)) {
+      out <- names(attr(x, "scaling")$x.scale$`scaled:center`)
+    }
+    if (is.null(out)) {
+      out <- NA
+    }
+    out
+  },
+  tags = c(
+    "Kernel Method",
+    "Support Vector Machines",
+    "Linear Classifier",
+    "Robust Methods",
+    "Cost Sensitive Learning",
+    "Two Class Only"
+  ),
+  levels = function(x) x$levels,
+  sort = function(x) {
+    # If the cost is high, the decision boundary will work hard to
+    # adapt. Also, if C is fixed, smaller values of sigma yeild more
+    # complex boundaries
+    x[order(x$cost, x$weight), ]
+  }
+)

--- a/inst/model_sources/files/svmLinearWeights.R
+++ b/inst/model_sources/files/svmLinearWeights.R
@@ -45,7 +45,11 @@ modelInfo <- list(
     attr(out, "probabilities")
   },
   predictors = function(x, ...) {
-    out <- if (!is.null(x$terms)) predictors.terms(x$terms) else x$xNames
+    if (!is.null(x$terms)) {
+      out <- predictors.terms(x$terms)
+    } else {
+      out <- x$xNames
+    }
     if (is.null(out)) {
       out <- names(attr(x, "scaling")$x.scale$`scaled:center`)
     }

--- a/inst/model_sources/files/svmLinearWeights2.R
+++ b/inst/model_sources/files/svmLinearWeights2.R
@@ -29,7 +29,11 @@ modelInfo <- list(
     #
     # 2 - L2-regularized L2-loss support vector classification (primal)
     # 3 - L2-regularized L1-loss support vector classification (dual)
-    model_type <- if (param$Loss == "L2") 2 else 3
+    if (param$Loss == "L2") {
+      model_type <- 2
+    } else {
+      model_type <- 3
+    }
     if (length(levels(y)) != 2) {
       stop("Currently implemented for 2-class problems")
     }

--- a/inst/model_sources/files/svmLinearWeights2.R
+++ b/inst/model_sources/files/svmLinearWeights2.R
@@ -1,52 +1,70 @@
-modelInfo <- list(label = "L2 Regularized Linear Support Vector Machines with Class Weights",
-                  library = "LiblineaR",
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = c('cost', "Loss", "weight"),
-                                          class = c("numeric", "character", "numeric"),
-                                          label = c("Cost", "Loss Function", 'Class Weight')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(cost = 2 ^((1:len) - 3),
-                                         Loss = c("L1", "L2"),
-                                         weight = 1:len)
-                    } else {
-                      out <- data.frame(cost = 2^runif(len, min = -10, max = 10),
-                                        Loss = sample(c("L1", "L2"), size = len, replace = TRUE),
-                                        weight = runif(len, min = 1, max = 25))
-                    }
-                    out
-                  }, 
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    # LiblineaR lists the following models 
-                    # 
-                    # 2 - L2-regularized L2-loss support vector classification (primal) 
-                    # 3 - L2-regularized L1-loss support vector classification (dual) 
-                    model_type <- if(param$Loss == "L2") 2 else 3
-                    if(length(levels(y)) != 2)
-                      stop("Currently implemented for 2-class problems")
-                    cwts <- c(1, param$weight)
-                    names(cwts) <- levels(y)
+modelInfo <- list(
+  label = "L2 Regularized Linear Support Vector Machines with Class Weights",
+  library = "LiblineaR",
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = c('cost', "Loss", "weight"),
+    class = c("numeric", "character", "numeric"),
+    label = c("Cost", "Loss Function", 'Class Weight')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        cost = 2^((1:len) - 3),
+        Loss = c("L1", "L2"),
+        weight = 1:len
+      )
+    } else {
+      out <- data.frame(
+        cost = 2^runif(len, min = -10, max = 10),
+        Loss = sample(c("L1", "L2"), size = len, replace = TRUE),
+        weight = runif(len, min = 1, max = 25)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    # LiblineaR lists the following models
+    #
+    # 2 - L2-regularized L2-loss support vector classification (primal)
+    # 3 - L2-regularized L1-loss support vector classification (dual)
+    model_type <- if (param$Loss == "L2") 2 else 3
+    if (length(levels(y)) != 2) {
+      stop("Currently implemented for 2-class problems")
+    }
+    cwts <- c(1, param$weight)
+    names(cwts) <- levels(y)
 
-                    out <- LiblineaR::LiblineaR(data = as.matrix(x), target = y,
-                                                cost = param$cost,
-                                                type = model_type,
-                                                wi = cwts,
-                                                ...)
+    out <- LiblineaR::LiblineaR(
+      data = as.matrix(x),
+      target = y,
+      cost = param$cost,
+      type = model_type,
+      wi = cwts,
+      ...
+    )
 
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    predict(modelFit, newdata)$predictions
-                  },
-                  prob = NULL,
-                  predictors = function(x, ...) { 
-                    out <- colnames(x$W)
-                    out[out != "Bias"]
-                    },
-                  tags = c("Kernel Method", "Support Vector Machines","Linear Classifier",
-                           "Robust Methods", "Cost Sensitive Learning", "Two Class Only"),
-                  levels = function(x) x$levels,
-                  sort = function(x) {
-                    x[order(x$cost),]
-                  })
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)$predictions
+  },
+  prob = NULL,
+  predictors = function(x, ...) {
+    out <- colnames(x$W)
+    out[out != "Bias"]
+  },
+  tags = c(
+    "Kernel Method",
+    "Support Vector Machines",
+    "Linear Classifier",
+    "Robust Methods",
+    "Cost Sensitive Learning",
+    "Two Class Only"
+  ),
+  levels = function(x) x$levels,
+  sort = function(x) {
+    x[order(x$cost), ]
+  }
+)

--- a/inst/model_sources/files/svmPoly.R
+++ b/inst/model_sources/files/svmPoly.R
@@ -1,95 +1,135 @@
-modelInfo <- list(label = "Support Vector Machines with Polynomial Kernel",
-                  library = "kernlab",
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('degree', 'scale', 'C'),
-                                          class = c("numeric", "numeric", "numeric"),
-                                          label = c('Polynomial Degree','Scale', 'Cost')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(degree = seq(1, min(len, 3)),      
-                                         scale = 10 ^((1:len) - 4),
-                                         C = 2 ^((1:len) - 3))
-                    } else {
-                      out <- data.frame(degree = sample(1:3, size = len, replace = TRUE),
-                                        scale = 10^runif(len, min = -5, log10(2)),
-                                        C = 2^runif(len, min = -5, max = 10))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    if(any(names(list(...)) == "prob.model") | is.numeric(y)) {
-                      out <- kernlab::ksvm(x = as.matrix(x), y = y,
-                                           kernel = kernlab::polydot(degree = param$degree,
-                                                                     scale = param$scale,
-                                                                     offset = 1),
-                                            C = param$C, ...)
-                    } else {
-                      out <- kernlab::ksvm(x = as.matrix(x), y = y,
-                                           kernel = kernlab::polydot(degree = param$degree,
-                                                                     scale = param$scale,
-                                                                     offset = 1),
-                                           C = param$C,
-                                           prob.model = classProbs,
-                                           ...)
-                    }
-                    out            
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    svmPred <- function(obj, x) {
-                      hasPM <- !is.null(unlist(obj@prob.model))
-                      if(hasPM) {
-                        pred <- kernlab::lev(obj)[apply(kernlab::predict(obj, x, type = "probabilities"), 
-                                               1, which.max)]
-                      } else pred <- kernlab::predict(obj, x)
-                      pred
-                    }
-                    out <- try(svmPred(modelFit, newdata), silent = TRUE)
-                    if(is.character(kernlab::lev(modelFit))) {
-                      if(class(out)[1] == "try-error") {
-                        warning("kernlab class prediction calculations failed; returning NAs")
-                        out <- rep("", nrow(newdata))
-                        out[seq(along = out)] <- NA
-                      }
-                    } else {
-                      if(class(out)[1] == "try-error") {
-                        warning("kernlab prediction calculations failed; returning NAs")
-                        out <- rep(NA, nrow(newdata))
-                      } 
-                    }
-                    if(is.matrix(out)) out <- out[,1]
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- try(kernlab::predict(modelFit, newdata, type="probabilities"),
-                               silent = TRUE)
-                    if(class(out)[1] != "try-error") {
-                      ## There are times when the SVM probability model will
-                      ## produce negative class probabilities, so we
-                      ## induce vlaues between 0 and 1
-                      if(any(out < 0)) {
-                        out[out < 0] <- 0
-                        out <- t(apply(out, 1, function(x) x/sum(x)))
-                      }
-                      out <- out[, kernlab::lev(modelFit), drop = FALSE]
-                    } else {
-                      warning("kernlab class probability calculations failed; returning NAs")
-                      out <- matrix(NA, nrow(newdata) * length(kernlab::lev(modelFit)), ncol = length(kernlab::lev(modelFit)))
-                      colnames(out) <- kernlab::lev(modelFit)
-                    }
-                    out
-                  },
-                  predictors = function(x, ...){
-                    if(hasTerms(x) & !is.null(x@terms)) {
-                      out <- predictors.terms(x@terms)
-                    } else {
-                      out <- colnames(attr(x, "xmatrix"))
-                    }
-                    if(is.null(out)) out <- names(attr(x, "scaling")$xscale$`scaled:center`)
-                    if(is.null(out)) out <-NA
-                    out
-                  },
-                  tags = c("Kernel Method", "Support Vector Machines", "Polynomial Model",
-                           "Robust Methods"),
-                  levels = function(x) kernlab::lev(x),
-                  sort = function(x) x[order(x$degree, x$C, x$scale),])
+modelInfo <- list(
+  label = "Support Vector Machines with Polynomial Kernel",
+  library = "kernlab",
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c('degree', 'scale', 'C'),
+    class = c("numeric", "numeric", "numeric"),
+    label = c('Polynomial Degree', 'Scale', 'Cost')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        degree = seq(1, min(len, 3)),
+        scale = 10^((1:len) - 4),
+        C = 2^((1:len) - 3)
+      )
+    } else {
+      out <- data.frame(
+        degree = sample(1:3, size = len, replace = TRUE),
+        scale = 10^runif(len, min = -5, log10(2)),
+        C = 2^runif(len, min = -5, max = 10)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (any(names(list(...)) == "prob.model") | is.numeric(y)) {
+      out <- kernlab::ksvm(
+        x = as.matrix(x),
+        y = y,
+        kernel = kernlab::polydot(
+          degree = param$degree,
+          scale = param$scale,
+          offset = 1
+        ),
+        C = param$C,
+        ...
+      )
+    } else {
+      out <- kernlab::ksvm(
+        x = as.matrix(x),
+        y = y,
+        kernel = kernlab::polydot(
+          degree = param$degree,
+          scale = param$scale,
+          offset = 1
+        ),
+        C = param$C,
+        prob.model = classProbs,
+        ...
+      )
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    svmPred <- function(obj, x) {
+      hasPM <- !is.null(unlist(obj@prob.model))
+      if (hasPM) {
+        pred <- kernlab::lev(obj)[apply(
+          kernlab::predict(obj, x, type = "probabilities"),
+          1,
+          which.max
+        )]
+      } else {
+        pred <- kernlab::predict(obj, x)
+      }
+      pred
+    }
+    out <- try(svmPred(modelFit, newdata), silent = TRUE)
+    if (is.character(kernlab::lev(modelFit))) {
+      if (class(out)[1] == "try-error") {
+        warning("kernlab class prediction calculations failed; returning NAs")
+        out <- rep("", nrow(newdata))
+        out[seq(along = out)] <- NA
+      }
+    } else {
+      if (class(out)[1] == "try-error") {
+        warning("kernlab prediction calculations failed; returning NAs")
+        out <- rep(NA, nrow(newdata))
+      }
+    }
+    if (is.matrix(out)) {
+      out <- out[, 1]
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- try(
+      kernlab::predict(modelFit, newdata, type = "probabilities"),
+      silent = TRUE
+    )
+    if (class(out)[1] != "try-error") {
+      ## There are times when the SVM probability model will
+      ## produce negative class probabilities, so we
+      ## induce vlaues between 0 and 1
+      if (any(out < 0)) {
+        out[out < 0] <- 0
+        out <- t(apply(out, 1, function(x) x / sum(x)))
+      }
+      out <- out[, kernlab::lev(modelFit), drop = FALSE]
+    } else {
+      warning("kernlab class probability calculations failed; returning NAs")
+      out <- matrix(
+        NA,
+        nrow(newdata) * length(kernlab::lev(modelFit)),
+        ncol = length(kernlab::lev(modelFit))
+      )
+      colnames(out) <- kernlab::lev(modelFit)
+    }
+    out
+  },
+  predictors = function(x, ...) {
+    if (hasTerms(x) & !is.null(x@terms)) {
+      out <- predictors.terms(x@terms)
+    } else {
+      out <- colnames(attr(x, "xmatrix"))
+    }
+    if (is.null(out)) {
+      out <- names(attr(x, "scaling")$xscale$`scaled:center`)
+    }
+    if (is.null(out)) {
+      out <- NA
+    }
+    out
+  },
+  tags = c(
+    "Kernel Method",
+    "Support Vector Machines",
+    "Polynomial Model",
+    "Robust Methods"
+  ),
+  levels = function(x) kernlab::lev(x),
+  sort = function(x) x[order(x$degree, x$C, x$scale), ]
+)

--- a/inst/model_sources/files/svmRadial.R
+++ b/inst/model_sources/files/svmRadial.R
@@ -1,99 +1,131 @@
-modelInfo <- list(label = "Support Vector Machines with Radial Basis Function Kernel",
-                  library = "kernlab",
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('sigma', 'C'),
-                                          class = c("numeric", "numeric"),
-                                          label = c('Sigma', "Cost")),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    sigmas <- kernlab::sigest(as.matrix(x), na.action = na.omit, scaled = TRUE)
-                    if(search == "grid") {
-                      out <- expand.grid(sigma = mean(as.vector(sigmas[-2])),
-                                         C = 2 ^((1:len) - 3))
-                    } else {
-                      rng <- extendrange(log(sigmas), f = .75)
-                      out <- data.frame(sigma = exp(runif(len, min = rng[1], max = rng[2])),
-                                        C = 2^runif(len, min = -5, max = 10))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    if(any(names(list(...)) == "prob.model") | is.numeric(y)) {
-                      out <- kernlab::ksvm(x = as.matrix(x), y = y,
-                                           kernel = "rbfdot",
-                                           kpar = list(sigma = param$sigma),
-                                           C = param$C, ...)
-                    } else {
-                      out <- kernlab::ksvm(x = as.matrix(x), y = y,
-                                           kernel = "rbfdot",
-                                           kpar = list(sigma = param$sigma),
-                                           C = param$C,
-                                           prob.model = classProbs,
-                                           ...)
-                    }
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    svmPred <- function(obj, x) {
-                      hasPM <- !is.null(unlist(obj@prob.model))
-                      if(hasPM) {
-                        pred <- kernlab::lev(obj)[apply(kernlab::predict(obj, x, type = "probabilities"),
-                                               1, which.max)]
-                      } else pred <- kernlab::predict(obj, x)
-                      pred
-                    }
-                    out <- try(svmPred(modelFit, newdata), silent = TRUE)
-                    if(is.character(kernlab::lev(modelFit))) {
-                      if(class(out)[1] == "try-error") {
-                        warning("kernlab class prediction calculations failed; returning NAs")
-                        out <- rep("", nrow(newdata))
-                        out[seq(along = out)] <- NA
-                      }
-                    } else {
-                      if(class(out)[1] == "try-error") {
-                        warning("kernlab prediction calculations failed; returning NAs")
-                        out <- rep(NA, nrow(newdata))
-                      }
-                    }
-                    if(is.matrix(out)) out <- out[,1]
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- try(kernlab::predict(modelFit, newdata, type="probabilities"),
-                               silent = TRUE)
-                    if(class(out)[1] != "try-error") {
-                      ## There are times when the SVM probability model will
-                      ## produce negative class probabilities, so we
-                      ## induce vlaues between 0 and 1
-                      if(any(out < 0)) {
-                        out[out < 0] <- 0
-                        out <- t(apply(out, 1, function(x) x/sum(x)))
-                      }
-                      out <- out[, kernlab::lev(modelFit), drop = FALSE]
-                    } else {
-                      num_lvls <- length(kernlab::lev(modelFit))
-                      warning("kernlab class probability calculations failed; returning NAs")
-                      out <- matrix(NA, nrow(newdata) * num_lvls,  ncol = num_lvls)
-                      colnames(out) <- kernlab::lev(modelFit)
-                    }
-                    out
-                  },
-                  predictors = function(x, ...){
-                    if(hasTerms(x) & !is.null(x@terms)) {
-                      out <- predictors.terms(x@terms)
-                    } else {
-                      out <- colnames(attr(x, "xmatrix"))
-                    }
-                    if(is.null(out)) out <- names(attr(x, "scaling")$x.scale$`scaled:center`)
-                    if(is.null(out)) out <-NA
-                    out
-                  },
-                  tags = c("Kernel Method", "Support Vector Machines", "Radial Basis Function",
-                           "Robust Methods"),
-                  levels = function(x) kernlab::lev(x),
-                  sort = function(x) {
-                    # If the cost is high, the decision boundary will work hard to
-                    # adapt. Also, if C is fixed, smaller values of sigma yeild more
-                    # complex boundaries
-                    x[order(x$C, -x$sigma),]
-                  })
+modelInfo <- list(
+  label = "Support Vector Machines with Radial Basis Function Kernel",
+  library = "kernlab",
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c('sigma', 'C'),
+    class = c("numeric", "numeric"),
+    label = c('Sigma', "Cost")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    sigmas <- kernlab::sigest(as.matrix(x), na.action = na.omit, scaled = TRUE)
+    if (search == "grid") {
+      out <- expand.grid(
+        sigma = mean(as.vector(sigmas[-2])),
+        C = 2^((1:len) - 3)
+      )
+    } else {
+      rng <- extendrange(log(sigmas), f = .75)
+      out <- data.frame(
+        sigma = exp(runif(len, min = rng[1], max = rng[2])),
+        C = 2^runif(len, min = -5, max = 10)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (any(names(list(...)) == "prob.model") | is.numeric(y)) {
+      out <- kernlab::ksvm(
+        x = as.matrix(x),
+        y = y,
+        kernel = "rbfdot",
+        kpar = list(sigma = param$sigma),
+        C = param$C,
+        ...
+      )
+    } else {
+      out <- kernlab::ksvm(
+        x = as.matrix(x),
+        y = y,
+        kernel = "rbfdot",
+        kpar = list(sigma = param$sigma),
+        C = param$C,
+        prob.model = classProbs,
+        ...
+      )
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    svmPred <- function(obj, x) {
+      hasPM <- !is.null(unlist(obj@prob.model))
+      if (hasPM) {
+        pred <- kernlab::lev(obj)[apply(
+          kernlab::predict(obj, x, type = "probabilities"),
+          1,
+          which.max
+        )]
+      } else {
+        pred <- kernlab::predict(obj, x)
+      }
+      pred
+    }
+    out <- try(svmPred(modelFit, newdata), silent = TRUE)
+    if (is.character(kernlab::lev(modelFit))) {
+      if (class(out)[1] == "try-error") {
+        warning("kernlab class prediction calculations failed; returning NAs")
+        out <- rep("", nrow(newdata))
+        out[seq(along = out)] <- NA
+      }
+    } else {
+      if (class(out)[1] == "try-error") {
+        warning("kernlab prediction calculations failed; returning NAs")
+        out <- rep(NA, nrow(newdata))
+      }
+    }
+    if (is.matrix(out)) {
+      out <- out[, 1]
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- try(
+      kernlab::predict(modelFit, newdata, type = "probabilities"),
+      silent = TRUE
+    )
+    if (class(out)[1] != "try-error") {
+      ## There are times when the SVM probability model will
+      ## produce negative class probabilities, so we
+      ## induce vlaues between 0 and 1
+      if (any(out < 0)) {
+        out[out < 0] <- 0
+        out <- t(apply(out, 1, function(x) x / sum(x)))
+      }
+      out <- out[, kernlab::lev(modelFit), drop = FALSE]
+    } else {
+      num_lvls <- length(kernlab::lev(modelFit))
+      warning("kernlab class probability calculations failed; returning NAs")
+      out <- matrix(NA, nrow(newdata) * num_lvls, ncol = num_lvls)
+      colnames(out) <- kernlab::lev(modelFit)
+    }
+    out
+  },
+  predictors = function(x, ...) {
+    if (hasTerms(x) & !is.null(x@terms)) {
+      out <- predictors.terms(x@terms)
+    } else {
+      out <- colnames(attr(x, "xmatrix"))
+    }
+    if (is.null(out)) {
+      out <- names(attr(x, "scaling")$x.scale$`scaled:center`)
+    }
+    if (is.null(out)) {
+      out <- NA
+    }
+    out
+  },
+  tags = c(
+    "Kernel Method",
+    "Support Vector Machines",
+    "Radial Basis Function",
+    "Robust Methods"
+  ),
+  levels = function(x) kernlab::lev(x),
+  sort = function(x) {
+    # If the cost is high, the decision boundary will work hard to
+    # adapt. Also, if C is fixed, smaller values of sigma yeild more
+    # complex boundaries
+    x[order(x$C, -x$sigma), ]
+  }
+)

--- a/inst/model_sources/files/svmRadialCost.R
+++ b/inst/model_sources/files/svmRadialCost.R
@@ -1,95 +1,120 @@
-modelInfo <- list(label = "Support Vector Machines with Radial Basis Function Kernel",
-                  library = "kernlab",
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('C'),
-                                          class = c("numeric"),
-                                          label = c("Cost")),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- data.frame(C = 2 ^((1:len) - 3))
-                    } else {
-                      out <- data.frame(C = 2^runif(len, min = -5, max = 10))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    if(any(names(list(...)) == "prob.model") | is.numeric(y)) {
-                      out <- kernlab::ksvm(x = as.matrix(x), y = y,
-                                           kernel = "rbfdot",
-                                           C = param$C, ...)
-                    } else {
-                      out <- kernlab::ksvm(x = as.matrix(x), y = y,
-                                           kernel = "rbfdot",
-                                           C = param$C,
-                                           prob.model = classProbs,
-                                          ...)
-                    }
-                    
-                    out            
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    svmPred <- function(obj, x) {
-                      hasPM <- !is.null(unlist(obj@prob.model))
-                      if(hasPM) {
-                        pred <- kernlab::lev(obj)[apply(kernlab::predict(obj, x, type = "probabilities"), 
-                                               1, which.max)]
-                      } else pred <- kernlab::predict(obj, x)
-                      pred
-                    }
-                    out <- try(svmPred(modelFit, newdata), silent = TRUE)
-                    if(is.character(kernlab::lev(modelFit))) {
-                      if(class(out)[1] == "try-error")
-                      {
-                        warning("kernlab class prediction calculations failed; returning NAs")
-                        out <- rep("", nrow(newdata))
-                        out[seq(along = out)] <- NA
-                      }
-                    } else {
-                      if(class(out)[1] == "try-error") {
-                        warning("kernlab prediction calculations failed; returning NAs")
-                        out <- rep(NA, nrow(newdata))
-                      } 
-                    }
-                    if(is.matrix(out)) out <- out[,1]
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- try(kernlab::predict(modelFit, newdata, type="probabilities"),
-                               silent = TRUE)
-                    if(class(out)[1] != "try-error")
-                    {
-                      ## There are times when the SVM probability model will
-                      ## produce negative class probabilities, so we
-                      ## induce vlaues between 0 and 1
-                      if(any(out < 0)) {
-                        out[out < 0] <- 0
-                        out <- t(apply(out, 1, function(x) x/sum(x)))
-                      }
-                      out <- out[, kernlab::lev(modelFit), drop = FALSE]
-                    } else {
-                      warning("kernlab class probability calculations failed; returning NAs")
-                      out <- matrix(NA, nrow(newdata) * length(kernlab::lev(modelFit)),
-                                    ncol = length(kernlab::lev(modelFit)))
-                      colnames(out) <- kernlab::lev(modelFit)
-                    }
-                    out
-                  },
-                  predictors = function(x, ...){
-                    if(hasTerms(x) & !is.null(x@terms)) {
-                      out <- predictors.terms(x@terms)
-                    } else {
-                      out <- colnames(attr(x, "xmatrix"))
-                    }
-                    if(is.null(out)) out <- names(attr(x, "scaling")$x.scale$`scaled:center`)
-                    if(is.null(out)) out <-NA
-                    out
-                  },
-                  tags = c("Kernel Method", "Support Vector Machines", "Radial Basis Function"),
-                  levels = function(x) kernlab::lev(x),
-                  sort = function(x) {
-                    # If the cost is high, the decision boundary will work hard to
-                    # adapt. Also, if C is fixed, smaller values of sigma yeild more
-                    # complex boundaries
-                    x[order(x$C),]
-                  })
+modelInfo <- list(
+  label = "Support Vector Machines with Radial Basis Function Kernel",
+  library = "kernlab",
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c('C'),
+    class = c("numeric"),
+    label = c("Cost")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(C = 2^((1:len) - 3))
+    } else {
+      out <- data.frame(C = 2^runif(len, min = -5, max = 10))
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (any(names(list(...)) == "prob.model") | is.numeric(y)) {
+      out <- kernlab::ksvm(
+        x = as.matrix(x),
+        y = y,
+        kernel = "rbfdot",
+        C = param$C,
+        ...
+      )
+    } else {
+      out <- kernlab::ksvm(
+        x = as.matrix(x),
+        y = y,
+        kernel = "rbfdot",
+        C = param$C,
+        prob.model = classProbs,
+        ...
+      )
+    }
+
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    svmPred <- function(obj, x) {
+      hasPM <- !is.null(unlist(obj@prob.model))
+      if (hasPM) {
+        pred <- kernlab::lev(obj)[apply(
+          kernlab::predict(obj, x, type = "probabilities"),
+          1,
+          which.max
+        )]
+      } else {
+        pred <- kernlab::predict(obj, x)
+      }
+      pred
+    }
+    out <- try(svmPred(modelFit, newdata), silent = TRUE)
+    if (is.character(kernlab::lev(modelFit))) {
+      if (class(out)[1] == "try-error") {
+        warning("kernlab class prediction calculations failed; returning NAs")
+        out <- rep("", nrow(newdata))
+        out[seq(along = out)] <- NA
+      }
+    } else {
+      if (class(out)[1] == "try-error") {
+        warning("kernlab prediction calculations failed; returning NAs")
+        out <- rep(NA, nrow(newdata))
+      }
+    }
+    if (is.matrix(out)) {
+      out <- out[, 1]
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- try(
+      kernlab::predict(modelFit, newdata, type = "probabilities"),
+      silent = TRUE
+    )
+    if (class(out)[1] != "try-error") {
+      ## There are times when the SVM probability model will
+      ## produce negative class probabilities, so we
+      ## induce vlaues between 0 and 1
+      if (any(out < 0)) {
+        out[out < 0] <- 0
+        out <- t(apply(out, 1, function(x) x / sum(x)))
+      }
+      out <- out[, kernlab::lev(modelFit), drop = FALSE]
+    } else {
+      warning("kernlab class probability calculations failed; returning NAs")
+      out <- matrix(
+        NA,
+        nrow(newdata) * length(kernlab::lev(modelFit)),
+        ncol = length(kernlab::lev(modelFit))
+      )
+      colnames(out) <- kernlab::lev(modelFit)
+    }
+    out
+  },
+  predictors = function(x, ...) {
+    if (hasTerms(x) & !is.null(x@terms)) {
+      out <- predictors.terms(x@terms)
+    } else {
+      out <- colnames(attr(x, "xmatrix"))
+    }
+    if (is.null(out)) {
+      out <- names(attr(x, "scaling")$x.scale$`scaled:center`)
+    }
+    if (is.null(out)) {
+      out <- NA
+    }
+    out
+  },
+  tags = c("Kernel Method", "Support Vector Machines", "Radial Basis Function"),
+  levels = function(x) kernlab::lev(x),
+  sort = function(x) {
+    # If the cost is high, the decision boundary will work hard to
+    # adapt. Also, if C is fixed, smaller values of sigma yeild more
+    # complex boundaries
+    x[order(x$C), ]
+  }
+)

--- a/inst/model_sources/files/svmRadialSigma.R
+++ b/inst/model_sources/files/svmRadialSigma.R
@@ -1,99 +1,135 @@
-modelInfo <- list(label = "Support Vector Machines with Radial Basis Function Kernel",
-                  library = "kernlab",
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('sigma', 'C'),
-                                          class = c("numeric", "numeric"),
-                                          label = c('Sigma', "Cost")),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    sigmas <- kernlab::sigest(as.matrix(x), na.action = na.omit, scaled = TRUE)
-                    if(search == "grid") {
-                      out <- expand.grid(sigma = seq(min(sigmas), max(sigmas), length = min(6, len)),
-                                         C = 2 ^((1:len) - 3))
-                    } else {
-                      rng <- extendrange(log(sigmas), f = .75)
-                      out <- data.frame(sigma = exp(runif(len, min = rng[1], max = rng[2])),
-                                        C = 2^runif(len, min = -5, max = 10))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    if(any(names(list(...)) == "prob.model") | is.numeric(y)) {
-                      out <- kernlab::ksvm(x = as.matrix(x), y = y,
-                                           kernel = "rbfdot",
-                                           kpar = list(sigma = param$sigma),
-                                           C = param$C, ...)
-                    } else {
-                      out <- kernlab::ksvm(x = as.matrix(x), y = y,
-                                           kernel = "rbfdot",
-                                           kpar = list(sigma = param$sigma),
-                                           C = param$C,
-                                           prob.model = classProbs,
-                                           ...)
-                    }
-                    out            
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    svmPred <- function(obj, x) {
-                      hasPM <- !is.null(unlist(obj@prob.model))
-                      if(hasPM) {
-                        pred <- kernlab::lev(obj)[apply(kernlab::predict(obj, x, type = "probabilities"), 
-                                               1, which.max)]
-                      } else pred <- kernlab::predict(obj, x)
-                      pred
-                    }
-                    out <- try(svmPred(modelFit, newdata), silent = TRUE)
-                    if(is.character(kernlab::lev(modelFit))) {
-                      if(class(out)[1] == "try-error") {
-                        warning("kernlab class prediction calculations failed; returning NAs")
-                        out <- rep("", nrow(newdata))
-                        out[seq(along = out)] <- NA
-                      }
-                    } else {
-                      if(class(out)[1] == "try-error") {
-                        warning("kernlab prediction calculations failed; returning NAs")
-                        out <- rep(NA, nrow(newdata))
-                      } 
-                    }
-                    if(is.matrix(out)) out <- out[,1]
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- try(kernlab::predict(modelFit, newdata, type="probabilities"),
-                               silent = TRUE)
-                    if(class(out)[1] != "try-error") {
-                      ## There are times when the SVM probability model will
-                      ## produce negative class probabilities, so we
-                      ## induce vlaues between 0 and 1
-                      if(any(out < 0)) {
-                        out[out < 0] <- 0
-                        out <- t(apply(out, 1, function(x) x/sum(x)))
-                      }
-                      out <- out[, kernlab::lev(modelFit), drop = FALSE]
-                    } else {
-                      warning("kernlab class probability calculations failed; returning NAs")
-                      out <- matrix(NA, nrow(newdata) * length(kernlab::lev(modelFit)), ncol = length(kernlab::lev(modelFit)))
-                      colnames(out) <- kernlab::lev(modelFit)
-                    }
-                    out
-                  },
-                  predictors = function(x, ...){
-                    if(hasTerms(x) & !is.null(x@terms)) {
-                      out <- predictors.terms(x@terms)
-                    } else {
-                      out <- colnames(attr(x, "xmatrix"))
-                    }
-                    if(is.null(out)) out <- names(attr(x, "scaling")$x.scale$`scaled:center`)
-                    if(is.null(out)) out <-NA
-                    out
-                  },
-                  notes = "This SVM model tunes over the cost parameter and the RBF kernel parameter sigma. In the latter case, using `tuneLength` will, at most, evaluate six values of the kernel parameter. This enables a broad search over the cost parameter and a relatively narrow search over `sigma`",
-                  tags = c("Kernel Method", "Support Vector Machines", "Radial Basis Function",
-                           "Robust Methods"),
-                  levels = function(x) kernlab::lev(x),
-                  sort = function(x) {
-                    # If the cost is high, the decision boundary will work hard to
-                    # adapt. Also, if C is fixed, smaller values of sigma yeild more
-                    # complex boundaries
-                    x[order(x$C, -x$sigma),]
-                  })
+modelInfo <- list(
+  label = "Support Vector Machines with Radial Basis Function Kernel",
+  library = "kernlab",
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c('sigma', 'C'),
+    class = c("numeric", "numeric"),
+    label = c('Sigma', "Cost")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    sigmas <- kernlab::sigest(as.matrix(x), na.action = na.omit, scaled = TRUE)
+    if (search == "grid") {
+      out <- expand.grid(
+        sigma = seq(min(sigmas), max(sigmas), length = min(6, len)),
+        C = 2^((1:len) - 3)
+      )
+    } else {
+      rng <- extendrange(log(sigmas), f = .75)
+      out <- data.frame(
+        sigma = exp(runif(len, min = rng[1], max = rng[2])),
+        C = 2^runif(len, min = -5, max = 10)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (any(names(list(...)) == "prob.model") | is.numeric(y)) {
+      out <- kernlab::ksvm(
+        x = as.matrix(x),
+        y = y,
+        kernel = "rbfdot",
+        kpar = list(sigma = param$sigma),
+        C = param$C,
+        ...
+      )
+    } else {
+      out <- kernlab::ksvm(
+        x = as.matrix(x),
+        y = y,
+        kernel = "rbfdot",
+        kpar = list(sigma = param$sigma),
+        C = param$C,
+        prob.model = classProbs,
+        ...
+      )
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    svmPred <- function(obj, x) {
+      hasPM <- !is.null(unlist(obj@prob.model))
+      if (hasPM) {
+        pred <- kernlab::lev(obj)[apply(
+          kernlab::predict(obj, x, type = "probabilities"),
+          1,
+          which.max
+        )]
+      } else {
+        pred <- kernlab::predict(obj, x)
+      }
+      pred
+    }
+    out <- try(svmPred(modelFit, newdata), silent = TRUE)
+    if (is.character(kernlab::lev(modelFit))) {
+      if (class(out)[1] == "try-error") {
+        warning("kernlab class prediction calculations failed; returning NAs")
+        out <- rep("", nrow(newdata))
+        out[seq(along = out)] <- NA
+      }
+    } else {
+      if (class(out)[1] == "try-error") {
+        warning("kernlab prediction calculations failed; returning NAs")
+        out <- rep(NA, nrow(newdata))
+      }
+    }
+    if (is.matrix(out)) {
+      out <- out[, 1]
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- try(
+      kernlab::predict(modelFit, newdata, type = "probabilities"),
+      silent = TRUE
+    )
+    if (class(out)[1] != "try-error") {
+      ## There are times when the SVM probability model will
+      ## produce negative class probabilities, so we
+      ## induce vlaues between 0 and 1
+      if (any(out < 0)) {
+        out[out < 0] <- 0
+        out <- t(apply(out, 1, function(x) x / sum(x)))
+      }
+      out <- out[, kernlab::lev(modelFit), drop = FALSE]
+    } else {
+      warning("kernlab class probability calculations failed; returning NAs")
+      out <- matrix(
+        NA,
+        nrow(newdata) * length(kernlab::lev(modelFit)),
+        ncol = length(kernlab::lev(modelFit))
+      )
+      colnames(out) <- kernlab::lev(modelFit)
+    }
+    out
+  },
+  predictors = function(x, ...) {
+    if (hasTerms(x) & !is.null(x@terms)) {
+      out <- predictors.terms(x@terms)
+    } else {
+      out <- colnames(attr(x, "xmatrix"))
+    }
+    if (is.null(out)) {
+      out <- names(attr(x, "scaling")$x.scale$`scaled:center`)
+    }
+    if (is.null(out)) {
+      out <- NA
+    }
+    out
+  },
+  notes = "This SVM model tunes over the cost parameter and the RBF kernel parameter sigma. In the latter case, using `tuneLength` will, at most, evaluate six values of the kernel parameter. This enables a broad search over the cost parameter and a relatively narrow search over `sigma`",
+  tags = c(
+    "Kernel Method",
+    "Support Vector Machines",
+    "Radial Basis Function",
+    "Robust Methods"
+  ),
+  levels = function(x) kernlab::lev(x),
+  sort = function(x) {
+    # If the cost is high, the decision boundary will work hard to
+    # adapt. Also, if C is fixed, smaller values of sigma yeild more
+    # complex boundaries
+    x[order(x$C, -x$sigma), ]
+  }
+)

--- a/inst/model_sources/files/svmRadialWeights.R
+++ b/inst/model_sources/files/svmRadialWeights.R
@@ -1,81 +1,116 @@
-modelInfo <- list(label = "Support Vector Machines with Class Weights",
-                  library = "kernlab",
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = c('sigma', 'C', 'Weight'),
-                                          class = c("numeric", "numeric", "numeric"),
-                                          label = c('Sigma', "Cost", "Weight")),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    sigmas <- kernlab::sigest(as.matrix(x), na.action = na.omit, scaled = TRUE)
-                    if(search == "grid") {
-                      out <- expand.grid(sigma = mean(as.vector(sigmas[-2])),
-                                         C = 2 ^((1:len) - 3),
-                                         Weight = 1:len)
-                    } else {
-                      rng <- extendrange(log(sigmas), f = .75)
-                      out <- data.frame(sigma = exp(runif(len, min = rng[1], max = rng[2])),
-                                        C = 2^runif(len, min = -5, max = 10),
-                                        Weight = runif(len, min = 1, max = 25))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    if(param$Weight != 1) {
-                      wts <- c(param$Weight, 1)
-                      names(wts) <- levels(y)
-                    } else wts <- NULL
-                    
-                    if(any(names(list(...)) == "prob.model") | is.numeric(y)) {
-                      out <- kernlab::ksvm(x = as.matrix(x), y = y,
-                                           kernel = "rbfdot",
-                                           kpar = list(sigma = param$sigma),
-                                           class.weights = wts,
-                                           C = param$C, ...)
-                    } else {
-                      out <- kernlab::ksvm(x = as.matrix(x), y = y,
-                                           kernel = "rbfdot",
-                                          kpar = list(sigma = param$sigma),
-                                          class.weights = wts,
-                                          C = param$C,
-                                          prob.model = classProbs,
-                                          ...)
-                    }
-                    out            
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- kernlab::predict(modelFit, newdata)
-                    if(is.matrix(out)) out <- out[,1]
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- try(kernlab::predict(modelFit, newdata, type="probabilities"),
-                               silent = TRUE)
-                    if(class(out)[1] != "try-error") {
-                      ## There are times when the SVM probability model will
-                      ## produce negative class probabilities, so we
-                      ## induce vlaues between 0 and 1
-                      if(any(out < 0)) {
-                        out[out < 0] <- 0
-                        out <- t(apply(out, 1, function(x) x/sum(x)))
-                      }
-                      out <- out[, kernlab::lev(modelFit), drop = FALSE]
-                    } else {
-                      warning("kernlab class probability calculations failed; returning NAs")
-                      out <- matrix(NA, nrow(newdata) * length(kernlab::lev(modelFit)), ncol = length(kernlab::lev(modelFit)))
-                      colnames(out) <- kernlab::lev(modelFit)
-                    }
-                    out
-                  },
-                  predictors = function(x, ...){
-                    if(hasTerms(x) & !is.null(x@terms)) {
-                      out <- predictors.terms(x@terms)
-                    } else {
-                      out <- colnames(attr(x, "xmatrix"))
-                    }
-                    if(is.null(out)) out <- names(attr(x, "scaling")$x.scale$`scaled:center`)
-                    if(is.null(out)) out <-NA
-                    out
-                  },
-                  tags = c("Kernel Method", "Support Vector Machines", "Radial Basis Function", "Cost Sensitive Learning", "Two Class Only"),
-                  levels = function(x) kernlab::lev(x),
-                  sort = function(x) x[order(x$C, -x$sigma, x$Weight),])
+modelInfo <- list(
+  label = "Support Vector Machines with Class Weights",
+  library = "kernlab",
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = c('sigma', 'C', 'Weight'),
+    class = c("numeric", "numeric", "numeric"),
+    label = c('Sigma', "Cost", "Weight")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    sigmas <- kernlab::sigest(as.matrix(x), na.action = na.omit, scaled = TRUE)
+    if (search == "grid") {
+      out <- expand.grid(
+        sigma = mean(as.vector(sigmas[-2])),
+        C = 2^((1:len) - 3),
+        Weight = 1:len
+      )
+    } else {
+      rng <- extendrange(log(sigmas), f = .75)
+      out <- data.frame(
+        sigma = exp(runif(len, min = rng[1], max = rng[2])),
+        C = 2^runif(len, min = -5, max = 10),
+        Weight = runif(len, min = 1, max = 25)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (param$Weight != 1) {
+      wts <- c(param$Weight, 1)
+      names(wts) <- levels(y)
+    } else {
+      wts <- NULL
+    }
+
+    if (any(names(list(...)) == "prob.model") | is.numeric(y)) {
+      out <- kernlab::ksvm(
+        x = as.matrix(x),
+        y = y,
+        kernel = "rbfdot",
+        kpar = list(sigma = param$sigma),
+        class.weights = wts,
+        C = param$C,
+        ...
+      )
+    } else {
+      out <- kernlab::ksvm(
+        x = as.matrix(x),
+        y = y,
+        kernel = "rbfdot",
+        kpar = list(sigma = param$sigma),
+        class.weights = wts,
+        C = param$C,
+        prob.model = classProbs,
+        ...
+      )
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- kernlab::predict(modelFit, newdata)
+    if (is.matrix(out)) {
+      out <- out[, 1]
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- try(
+      kernlab::predict(modelFit, newdata, type = "probabilities"),
+      silent = TRUE
+    )
+    if (class(out)[1] != "try-error") {
+      ## There are times when the SVM probability model will
+      ## produce negative class probabilities, so we
+      ## induce vlaues between 0 and 1
+      if (any(out < 0)) {
+        out[out < 0] <- 0
+        out <- t(apply(out, 1, function(x) x / sum(x)))
+      }
+      out <- out[, kernlab::lev(modelFit), drop = FALSE]
+    } else {
+      warning("kernlab class probability calculations failed; returning NAs")
+      out <- matrix(
+        NA,
+        nrow(newdata) * length(kernlab::lev(modelFit)),
+        ncol = length(kernlab::lev(modelFit))
+      )
+      colnames(out) <- kernlab::lev(modelFit)
+    }
+    out
+  },
+  predictors = function(x, ...) {
+    if (hasTerms(x) & !is.null(x@terms)) {
+      out <- predictors.terms(x@terms)
+    } else {
+      out <- colnames(attr(x, "xmatrix"))
+    }
+    if (is.null(out)) {
+      out <- names(attr(x, "scaling")$x.scale$`scaled:center`)
+    }
+    if (is.null(out)) {
+      out <- NA
+    }
+    out
+  },
+  tags = c(
+    "Kernel Method",
+    "Support Vector Machines",
+    "Radial Basis Function",
+    "Cost Sensitive Learning",
+    "Two Class Only"
+  ),
+  levels = function(x) kernlab::lev(x),
+  sort = function(x) x[order(x$C, -x$sigma, x$Weight), ]
+)

--- a/inst/model_sources/files/svmSpectrumString.R
+++ b/inst/model_sources/files/svmSpectrumString.R
@@ -1,91 +1,119 @@
-modelInfo <- list(label = "Support Vector Machines with Spectrum String Kernel",
-                  library = "kernlab",
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('length', 'C'),
-                                          class = c("numeric", "numeric"),
-                                          label = c('length', "Cost")),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(length = 2:(len+1),
-                                         C = 2 ^((1:len) - 3))
-                    } else {
-                      out <- data.frame(length = sample(1:20, size = len, replace = TRUE),
-                                        C = 2^runif(len, min = -5, max = 10))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    if(any(names(list(...)) == "prob.model") | is.numeric(y)) {
-                      out <- kernlab::ksvm(x = x[,1], y = y,
-                                           kernel = "stringdot",
-                                           kpar = list(type = "spectrum",
-                                                       length = param$length),
-                                           C = param$C, ...)
-                    } else {
-                      out <- kernlab::ksvm(x = x[,1], y = y,
-                                           kernel = "stringdot",
-                                           kpar = list(type = "spectrum",
-                                                       length = param$length),
-                                           C = param$C,
-                                           prob.model = classProbs,
-                                           ...)
-                    }
-                    out            
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    svmPred <- function(obj, x) {
-                      hasPM <- !is.null(unlist(obj@prob.model))
-                      if(hasPM) {
-                        pred <- kernlab::lev(obj)[apply(kernlab::predict(obj, x, type = "probabilities"), 
-                                               1, which.max)]
-                      } else pred <- kernlab::predict(obj, x)
-                      pred
-                    }
-                    out <- try(svmPred(modelFit, newdata[,1]), silent = TRUE)
-                    if(is.character(kernlab::lev(modelFit))) {
-                      if(class(out)[1] == "try-error")  {
-                        warning("kernlab class prediction calculations failed; returning NAs")
-                        out <- rep("", nrow(newdata))
-                        out[seq(along = out)] <- NA
-                      }
-                    } else {
-                      if(class(out)[1] == "try-error")  {
-                        warning("kernlab prediction calculations failed; returning NAs")
-                        out <- rep(NA, nrow(newdata))
-                      } 
-                    }
-                    if(is.matrix(out)) out <- out[,1]
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    out <- try(kernlab::predict(modelFit, newdata[,1], type="probabilities"),
-                               silent = TRUE)
-                    if(class(out)[1] != "try-error") {
-                      ## There are times when the SVM probability model will
-                      ## produce negative class probabilities, so we
-                      ## induce vlaues between 0 and 1
-                      if(any(out < 0)) {
-                        out[out < 0] <- 0
-                        out <- t(apply(out, 1, function(x) x/sum(x)))
-                      }
-                      out <- out[, kernlab::lev(modelFit), drop = FALSE]
-                    } else {
-                      warning("kernlab class probability calculations failed; returning NAs")
-                      out <- matrix(NA, nrow(newdata) * length(kernlab::lev(modelFit)), ncol = length(kernlab::lev(modelFit)))
-                      colnames(out) <- kernlab::lev(modelFit)
-                    }
-                    out
-                  },
-                  predictors = function(x, ...){
-                    NA
-                  },
-                  tags = c("Kernel Method", "Support Vector Machines", "String Kernel",
-                           "Robust Methods", "Text Mining"),
-                  levels = function(x) kernlab::lev(x),
-                  sort = function(x) {
-                    # If the cost is high, the decision boundary will work hard to
-                    # adapt. Also, if C is fixed, smaller values of sigma yeild more
-                    # complex boundaries
-                    x[order(x$C, -x$length),]
-                  })
+modelInfo <- list(
+  label = "Support Vector Machines with Spectrum String Kernel",
+  library = "kernlab",
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c('length', 'C'),
+    class = c("numeric", "numeric"),
+    label = c('length', "Cost")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(length = 2:(len + 1), C = 2^((1:len) - 3))
+    } else {
+      out <- data.frame(
+        length = sample(1:20, size = len, replace = TRUE),
+        C = 2^runif(len, min = -5, max = 10)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (any(names(list(...)) == "prob.model") | is.numeric(y)) {
+      out <- kernlab::ksvm(
+        x = x[, 1],
+        y = y,
+        kernel = "stringdot",
+        kpar = list(type = "spectrum", length = param$length),
+        C = param$C,
+        ...
+      )
+    } else {
+      out <- kernlab::ksvm(
+        x = x[, 1],
+        y = y,
+        kernel = "stringdot",
+        kpar = list(type = "spectrum", length = param$length),
+        C = param$C,
+        prob.model = classProbs,
+        ...
+      )
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    svmPred <- function(obj, x) {
+      hasPM <- !is.null(unlist(obj@prob.model))
+      if (hasPM) {
+        pred <- kernlab::lev(obj)[apply(
+          kernlab::predict(obj, x, type = "probabilities"),
+          1,
+          which.max
+        )]
+      } else {
+        pred <- kernlab::predict(obj, x)
+      }
+      pred
+    }
+    out <- try(svmPred(modelFit, newdata[, 1]), silent = TRUE)
+    if (is.character(kernlab::lev(modelFit))) {
+      if (class(out)[1] == "try-error") {
+        warning("kernlab class prediction calculations failed; returning NAs")
+        out <- rep("", nrow(newdata))
+        out[seq(along = out)] <- NA
+      }
+    } else {
+      if (class(out)[1] == "try-error") {
+        warning("kernlab prediction calculations failed; returning NAs")
+        out <- rep(NA, nrow(newdata))
+      }
+    }
+    if (is.matrix(out)) {
+      out <- out[, 1]
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    out <- try(
+      kernlab::predict(modelFit, newdata[, 1], type = "probabilities"),
+      silent = TRUE
+    )
+    if (class(out)[1] != "try-error") {
+      ## There are times when the SVM probability model will
+      ## produce negative class probabilities, so we
+      ## induce vlaues between 0 and 1
+      if (any(out < 0)) {
+        out[out < 0] <- 0
+        out <- t(apply(out, 1, function(x) x / sum(x)))
+      }
+      out <- out[, kernlab::lev(modelFit), drop = FALSE]
+    } else {
+      warning("kernlab class probability calculations failed; returning NAs")
+      out <- matrix(
+        NA,
+        nrow(newdata) * length(kernlab::lev(modelFit)),
+        ncol = length(kernlab::lev(modelFit))
+      )
+      colnames(out) <- kernlab::lev(modelFit)
+    }
+    out
+  },
+  predictors = function(x, ...) {
+    NA
+  },
+  tags = c(
+    "Kernel Method",
+    "Support Vector Machines",
+    "String Kernel",
+    "Robust Methods",
+    "Text Mining"
+  ),
+  levels = function(x) kernlab::lev(x),
+  sort = function(x) {
+    # If the cost is high, the decision boundary will work hard to
+    # adapt. Also, if C is fixed, smaller values of sigma yeild more
+    # complex boundaries
+    x[order(x$C, -x$length), ]
+  }
+)

--- a/inst/model_sources/files/tan.R
+++ b/inst/model_sources/files/tan.R
@@ -23,10 +23,10 @@ modelInfo <- list(
   },
   loop = NULL,
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     bnclassify::bnc(

--- a/inst/model_sources/files/tan.R
+++ b/inst/model_sources/files/tan.R
@@ -1,38 +1,57 @@
-modelInfo <- list(label = "Tree Augmented Naive Bayes Classifier",
-                  library = "bnclassify",
-                  type = "Classification",
-                  parameters = data.frame(parameter = c('score', "smooth"),
-                                          class = c("character", "numeric"),
-                                          label = c('Score Function', "Smoothing Parameter")),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") { 
-                      out <- expand.grid(score = c('loglik', 'bic', 'aic'),
-                                         smooth = 0:(len-1))
-                    } else {
-                      out <- data.frame(smooth= runif(len, min = 0, max = 10),
-                                        score = sample(c('loglik', 'bic', 'aic'),
-                                                       size = len, replace = TRUE))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    bnclassify::bnc('tan_cl', class = '.outcome', dataset = dat,
-                                    smooth = param$smooth,
-                                    dag_args = list(score = as.character(param$score)),
-                                    ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata)       
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata, prob = TRUE) 
-                  },
-                  levels = function(x) x$obsLevels,
-                  predictors = function(x, s = NULL, ...) x$xNames,
-                  tags = c("Bayesian Model", "Categorical Predictors Only"),
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Tree Augmented Naive Bayes Classifier",
+  library = "bnclassify",
+  type = "Classification",
+  parameters = data.frame(
+    parameter = c('score', "smooth"),
+    class = c("character", "numeric"),
+    label = c('Score Function', "Smoothing Parameter")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        score = c('loglik', 'bic', 'aic'),
+        smooth = 0:(len - 1)
+      )
+    } else {
+      out <- data.frame(
+        smooth = runif(len, min = 0, max = 10),
+        score = sample(c('loglik', 'bic', 'aic'), size = len, replace = TRUE)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    bnclassify::bnc(
+      'tan_cl',
+      class = '.outcome',
+      dataset = dat,
+      smooth = param$smooth,
+      dag_args = list(score = as.character(param$score)),
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata, prob = TRUE)
+  },
+  levels = function(x) x$obsLevels,
+  predictors = function(x, s = NULL, ...) x$xNames,
+  tags = c("Bayesian Model", "Categorical Predictors Only"),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/tanSearch.R
+++ b/inst/model_sources/files/tanSearch.R
@@ -2,54 +2,80 @@ modelInfo <- list(
   label = "Tree Augmented Naive Bayes Classifier Structure Learner Wrapper",
   library = "bnclassify",
   type = "Classification",
-  parameters = data.frame(parameter = c("k", 'epsilon', "smooth", "final_smooth", "sp"),
-                          class = c(rep("numeric", 4), "logical"),
-                          label = c('#Folds', "Minimum Absolute Improvement", 
-                                    "Smoothing Parameter", "Final Smoothing Parameter", 
-                                    "Super-Parent")),
+  parameters = data.frame(
+    parameter = c("k", 'epsilon', "smooth", "final_smooth", "sp"),
+    class = c(rep("numeric", 4), "logical"),
+    label = c(
+      '#Folds',
+      "Minimum Absolute Improvement",
+      "Smoothing Parameter",
+      "Final Smoothing Parameter",
+      "Super-Parent"
+    )
+  ),
   grid = function(x, y, len = NULL, search = "grid") {
-    if(search == "grid") { 
-      out <- expand.grid(k = 10, epsilon = 0.01, smooth = 0.01,
-                         final_smooth = 1,
-                         sp = c(TRUE, FALSE))
+    if (search == "grid") {
+      out <- expand.grid(
+        k = 10,
+        epsilon = 0.01,
+        smooth = 0.01,
+        final_smooth = 1,
+        sp = c(TRUE, FALSE)
+      )
     } else {
-      out <- data.frame(k = sample(3:10, size = len, replace = TRUE),
-                        epsilon = runif(len, min = 0, max = .05),
-                        smooth= runif(len, min = 0, max = 10),
-                        final_smooth= runif(len, min = 0, max = 10),
-                        sp = sample(c(TRUE, FALSE), size = len, replace = TRUE))
+      out <- data.frame(
+        k = sample(3:10, size = len, replace = TRUE),
+        epsilon = runif(len, min = 0, max = .05),
+        smooth = runif(len, min = 0, max = 10),
+        final_smooth = runif(len, min = 0, max = 10),
+        sp = sample(c(TRUE, FALSE), size = len, replace = TRUE)
+      )
     }
-    out                    
+    out
   },
   loop = NULL,
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-    dat$.outcome <- y
-    if(param$sp) {
-      struct <- bnclassify::tan_hcsp(class = '.outcome', dataset = dat,
-                                     k = param$k,
-                                     epsilon = param$epsilon,
-                                     smooth = param$smooth,
-                                     ...)
+    dat <- if (is.data.frame(x)) {
+      x
     } else {
-      struct <- bnclassify::tan_hc(class = '.outcome', dataset = dat,
-                                   k = param$k,
-                                   epsilon = param$epsilon,
-                                   smooth = param$smooth,
-                                   ...)
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    if (param$sp) {
+      struct <- bnclassify::tan_hcsp(
+        class = '.outcome',
+        dataset = dat,
+        k = param$k,
+        epsilon = param$epsilon,
+        smooth = param$smooth,
+        ...
+      )
+    } else {
+      struct <- bnclassify::tan_hc(
+        class = '.outcome',
+        dataset = dat,
+        k = param$k,
+        epsilon = param$epsilon,
+        smooth = param$smooth,
+        ...
+      )
     }
     bnclassify::lp(struct, dat, smooth = param$final_smooth, ...)
   },
   predict = function(modelFit, newdata, submodels = NULL) {
-    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-    predict(modelFit, newdata)       
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata)
   },
   prob = function(modelFit, newdata, submodels = NULL) {
-    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-    predict(modelFit, newdata, prob = TRUE) 
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata, prob = TRUE)
   },
   levels = function(x) x$obsLevels,
   predictors = function(x, s = NULL, ...) x$xNames,
   tags = c("Bayesian Model", "Categorical Predictors Only"),
-  sort = function(x) x[order(x[,1]),]
+  sort = function(x) x[order(x[, 1]), ]
 )

--- a/inst/model_sources/files/tanSearch.R
+++ b/inst/model_sources/files/tanSearch.R
@@ -35,10 +35,10 @@ modelInfo <- list(
   },
   loop = NULL,
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     if (param$sp) {

--- a/inst/model_sources/files/treebag.R
+++ b/inst/model_sources/files/treebag.R
@@ -1,83 +1,118 @@
-modelInfo <- list(label = "Bagged CART",
-                  library = c("ipred", "plyr", "e1071"),
-                  loop = NULL,
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = "parameter",
-                                          class = "character",
-                                          label = "parameter"),
-                  grid = function(x, y, len = NULL, search = "grid") data.frame(parameter = "none"),
-                  fit = function(x, y, wts, param, lev, last,classProbs, ...) {
-                    theDots <- list(...)
-                    if(!any(names(theDots) == "keepX")) theDots$keepX <- FALSE   
-                    modelArgs <- c(list(X = x, y = y), theDots)
-                    if(!is.null(wts)) modelArgs$weights <- wts
-                    do.call(ipred::ipredbagg, modelArgs)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) 
-                    predict(modelFit, newdata),
-                  prob = function(modelFit, newdata, submodels = NULL)
-                    predict(modelFit, newdata, type = "prob"),
-                  predictors = function(x, surrogate = TRUE, ...) {
-                    code <- getModelInfo("rpart", regex = FALSE)[[1]]$predictors
-                    eachTree <- lapply(x$mtree,
-                                       function(u, surr) code(u$btree, surrogate = surr),
-                                       surr = surrogate)
-                    unique(unlist(eachTree))
-                  },
-                  varImp = function(object, ...) {
-                    allImp <- lapply(object$mtrees, function(x) varImp(x$btree), ...)
-                    allImp <- lapply(allImp, 
-                                     function(x) {
-                                       x$variable <- rownames(x)
-                                       x
-                                     })
-                    allImp <- do.call("rbind", allImp)
-                    meanImp <- plyr::ddply(allImp, plyr::`.`(variable),
-                                     function(x) c(Overall = mean(x$Overall)))
-                    out <- data.frame(Overall = meanImp$Overall)
-                    rownames(out) <- meanImp$variable
-                    out
-                  },
-                  trim = function(x) {
-                    trim_rpart <- function(x) {
-                      x$call <- list(na.action = (x$call)$na.action)
-                      x$x <- NULL
-                      x$y <- NULL
-                      x$where <- NULL
-                      x
-                    }
-                    x$mtrees <- lapply(x$mtrees, 
-                                       function(x){
-                                         x$bindx <- NULL
-                                         x$btree <- trim_rpart(x$btree)
-                                         x
-                                       } )
-                    x
-                  },
-                  tags = c("Tree-Based Model", "Ensemble Model", "Bagging", "Accepts Case Weights"), 
-                  levels = function(x) levels(x$y),
-                  sort = function(x) x,
-                  oob = function(x) {
-                    if(is.null(x$X)) stop("to get OOB stats, keepX must be TRUE when calling the bagging function")
-                    foo <- function(object, y, x) {
-                      holdY <- y[-object$bindx]
-                      tmp_x <- x[-object$bindx,,drop = FALSE]
-                      if(!is.data.frame(tmp_x)) tmp_x <- as.data.frame(tmp_x, stringsAsFactors = TRUE)
-                      if(is.factor(y)) {
-                        tmp <- predict(object$btree, tmp_x, type = "class")
-                        tmp <- factor(as.character(tmp), levels = levels(y))
-                        out <- c(mean(holdY == tmp), e1071::classAgreement(table(holdY, tmp))$kappa)
-                      } else {
-                        tmp <- predict(object$btree, tmp_x)
-                        out <- c(sqrt(mean((tmp - holdY)^2, na.rm = TRUE)),
-                                 cor(holdY, tmp, use = "pairwise.complete.obs")^2)
-                      }
-                      out
-                    }
-                    eachStat <- lapply(x$mtrees, foo, y = x$y, x = x$X)
-                    eachStat <- matrix(unlist(eachStat), nrow = length(eachStat[[1]]))
-                    out <- c(apply(eachStat, 1, mean, na.rm = TRUE),
-                             apply(eachStat, 1, sd, na.rm = TRUE))
-                    names(out) <- if(is.factor(x$y)) c("Accuracy", "Kappa", "AccuracySD", "KappaSD") else c("RMSE", "Rsquared", "RMSESD", "RsquaredSD")
-                    out
-                  })
+modelInfo <- list(
+  label = "Bagged CART",
+  library = c("ipred", "plyr", "e1071"),
+  loop = NULL,
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = "parameter",
+    class = "character",
+    label = "parameter"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(parameter = "none")
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    theDots <- list(...)
+    if (!any(names(theDots) == "keepX")) {
+      theDots$keepX <- FALSE
+    }
+    modelArgs <- c(list(X = x, y = y), theDots)
+    if (!is.null(wts)) {
+      modelArgs$weights <- wts
+    }
+    do.call(ipred::ipredbagg, modelArgs)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata)
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    predict(modelFit, newdata, type = "prob")
+  },
+  predictors = function(x, surrogate = TRUE, ...) {
+    code <- getModelInfo("rpart", regex = FALSE)[[1]]$predictors
+    eachTree <- lapply(
+      x$mtree,
+      function(u, surr) code(u$btree, surrogate = surr),
+      surr = surrogate
+    )
+    unique(unlist(eachTree))
+  },
+  varImp = function(object, ...) {
+    allImp <- lapply(object$mtrees, function(x) varImp(x$btree), ...)
+    allImp <- lapply(allImp, function(x) {
+      x$variable <- rownames(x)
+      x
+    })
+    allImp <- do.call("rbind", allImp)
+    meanImp <- plyr::ddply(allImp, plyr::`.`(variable), function(x) {
+      c(Overall = mean(x$Overall))
+    })
+    out <- data.frame(Overall = meanImp$Overall)
+    rownames(out) <- meanImp$variable
+    out
+  },
+  trim = function(x) {
+    trim_rpart <- function(x) {
+      x$call <- list(na.action = (x$call)$na.action)
+      x$x <- NULL
+      x$y <- NULL
+      x$where <- NULL
+      x
+    }
+    x$mtrees <- lapply(x$mtrees, function(x) {
+      x$bindx <- NULL
+      x$btree <- trim_rpart(x$btree)
+      x
+    })
+    x
+  },
+  tags = c(
+    "Tree-Based Model",
+    "Ensemble Model",
+    "Bagging",
+    "Accepts Case Weights"
+  ),
+  levels = function(x) levels(x$y),
+  sort = function(x) x,
+  oob = function(x) {
+    if (is.null(x$X)) {
+      stop(
+        "to get OOB stats, keepX must be TRUE when calling the bagging function"
+      )
+    }
+    foo <- function(object, y, x) {
+      holdY <- y[-object$bindx]
+      tmp_x <- x[-object$bindx, , drop = FALSE]
+      if (!is.data.frame(tmp_x)) {
+        tmp_x <- as.data.frame(tmp_x, stringsAsFactors = TRUE)
+      }
+      if (is.factor(y)) {
+        tmp <- predict(object$btree, tmp_x, type = "class")
+        tmp <- factor(as.character(tmp), levels = levels(y))
+        out <- c(
+          mean(holdY == tmp),
+          e1071::classAgreement(table(holdY, tmp))$kappa
+        )
+      } else {
+        tmp <- predict(object$btree, tmp_x)
+        out <- c(
+          sqrt(mean((tmp - holdY)^2, na.rm = TRUE)),
+          cor(holdY, tmp, use = "pairwise.complete.obs")^2
+        )
+      }
+      out
+    }
+    eachStat <- lapply(x$mtrees, foo, y = x$y, x = x$X)
+    eachStat <- matrix(unlist(eachStat), nrow = length(eachStat[[1]]))
+    out <- c(
+      apply(eachStat, 1, mean, na.rm = TRUE),
+      apply(eachStat, 1, sd, na.rm = TRUE)
+    )
+    names(out) <- if (is.factor(x$y)) {
+      c("Accuracy", "Kappa", "AccuracySD", "KappaSD")
+    } else {
+      c("RMSE", "Rsquared", "RMSESD", "RsquaredSD")
+    }
+    out
+  }
+)

--- a/inst/model_sources/files/treebag.R
+++ b/inst/model_sources/files/treebag.R
@@ -108,10 +108,10 @@ modelInfo <- list(
       apply(eachStat, 1, mean, na.rm = TRUE),
       apply(eachStat, 1, sd, na.rm = TRUE)
     )
-    names(out) <- if (is.factor(x$y)) {
-      c("Accuracy", "Kappa", "AccuracySD", "KappaSD")
+    if (is.factor(x$y)) {
+      names(out) <- c("Accuracy", "Kappa", "AccuracySD", "KappaSD")
     } else {
-      c("RMSE", "Rsquared", "RMSESD", "RsquaredSD")
+      names(out) <- c("RMSE", "Rsquared", "RMSESD", "RsquaredSD")
     }
     out
   }

--- a/inst/model_sources/files/vbmpRadial.R
+++ b/inst/model_sources/files/vbmpRadial.R
@@ -1,40 +1,57 @@
-modelInfo <- list(label = "Variational Bayesian Multinomial Probit Regression",
-                  library = "vbmp",
-                  loop = NULL,
-                  type = c('Classification'),
-                  parameters = data.frame(parameter = c('estimateTheta'),
-                                          class = c('character'),
-                                          label = c('Theta Estimated')),
-                  grid = function(x, y, len = NULL, search = "grid") data.frame(estimateTheta = "yes"),
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    theDots <- list(...)
-                    if(any(names(theDots) == "control"))
-                    {
-                      theDots$control$bThetaEstimate <- ifelse(param$estimateTheta == "Yes", TRUE, FALSE)
-                      ctl <- theDots$control
-                      theDots$control <- NULL
-                    } else ctl <- list(bThetaEstimate = ifelse(param$estimateTheta == "Yes", TRUE, FALSE))                        
-                    if(any(names(theDots) == "theta"))
-                    {
-                      theta <- theDots$theta
-                      theDots$theta <- NULL
-                    } else theta <- runif(ncol(x))
+modelInfo <- list(
+  label = "Variational Bayesian Multinomial Probit Regression",
+  library = "vbmp",
+  loop = NULL,
+  type = c('Classification'),
+  parameters = data.frame(
+    parameter = c('estimateTheta'),
+    class = c('character'),
+    label = c('Theta Estimated')
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    data.frame(estimateTheta = "yes")
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    theDots <- list(...)
+    if (any(names(theDots) == "control")) {
+      theDots$control$bThetaEstimate <- ifelse(
+        param$estimateTheta == "Yes",
+        TRUE,
+        FALSE
+      )
+      ctl <- theDots$control
+      theDots$control <- NULL
+    } else {
+      ctl <- list(
+        bThetaEstimate = ifelse(param$estimateTheta == "Yes", TRUE, FALSE)
+      )
+    }
+    if (any(names(theDots) == "theta")) {
+      theta <- theDots$theta
+      theDots$theta <- NULL
+    } else {
+      theta <- runif(ncol(x))
+    }
 
-                    vbmp::vbmp(x, as.numeric(y),
-                               theta = theta,
-                               control = ctl,
-                               X.TEST = x[1,],
-                               t.class.TEST  = as.numeric(y)[1])
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    probs <- vbmp::predictCPP(modelFit, newdata)
-                    modelFit$obsLevels[apply(probs, 1, which.max)]
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    probs <- vbmp::predictCPP(modelFit, newdata)
-                    colnames(probs) <- modelFit$obsLevels
-                    probs
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("Gaussian Process", "Bayesian Model", "Radial Basis Function"),
-                  sort = function(x) x)
+    vbmp::vbmp(
+      x,
+      as.numeric(y),
+      theta = theta,
+      control = ctl,
+      X.TEST = x[1, ],
+      t.class.TEST = as.numeric(y)[1]
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    probs <- vbmp::predictCPP(modelFit, newdata)
+    modelFit$obsLevels[apply(probs, 1, which.max)]
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    probs <- vbmp::predictCPP(modelFit, newdata)
+    colnames(probs) <- modelFit$obsLevels
+    probs
+  },
+  levels = function(x) x$obsLevels,
+  tags = c("Gaussian Process", "Bayesian Model", "Radial Basis Function"),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/vglmAdjCat.R
+++ b/inst/model_sources/files/vglmAdjCat.R
@@ -36,10 +36,10 @@ modelInfo <- list(
     )
 
     ## Set up data
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
 
@@ -109,7 +109,11 @@ modelInfo <- list(
   varImp = NULL,
   predictors = function(x, ...) caret:::predictors.terms(x@terms$terms),
   levels = function(x) {
-    if (any(names(x) == "obsLevels")) x$obsLevels else NULL
+    if (any(names(x) == "obsLevels")) {
+      x$obsLevels
+    } else {
+      NULL
+    }
   },
   tags = c(
     "Logistic Regression",

--- a/inst/model_sources/files/vglmAdjCat.R
+++ b/inst/model_sources/files/vglmAdjCat.R
@@ -3,66 +3,104 @@ modelInfo <- list(
   library = "VGAM",
   loop = NULL,
   type = "Classification",
-  parameters = data.frame(parameter = c("parallel", "link"),
-                          class = c("logical", "character"),
-                          label = c("Parallel Curves", "Link Function")),
+  parameters = data.frame(
+    parameter = c("parallel", "link"),
+    class = c("logical", "character"),
+    label = c("Parallel Curves", "Link Function")
+  ),
   grid = function(x, y, len = NULL, search = "grid") {
     links <- c("loge")
-    if(search == "grid") {
+    if (search == "grid") {
       out <- expand.grid(parallel = c(TRUE, FALSE), link = links)
     } else {
-      out <- data.frame(parallel = sample(c(TRUE, FALSE), size = len, replace = TRUE),
-                        link = sample(links, size = len, replace = TRUE))
+      out <- data.frame(
+        parallel = sample(c(TRUE, FALSE), size = len, replace = TRUE),
+        link = sample(links, size = len, replace = TRUE)
+      )
     }
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
     theDots <- list(...)
-    if(any(names(theDots) == "family")) {
-      stop(paste("The `family` argument cannot be pass from `train` to `vglm`.",
-                 "If you need to change the values of `reverse`, multiple.responses`",
-                 "or `whitespace` you will have to use a custom model (see",
-                 "http://topepo.github.io/caret/custom_models.html for details)."))
+    if (any(names(theDots) == "family")) {
+      stop(paste(
+        "The `family` argument cannot be pass from `train` to `vglm`.",
+        "If you need to change the values of `reverse`, multiple.responses`",
+        "or `whitespace` you will have to use a custom model (see",
+        "http://topepo.github.io/caret/custom_models.html for details)."
+      ))
     }
 
-    fam <- do.call(VGAM::cumulative, list(link = as.character(param$link), parallel = param$parallel))
+    fam <- do.call(
+      VGAM::cumulative,
+      list(link = as.character(param$link), parallel = param$parallel)
+    )
 
     ## Set up data
-    dat <- if (is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
     dat$.outcome <- y
 
     ## you can't programatically pass argments to `vglm`. This solution is from
     ## the pakcage maintainer T Yee on 4/15/16:
     ## Pass in model weights, if any
     if (!is.null(wts)) {
-      run_this <- eval(substitute(expression({
-        paste("VGAM::vglm(.outcome ~ ., ",
-              "VGAM::acat(link = '",  .lnk , "', ",
-              "parallel = ", .par ,
-              "), ",
-              "data = dat)", sep = "")}),
-        list(.par = param$parallel, .lnk = as.character(param$link))))
+      run_this <- eval(substitute(
+        expression({
+          paste(
+            "VGAM::vglm(.outcome ~ ., ",
+            "VGAM::acat(link = '",
+            .lnk,
+            "', ",
+            "parallel = ",
+            .par,
+            "), ",
+            "data = dat)",
+            sep = ""
+          )
+        }),
+        list(.par = param$parallel, .lnk = as.character(param$link))
+      ))
       run_this <- eval(run_this)
       out <- eval(parse(text = run_this))
     } else {
-      run_this <- eval(substitute(expression({
-        paste("VGAM::vglm(.outcome ~ ., ",
-              "VGAM::acat(link = '",  .lnk , "', ",
-              "parallel = ", .par ,
-              "), weights = wts,",
-              "data = dat)", sep = "")}),
-        list(.par = param$parallel, .lnk = as.character(param$link))))
+      run_this <- eval(substitute(
+        expression({
+          paste(
+            "VGAM::vglm(.outcome ~ ., ",
+            "VGAM::acat(link = '",
+            .lnk,
+            "', ",
+            "parallel = ",
+            .par,
+            "), weights = wts,",
+            "data = dat)",
+            sep = ""
+          )
+        }),
+        list(.par = param$parallel, .lnk = as.character(param$link))
+      ))
       run_this <- eval(run_this)
       out <- eval(parse(text = run_this))
     }
     out
   },
   predict = function(modelFit, newdata, preProc = NULL, submodels = NULL) {
-    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
     out <- VGAM::predictvglm(modelFit, newdata = newdata, type = "response")
-    ordered(modelFit@misc$ynames[apply(out, 1, which.max)], levels = modelFit@misc$ynames)
-    },
-  prob = function(modelFit, newdata, preProc = NULL, submodels = NULL){
-    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    ordered(
+      modelFit@misc$ynames[apply(out, 1, which.max)],
+      levels = modelFit@misc$ynames
+    )
+  },
+  prob = function(modelFit, newdata, preProc = NULL, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
     out <- VGAM::predictvglm(modelFit, newdata = newdata, type = "response")
     out <- as.data.frame(out, stringsAsFactors = TRUE)
     names(out) <- modelFit@misc$ynames
@@ -70,7 +108,14 @@ modelInfo <- list(
   },
   varImp = NULL,
   predictors = function(x, ...) caret:::predictors.terms(x@terms$terms),
-  levels = function(x)
-    if (any(names(x) == "obsLevels")) x$obsLevels else NULL,
-  tags = c("Logistic Regression", "Linear Classifier", "Accepts Case Weights", "Ordinal Outcomes"),
-  sort = function(x) x)
+  levels = function(x) {
+    if (any(names(x) == "obsLevels")) x$obsLevels else NULL
+  },
+  tags = c(
+    "Logistic Regression",
+    "Linear Classifier",
+    "Accepts Case Weights",
+    "Ordinal Outcomes"
+  ),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/vglmContRatio.R
+++ b/inst/model_sources/files/vglmContRatio.R
@@ -36,10 +36,10 @@ modelInfo <- list(
     )
 
     ## Set up data
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
 
@@ -109,7 +109,11 @@ modelInfo <- list(
   varImp = NULL,
   predictors = function(x, ...) caret:::predictors.terms(x@terms$terms),
   levels = function(x) {
-    if (any(names(x) == "obsLevels")) x$obsLevels else NULL
+    if (any(names(x) == "obsLevels")) {
+      x$obsLevels
+    } else {
+      NULL
+    }
   },
   tags = c(
     "Logistic Regression",

--- a/inst/model_sources/files/vglmContRatio.R
+++ b/inst/model_sources/files/vglmContRatio.R
@@ -3,66 +3,104 @@ modelInfo <- list(
   library = "VGAM",
   loop = NULL,
   type = "Classification",
-  parameters = data.frame(parameter = c("parallel", "link"),
-                          class = c("logical", "character"),
-                          label = c("Parallel Curves", "Link Function")),
+  parameters = data.frame(
+    parameter = c("parallel", "link"),
+    class = c("logical", "character"),
+    label = c("Parallel Curves", "Link Function")
+  ),
   grid = function(x, y, len = NULL, search = "grid") {
     links <- c("logit", "probit", "cloglog", "cauchit", "logc")
-    if(search == "grid") {
+    if (search == "grid") {
       out <- expand.grid(parallel = c(TRUE, FALSE), link = links)
     } else {
-      out <- data.frame(parallel = sample(c(TRUE, FALSE), size = len, replace = TRUE),
-                        link = sample(links, size = len, replace = TRUE))
+      out <- data.frame(
+        parallel = sample(c(TRUE, FALSE), size = len, replace = TRUE),
+        link = sample(links, size = len, replace = TRUE)
+      )
     }
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
     theDots <- list(...)
-    if(any(names(theDots) == "family")) {
-      stop(paste("The `family` argument cannot be pass from `train` to `vglm`.",
-                 "If you need to change the values of `reverse`",
-                 "or `whitespace` you will have to use a custom model (see",
-                 "http://topepo.github.io/caret/custom_models.html for details)."))
+    if (any(names(theDots) == "family")) {
+      stop(paste(
+        "The `family` argument cannot be pass from `train` to `vglm`.",
+        "If you need to change the values of `reverse`",
+        "or `whitespace` you will have to use a custom model (see",
+        "http://topepo.github.io/caret/custom_models.html for details)."
+      ))
     }
 
-    fam <- do.call(VGAM::cumulative, list(link = as.character(param$link), parallel = param$parallel))
+    fam <- do.call(
+      VGAM::cumulative,
+      list(link = as.character(param$link), parallel = param$parallel)
+    )
 
     ## Set up data
-    dat <- if (is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
     dat$.outcome <- y
 
     ## you can't programatically pass argments to `vglm`. This solution is from
     ## the pakcage maintainer T Yee on 4/15/16:
     ## Pass in model weights, if any
     if (!is.null(wts)) {
-      run_this <- eval(substitute(expression({
-        paste("VGAM::vglm(.outcome ~ ., ",
-              "VGAM::cratio(link = '",  .lnk , "', ",
-              "parallel = ", .par ,
-              "), ",
-              "data = dat)", sep = "")}),
-        list(.par = param$parallel, .lnk = as.character(param$link))))
+      run_this <- eval(substitute(
+        expression({
+          paste(
+            "VGAM::vglm(.outcome ~ ., ",
+            "VGAM::cratio(link = '",
+            .lnk,
+            "', ",
+            "parallel = ",
+            .par,
+            "), ",
+            "data = dat)",
+            sep = ""
+          )
+        }),
+        list(.par = param$parallel, .lnk = as.character(param$link))
+      ))
       run_this <- eval(run_this)
       out <- eval(parse(text = run_this))
     } else {
-      run_this <- eval(substitute(expression({
-        paste("VGAM::vglm(.outcome ~ ., ",
-              "VGAM::cratio(link = '",  .lnk , "', ",
-              "parallel = ", .par ,
-              "), weights = wts,",
-              "data = dat)", sep = "")}),
-        list(.par = param$parallel, .lnk = as.character(param$link))))
+      run_this <- eval(substitute(
+        expression({
+          paste(
+            "VGAM::vglm(.outcome ~ ., ",
+            "VGAM::cratio(link = '",
+            .lnk,
+            "', ",
+            "parallel = ",
+            .par,
+            "), weights = wts,",
+            "data = dat)",
+            sep = ""
+          )
+        }),
+        list(.par = param$parallel, .lnk = as.character(param$link))
+      ))
       run_this <- eval(run_this)
       out <- eval(parse(text = run_this))
     }
     out
   },
   predict = function(modelFit, newdata, preProc = NULL, submodels = NULL) {
-    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
     out <- VGAM::predictvglm(modelFit, newdata = newdata, type = "response")
-    ordered(modelFit@misc$ynames[apply(out, 1, which.max)], levels = modelFit@misc$ynames)
-    },
-  prob = function(modelFit, newdata, preProc = NULL, submodels = NULL){
-    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    ordered(
+      modelFit@misc$ynames[apply(out, 1, which.max)],
+      levels = modelFit@misc$ynames
+    )
+  },
+  prob = function(modelFit, newdata, preProc = NULL, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
     out <- VGAM::predictvglm(modelFit, newdata = newdata, type = "response")
     out <- as.data.frame(out, stringsAsFactors = TRUE)
     names(out) <- modelFit@misc$ynames
@@ -70,7 +108,14 @@ modelInfo <- list(
   },
   varImp = NULL,
   predictors = function(x, ...) caret:::predictors.terms(x@terms$terms),
-  levels = function(x)
-    if (any(names(x) == "obsLevels")) x$obsLevels else NULL,
-  tags = c("Logistic Regression", "Linear Classifier", "Accepts Case Weights", "Ordinal Outcomes"),
-  sort = function(x) x)
+  levels = function(x) {
+    if (any(names(x) == "obsLevels")) x$obsLevels else NULL
+  },
+  tags = c(
+    "Logistic Regression",
+    "Linear Classifier",
+    "Accepts Case Weights",
+    "Ordinal Outcomes"
+  ),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/vglmCumulative.R
+++ b/inst/model_sources/files/vglmCumulative.R
@@ -36,10 +36,10 @@ modelInfo <- list(
     )
 
     ## Set up data
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
 
@@ -109,7 +109,11 @@ modelInfo <- list(
   varImp = NULL,
   predictors = function(x, ...) caret:::predictors.terms(x@terms$terms),
   levels = function(x) {
-    if (any(names(x) == "obsLevels")) x$obsLevels else NULL
+    if (any(names(x) == "obsLevels")) {
+      x$obsLevels
+    } else {
+      NULL
+    }
   },
   tags = c(
     "Logistic Regression",

--- a/inst/model_sources/files/vglmCumulative.R
+++ b/inst/model_sources/files/vglmCumulative.R
@@ -3,66 +3,104 @@ modelInfo <- list(
   library = "VGAM",
   loop = NULL,
   type = "Classification",
-  parameters = data.frame(parameter = c("parallel", "link"),
-                          class = c("logical", "character"),
-                          label = c("Parallel Curves", "Link Function")),
+  parameters = data.frame(
+    parameter = c("parallel", "link"),
+    class = c("logical", "character"),
+    label = c("Parallel Curves", "Link Function")
+  ),
   grid = function(x, y, len = NULL, search = "grid") {
     links <- c("logit", "probit", "cloglog", "cauchit", "logc")
-    if(search == "grid") {
+    if (search == "grid") {
       out <- expand.grid(parallel = c(TRUE, FALSE), link = links)
     } else {
-      out <- data.frame(parallel = sample(c(TRUE, FALSE), size = len, replace = TRUE),
-                        link = sample(links, size = len, replace = TRUE))
+      out <- data.frame(
+        parallel = sample(c(TRUE, FALSE), size = len, replace = TRUE),
+        link = sample(links, size = len, replace = TRUE)
+      )
     }
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
     theDots <- list(...)
-    if(any(names(theDots) == "family")) {
-      stop(paste("The `family` argument cannot be pass from `train` to `vglm`.",
-                 "If you need to change the values of `reverse`, multiple.responses`",
-                 "or `whitespace` you will have to use a custom model (see",
-                 "http://topepo.github.io/caret/custom_models.html for details)."))
+    if (any(names(theDots) == "family")) {
+      stop(paste(
+        "The `family` argument cannot be pass from `train` to `vglm`.",
+        "If you need to change the values of `reverse`, multiple.responses`",
+        "or `whitespace` you will have to use a custom model (see",
+        "http://topepo.github.io/caret/custom_models.html for details)."
+      ))
     }
 
-    fam <- do.call(VGAM::cumulative, list(link = as.character(param$link), parallel = param$parallel))
+    fam <- do.call(
+      VGAM::cumulative,
+      list(link = as.character(param$link), parallel = param$parallel)
+    )
 
     ## Set up data
-    dat <- if (is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
     dat$.outcome <- y
 
     ## you can't programatically pass argments to `vglm`. This solution is from
     ## the pakcage maintainer T Yee on 4/15/16:
     ## Pass in model weights, if any
     if (!is.null(wts)) {
-      run_this <- eval(substitute(expression({
-        paste("VGAM::vglm(.outcome ~ ., ",
-              "VGAM::cumulative(link = '",  .lnk , "', ",
-              "parallel = ", .par ,
-              "), ",
-              "data = dat)", sep = "")}),
-        list(.par = param$parallel, .lnk = as.character(param$link))))
+      run_this <- eval(substitute(
+        expression({
+          paste(
+            "VGAM::vglm(.outcome ~ ., ",
+            "VGAM::cumulative(link = '",
+            .lnk,
+            "', ",
+            "parallel = ",
+            .par,
+            "), ",
+            "data = dat)",
+            sep = ""
+          )
+        }),
+        list(.par = param$parallel, .lnk = as.character(param$link))
+      ))
       run_this <- eval(run_this)
       out <- eval(parse(text = run_this))
     } else {
-      run_this <- eval(substitute(expression({
-        paste("VGAM::vglm(.outcome ~ ., ",
-              "VGAM::cumulative(link = '",  .lnk , "', ",
-              "parallel = ", .par ,
-              "), weights = wts,",
-              "data = dat)", sep = "")}),
-        list(.par = param$parallel, .lnk = as.character(param$link))))
+      run_this <- eval(substitute(
+        expression({
+          paste(
+            "VGAM::vglm(.outcome ~ ., ",
+            "VGAM::cumulative(link = '",
+            .lnk,
+            "', ",
+            "parallel = ",
+            .par,
+            "), weights = wts,",
+            "data = dat)",
+            sep = ""
+          )
+        }),
+        list(.par = param$parallel, .lnk = as.character(param$link))
+      ))
       run_this <- eval(run_this)
       out <- eval(parse(text = run_this))
     }
     out
   },
   predict = function(modelFit, newdata, preProc = NULL, submodels = NULL) {
-    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
     out <- VGAM::predictvglm(modelFit, newdata = newdata, type = "response")
-    ordered(modelFit@misc$ynames[apply(out, 1, which.max)], levels = modelFit@misc$ynames)
-    },
-  prob = function(modelFit, newdata, preProc = NULL, submodels = NULL){
-    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    ordered(
+      modelFit@misc$ynames[apply(out, 1, which.max)],
+      levels = modelFit@misc$ynames
+    )
+  },
+  prob = function(modelFit, newdata, preProc = NULL, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
     out <- VGAM::predictvglm(modelFit, newdata = newdata, type = "response")
     out <- as.data.frame(out, stringsAsFactors = TRUE)
     names(out) <- modelFit@misc$ynames
@@ -70,7 +108,14 @@ modelInfo <- list(
   },
   varImp = NULL,
   predictors = function(x, ...) caret:::predictors.terms(x@terms$terms),
-  levels = function(x)
-    if (any(names(x) == "obsLevels")) x$obsLevels else NULL,
-  tags = c("Logistic Regression", "Linear Classifier", "Accepts Case Weights", "Ordinal Outcomes"),
-  sort = function(x) x)
+  levels = function(x) {
+    if (any(names(x) == "obsLevels")) x$obsLevels else NULL
+  },
+  tags = c(
+    "Logistic Regression",
+    "Linear Classifier",
+    "Accepts Case Weights",
+    "Ordinal Outcomes"
+  ),
+  sort = function(x) x
+)

--- a/inst/model_sources/files/widekernelpls.R
+++ b/inst/model_sources/files/widekernelpls.R
@@ -25,16 +25,16 @@ modelInfo <- list(
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
     ncomp <- min(ncol(x), param$ncomp)
-    out <- if (is.factor(y)) {
-      caret::plsda(x, y, method = "widekernelpls", ncomp = ncomp, ...)
+    if (is.factor(y)) {
+      out <- caret::plsda(x, y, method = "widekernelpls", ncomp = ncomp, ...)
     } else {
-      dat <- if (is.data.frame(x)) {
-        x
+      if (is.data.frame(x)) {
+        dat <- x
       } else {
-        as.data.frame(x, stringsAsFactors = TRUE)
+        dat <- as.data.frame(x, stringsAsFactors = TRUE)
       }
       dat$.outcome <- y
-      pls::plsr(
+      out <- pls::plsr(
         .outcome ~ .,
         data = dat,
         method = "widekernelpls",
@@ -45,13 +45,13 @@ modelInfo <- list(
     out
   },
   predict = function(modelFit, newdata, submodels = NULL) {
-    out <- if (modelFit$problemType == "Classification") {
+    if (modelFit$problemType == "Classification") {
       if (!is.matrix(newdata)) {
         newdata <- as.matrix(newdata)
       }
       out <- predict(modelFit, newdata, type = "class")
     } else {
-      as.vector(pls:::predict.mvr(
+      out <- as.vector(pls:::predict.mvr(
         modelFit,
         newdata,
         ncomp = max(modelFit$ncomp)
@@ -136,7 +136,11 @@ modelInfo <- list(
 
     nms <- dimnames(perf)
     if (length(nms$estimate) > 1) {
-      pIndex <- if (is.null(estimate)) 1 else which(nms$estimate == estimate)
+      if (is.null(estimate)) {
+        pIndex <- 1
+      } else {
+        pIndex <- which(nms$estimate == estimate)
+      }
       perf <- perf[pIndex, , , drop = FALSE]
     }
     numResp <- dim(modelCoef)[2]

--- a/inst/model_sources/files/widekernelpls.R
+++ b/inst/model_sources/files/widekernelpls.R
@@ -1,130 +1,174 @@
-modelInfo <- list(label = "Partial Least Squares",
-                  library = "pls",
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = 'ncomp',
-                                          class = "numeric",
-                                          label = '#Components'),
-                  grid = function(x, y, len = NULL, search = "grid")  {
-                    if(search == "grid") {
-                      out <- data.frame(ncomp = seq(1, min(ncol(x) - 1, len), by = 1))
-                    } else {
-                      out <- data.frame(ncomp = unique(sample(1:(ncol(x)-1), size = len, replace = TRUE)))
-                    }
-                    out
-                  },
-                  loop = function(grid) {
-                    grid <- grid[order(grid$ncomp, decreasing = TRUE),, drop = FALSE]
-                    loop <- grid[1,,drop = FALSE]
-                    submodels <- list(grid[-1,,drop = FALSE])
-                    list(loop = loop, submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    ncomp <- min(ncol(x), param$ncomp)
-                    out <- if(is.factor(y))
-                    {
-                      caret::plsda(x, y, method = "widekernelpls", ncomp = ncomp, ...)
-                    } else {
-                      dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                      dat$.outcome <- y
-                      pls::plsr(.outcome ~ ., data = dat, method = "widekernelpls", ncomp = ncomp, ...)
-                    }
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- if(modelFit$problemType == "Classification")
-                    {
-                      if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                      out <- predict(modelFit, newdata, type="class")
+modelInfo <- list(
+  label = "Partial Least Squares",
+  library = "pls",
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = 'ncomp',
+    class = "numeric",
+    label = '#Components'
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(ncomp = seq(1, min(ncol(x) - 1, len), by = 1))
+    } else {
+      out <- data.frame(
+        ncomp = unique(sample(1:(ncol(x) - 1), size = len, replace = TRUE))
+      )
+    }
+    out
+  },
+  loop = function(grid) {
+    grid <- grid[order(grid$ncomp, decreasing = TRUE), , drop = FALSE]
+    loop <- grid[1, , drop = FALSE]
+    submodels <- list(grid[-1, , drop = FALSE])
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    ncomp <- min(ncol(x), param$ncomp)
+    out <- if (is.factor(y)) {
+      caret::plsda(x, y, method = "widekernelpls", ncomp = ncomp, ...)
+    } else {
+      dat <- if (is.data.frame(x)) {
+        x
+      } else {
+        as.data.frame(x, stringsAsFactors = TRUE)
+      }
+      dat$.outcome <- y
+      pls::plsr(
+        .outcome ~ .,
+        data = dat,
+        method = "widekernelpls",
+        ncomp = ncomp,
+        ...
+      )
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- if (modelFit$problemType == "Classification") {
+      if (!is.matrix(newdata)) {
+        newdata <- as.matrix(newdata)
+      }
+      out <- predict(modelFit, newdata, type = "class")
+    } else {
+      as.vector(pls:::predict.mvr(
+        modelFit,
+        newdata,
+        ncomp = max(modelFit$ncomp)
+      ))
+    }
 
-                    } else as.vector(pls:::predict.mvr(modelFit, newdata, ncomp = max(modelFit$ncomp)))
+    if (!is.null(submodels)) {
+      ## We'll merge the first set of predictions below
+      tmp <- vector(mode = "list", length = nrow(submodels))
 
-                    if(!is.null(submodels))
-                    {
-                      ## We'll merge the first set of predictions below
-                      tmp <- vector(mode = "list", length = nrow(submodels))
+      if (modelFit$problemType == "Classification") {
+        if (length(submodels$ncomp) > 1) {
+          tmp <- as.list(predict(modelFit, newdata, ncomp = submodels$ncomp))
+        } else {
+          tmp <- list(predict(modelFit, newdata, ncomp = submodels$ncomp))
+        }
+      } else {
+        tmp <- as.list(
+          as.data.frame(
+            apply(
+              predict(modelFit, newdata, ncomp = submodels$ncomp),
+              3,
+              function(x) list(x)
+            )
+          )
+        )
+      }
 
-                      if(modelFit$problemType == "Classification")
-                      {
-                        if(length(submodels$ncomp) > 1)
-                        {
-                          tmp <- as.list(predict(modelFit, newdata, ncomp = submodels$ncomp))
-                        } else tmp <- list(predict(modelFit, newdata, ncomp = submodels$ncomp))
+      out <- c(list(out), tmp)
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.matrix(newdata)) {
+      newdata <- as.matrix(newdata)
+    }
+    out <- predict(
+      modelFit,
+      newdata,
+      type = "prob",
+      ncomp = modelFit$tuneValue$ncomp
+    )
+    if (length(dim(out)) == 3) {
+      if (dim(out)[1] > 1) {
+        out <- out[,, 1]
+      } else {
+        out <- as.data.frame(t(out[,, 1]), stringsAsFactors = TRUE)
+      }
+    }
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
 
-                      } else {
-                        tmp <- as.list(
-                          as.data.frame(
-                            apply(predict(modelFit, newdata, ncomp = submodels$ncomp), 3, function(x) list(x))))
-                      }
+      for (j in seq(along = submodels$ncomp)) {
+        tmpProb <- predict(
+          modelFit,
+          newdata,
+          type = "prob",
+          ncomp = submodels$ncomp[j]
+        )
+        if (length(dim(tmpProb)) == 3) {
+          if (dim(tmpProb)[1] > 1) {
+            tmpProb <- tmpProb[,, 1]
+          } else {
+            tmpProb <- as.data.frame(t(tmpProb[,, 1]), stringsAsFactors = TRUE)
+          }
+        }
+        tmp[[j + 1]] <- as.data.frame(
+          tmpProb[, modelFit$obsLevels, drop = FALSE],
+          stringsAsFactors = TRUE
+        )
+      }
+      out <- tmp
+    }
+    out
+  },
+  predictors = function(x, ...) rownames(x$projection),
+  varImp = function(object, estimate = NULL, ...) {
+    library(pls)
+    modelCoef <- coef(object, intercept = FALSE, comps = 1:object$ncomp)
+    perf <- pls:::MSEP.mvr(object)$val
 
-                      out <- c(list(out), tmp)
-                    }
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.matrix(newdata)) newdata <- as.matrix(newdata)
-                    out <- predict(modelFit, newdata, type = "prob",  ncomp = modelFit$tuneValue$ncomp)
-                    if(length(dim(out)) == 3){
-                      if(dim(out)[1] > 1) {
-                        out <- out[,,1]
-                      } else {
-                        out <- as.data.frame(t(out[,,1]), stringsAsFactors = TRUE)
-                      }
-                    }
-                    if(!is.null(submodels))
-                    {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
+    nms <- dimnames(perf)
+    if (length(nms$estimate) > 1) {
+      pIndex <- if (is.null(estimate)) 1 else which(nms$estimate == estimate)
+      perf <- perf[pIndex, , , drop = FALSE]
+    }
+    numResp <- dim(modelCoef)[2]
 
-                      for(j in seq(along = submodels$ncomp))
-                      {
-                        tmpProb <- predict(modelFit, newdata, type = "prob",  ncomp = submodels$ncomp[j])
-                        if(length(dim(tmpProb)) == 3){
-                          if(dim(tmpProb)[1] > 1) {
-                            tmpProb <- tmpProb[,,1]
-                          } else {
-                            tmpProb <- as.data.frame(t(tmpProb[,,1]), stringsAsFactors = TRUE)
-                          }
-                        }
-                        tmp[[j+1]] <- as.data.frame(tmpProb[, modelFit$obsLevels, drop = FALSE], stringsAsFactors = TRUE)
-                      }
-                      out <- tmp
-                    }
-                    out
-                  },
-                  predictors = function(x, ...) rownames(x$projection),
-                  varImp = function(object, estimate = NULL, ...) {
-                  	library(pls)
-                    modelCoef <- coef(object, intercept = FALSE, comps = 1:object$ncomp)
-                    perf <- pls:::MSEP.mvr(object)$val
+    if (numResp <= 2) {
+      modelCoef <- modelCoef[, 1, , drop = FALSE]
+      perf <- perf[, 1, ]
+      delta <- -diff(perf)
+      delta <- delta / sum(delta)
+      out <- data.frame(
+        Overall = apply(abs(modelCoef), 1, weighted.mean, w = delta)
+      )
+    } else {
+      perf <- -t(apply(perf[1, , ], 1, diff))
+      perf <- t(apply(perf, 1, function(u) u / sum(u)))
+      out <- matrix(NA, ncol = numResp, nrow = dim(modelCoef)[1])
 
-                    nms <- dimnames(perf)
-                    if(length(nms$estimate) > 1) {
-                      pIndex <- if(is.null(estimate)) 1 else which(nms$estimate == estimate)
-                      perf <- perf[pIndex,,,drop = FALSE]
-                    }
-                    numResp <- dim(modelCoef)[2]
-
-                    if(numResp <= 2) {
-                      modelCoef <- modelCoef[,1,,drop = FALSE]
-                      perf <- perf[,1,]
-                      delta <- -diff(perf)
-                      delta <- delta/sum(delta)
-                      out <- data.frame(Overall = apply(abs(modelCoef), 1,
-                                                        weighted.mean, w = delta))
-                    } else {
-                      perf <- -t(apply(perf[1,,], 1, diff))
-                      perf <- t(apply(perf, 1, function(u) u/sum(u)))
-                      out <- matrix(NA, ncol = numResp, nrow = dim(modelCoef)[1])
-
-                      for(i in 1:numResp) {
-                        tmp <- abs(modelCoef[,i,, drop = FALSE])
-                        out[,i] <- apply(tmp, 1,  weighted.mean, w = perf[i,])
-                      }
-                      colnames(out) <- dimnames(modelCoef)[[2]]
-                      rownames(out) <- dimnames(modelCoef)[[1]]
-                    }
-                    as.data.frame(out, stringsAsFactors = TRUE)
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("Partial Least Squares", "Feature Extraction", "Linear Classifier", "Linear Regression"),
-                  sort = function(x) x[order(x[,1]),])
+      for (i in 1:numResp) {
+        tmp <- abs(modelCoef[, i, , drop = FALSE])
+        out[, i] <- apply(tmp, 1, weighted.mean, w = perf[i, ])
+      }
+      colnames(out) <- dimnames(modelCoef)[[2]]
+      rownames(out) <- dimnames(modelCoef)[[1]]
+    }
+    as.data.frame(out, stringsAsFactors = TRUE)
+  },
+  levels = function(x) x$obsLevels,
+  tags = c(
+    "Partial Least Squares",
+    "Feature Extraction",
+    "Linear Classifier",
+    "Linear Regression"
+  ),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/wsrf.R
+++ b/inst/model_sources/files/wsrf.R
@@ -25,10 +25,10 @@ modelInfo <- list(
     out
   },
   fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-    dat <- if (is.data.frame(x)) {
-      x
+    if (is.data.frame(x)) {
+      dat <- x
     } else {
-      as.data.frame(x, stringsAsFactors = TRUE)
+      dat <- as.data.frame(x, stringsAsFactors = TRUE)
     }
     dat$.outcome <- y
     wsrf::wsrf(.outcome ~ ., data = dat, mtry = min(param$mtry, ncol(x)), ...)

--- a/inst/model_sources/files/wsrf.R
+++ b/inst/model_sources/files/wsrf.R
@@ -1,35 +1,58 @@
-modelInfo <- list(label = "Weighted Subspace Random Forest",
-                  library = "wsrf",
-                  loop = NULL,
-                  type = c("Classification"),
-                  parameters = data.frame(parameter = "mtry",
-                                          class = "numeric",
-                                          label = "#Randomly Selected Predictors"),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- data.frame(mtry = caret::var_seq(p = ncol(x),
-                                                              classification = is.factor(y),
-                                                              len = len))
-                    } else {
-                      out <- data.frame(mtry = unique(sample(1:ncol(x), size = len, replace = TRUE)))
-                    }
-                    out
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    dat <- if(is.data.frame(x)) x else as.data.frame(x, stringsAsFactors = TRUE)
-                    dat$.outcome <- y
-                    wsrf::wsrf(.outcome ~ ., data = dat, mtry = min(param$mtry, ncol(x)), ...)
-                    },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata)$class
-                    },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!is.data.frame(newdata)) newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
-                    predict(modelFit, newdata, type = "prob")$prob
-                    },
-                  predictors = function(x, ...) x$xNames,
-                  varImp = NULL,
-                  levels = function(x) x$obsLevels,
-                  tags = c("Random Forest", "Ensemble Model", "Bagging", "Implicit Feature Selection"),
-                  sort = function(x) x[order(x[,1]),])
+modelInfo <- list(
+  label = "Weighted Subspace Random Forest",
+  library = "wsrf",
+  loop = NULL,
+  type = c("Classification"),
+  parameters = data.frame(
+    parameter = "mtry",
+    class = "numeric",
+    label = "#Randomly Selected Predictors"
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- data.frame(
+        mtry = caret::var_seq(
+          p = ncol(x),
+          classification = is.factor(y),
+          len = len
+        )
+      )
+    } else {
+      out <- data.frame(
+        mtry = unique(sample(1:ncol(x), size = len, replace = TRUE))
+      )
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    dat <- if (is.data.frame(x)) {
+      x
+    } else {
+      as.data.frame(x, stringsAsFactors = TRUE)
+    }
+    dat$.outcome <- y
+    wsrf::wsrf(.outcome ~ ., data = dat, mtry = min(param$mtry, ncol(x)), ...)
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata)$class
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!is.data.frame(newdata)) {
+      newdata <- as.data.frame(newdata, stringsAsFactors = TRUE)
+    }
+    predict(modelFit, newdata, type = "prob")$prob
+  },
+  predictors = function(x, ...) x$xNames,
+  varImp = NULL,
+  levels = function(x) x$obsLevels,
+  tags = c(
+    "Random Forest",
+    "Ensemble Model",
+    "Bagging",
+    "Implicit Feature Selection"
+  ),
+  sort = function(x) x[order(x[, 1]), ]
+)

--- a/inst/model_sources/files/xgbDART.R
+++ b/inst/model_sources/files/xgbDART.R
@@ -1,260 +1,342 @@
 #xgbDART
-modelInfo <- list(label = "eXtreme Gradient Boosting",
-                  library = c("xgboost", "plyr"),
-                  check = function(pkg) {
-                    requireNamespace("xgboost")
-                    current <- packageDescription("xgboost")$Version
-                    expected <- "0.6.4"
-                    if(compareVersion(current, expected) < 0)
-                      stop("This modeling workflow requires xgboost version ",
-                           expected, " or greater. Consider using the drat repo.", call. = FALSE)
-                  },
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c("nrounds",
-                                                        "max_depth",
-                                                        "eta",
-                                                        "gamma",
-                                                        "subsample",
-                                                        "colsample_bytree",
-                                                        "rate_drop",
-                                                        "skip_drop",
-                                                        "min_child_weight"),
-                                          class = c(rep("numeric", 9)),
-                                          label = c("# Boosting Iterations",
-                                                    "Max Tree Depth",
-                                                    "Shrinkage",
-                                                    "Minimum Loss Reduction",
-                                                    "Subsample Percentage",
-                                                    "Subsample Ratio of Columns",
-                                                    "Fraction of Trees Dropped",
-                                                    "Prob. of Skipping Drop-out",
-                                                    "Minimum Sum of Instance Weight")),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(nrounds = floor((1:len) * 50),
-                                         max_depth = seq(1, len),
-                                         eta = c(0.3, 0.4), # "Usually" one should be the lowest possible
-                                         gamma = 0,
-                                         subsample = seq(.5, 1, length = len),
-                                         colsample_bytree = c(0.6, 0.8),
-                                         rate_drop = c(0.01, 0.50),
-                                         skip_drop = c(0.05, 0.95),
-                                         min_child_weight = c(1))
-                    } else {
-                      out <- data.frame(nrounds = sample(1:1000, size = len, replace = TRUE),
-                                        max_depth = sample(1:10, replace = TRUE, size = len),
-                                        eta = runif(len, min = 0.001, max = 0.6),
-                                        gamma = runif(len, min = 0.0, max = 10.0),
-                                        subsample = runif(len, min = 0.25, max = 1.00),
-                                        colsample_bytree = runif(len, min = 0.30, max = 0.70),
-                                        rate_drop = runif(len, min = 0.01, max = 0.50),
-                                        skip_drop = runif(len, min = 0.05, max = 0.95),
-                                        min_child_weight = sample(0:20, size = len, replace = TRUE))
-                      out$nrounds <- floor(out$nrounds)
-                    }
-                    out
-                  },
-                  loop = function(grid) {
-                    loop <- plyr::ddply(grid, c( "max_depth", "eta",            "rate_drop",
-                                                 "skip_drop", "min_child_weight",
-                                                 "subsample", "colsample_bytree", "gamma"),
-                                        function(x) c(nrounds = max(x$nrounds)))
-                    submodels <- vector(mode = "list", length = nrow(loop))
-                    for(i in seq(along = loop$nrounds)) {
-                      index <- which(grid$max_depth == loop$max_depth[i] &
-                                       grid$eta == loop$eta[i] &
-                                       grid$gamma == loop$gamma[i] &
-                                       grid$subsample == loop$subsample[i]  &
-                                       grid$colsample_bytree == loop$colsample_bytree[i]  &
-                                       grid$rate_drop == loop$rate_drop[i] &
-                                       grid$skip_drop == loop$skip_drop[i] &
-                                       grid$min_child_weight == loop$min_child_weight[i] )
-                      trees <- grid[index, "nrounds"]
-                      submodels[[i]] <- data.frame(nrounds = trees[trees != loop$nrounds[i]])
-                    }
-                    list(loop = loop, submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    if(!inherits(x, "xgb.DMatrix"))
-                      x <- as.matrix(x)
+modelInfo <- list(
+  label = "eXtreme Gradient Boosting",
+  library = c("xgboost", "plyr"),
+  check = function(pkg) {
+    requireNamespace("xgboost")
+    current <- packageDescription("xgboost")$Version
+    expected <- "0.6.4"
+    if (compareVersion(current, expected) < 0) {
+      stop(
+        "This modeling workflow requires xgboost version ",
+        expected,
+        " or greater. Consider using the drat repo.",
+        call. = FALSE
+      )
+    }
+  },
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c(
+      "nrounds",
+      "max_depth",
+      "eta",
+      "gamma",
+      "subsample",
+      "colsample_bytree",
+      "rate_drop",
+      "skip_drop",
+      "min_child_weight"
+    ),
+    class = c(rep("numeric", 9)),
+    label = c(
+      "# Boosting Iterations",
+      "Max Tree Depth",
+      "Shrinkage",
+      "Minimum Loss Reduction",
+      "Subsample Percentage",
+      "Subsample Ratio of Columns",
+      "Fraction of Trees Dropped",
+      "Prob. of Skipping Drop-out",
+      "Minimum Sum of Instance Weight"
+    )
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        nrounds = floor((1:len) * 50),
+        max_depth = seq(1, len),
+        eta = c(0.3, 0.4), # "Usually" one should be the lowest possible
+        gamma = 0,
+        subsample = seq(.5, 1, length = len),
+        colsample_bytree = c(0.6, 0.8),
+        rate_drop = c(0.01, 0.50),
+        skip_drop = c(0.05, 0.95),
+        min_child_weight = c(1)
+      )
+    } else {
+      out <- data.frame(
+        nrounds = sample(1:1000, size = len, replace = TRUE),
+        max_depth = sample(1:10, replace = TRUE, size = len),
+        eta = runif(len, min = 0.001, max = 0.6),
+        gamma = runif(len, min = 0.0, max = 10.0),
+        subsample = runif(len, min = 0.25, max = 1.00),
+        colsample_bytree = runif(len, min = 0.30, max = 0.70),
+        rate_drop = runif(len, min = 0.01, max = 0.50),
+        skip_drop = runif(len, min = 0.05, max = 0.95),
+        min_child_weight = sample(0:20, size = len, replace = TRUE)
+      )
+      out$nrounds <- floor(out$nrounds)
+    }
+    out
+  },
+  loop = function(grid) {
+    loop <- plyr::ddply(
+      grid,
+      c(
+        "max_depth",
+        "eta",
+        "rate_drop",
+        "skip_drop",
+        "min_child_weight",
+        "subsample",
+        "colsample_bytree",
+        "gamma"
+      ),
+      function(x) c(nrounds = max(x$nrounds))
+    )
+    submodels <- vector(mode = "list", length = nrow(loop))
+    for (i in seq(along = loop$nrounds)) {
+      index <- which(
+        grid$max_depth == loop$max_depth[i] &
+          grid$eta == loop$eta[i] &
+          grid$gamma == loop$gamma[i] &
+          grid$subsample == loop$subsample[i] &
+          grid$colsample_bytree == loop$colsample_bytree[i] &
+          grid$rate_drop == loop$rate_drop[i] &
+          grid$skip_drop == loop$skip_drop[i] &
+          grid$min_child_weight == loop$min_child_weight[i]
+      )
+      trees <- grid[index, "nrounds"]
+      submodels[[i]] <- data.frame(nrounds = trees[trees != loop$nrounds[i]])
+    }
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (!inherits(x, "xgb.DMatrix")) {
+      x <- as.matrix(x)
+    }
 
-                    if(is.factor(y)) {
+    if (is.factor(y)) {
+      if (length(lev) == 2) {
+        y <- ifelse(y == lev[1], 1, 0)
 
-                      if(length(lev) == 2) {
+        if (!inherits(x, "xgb.DMatrix")) {
+          x <- xgboost::xgb.DMatrix(x, label = y, missing = NA)
+        } else {
+          xgboost::setinfo(x, "label", y)
+        }
 
-                        y <- ifelse(y == lev[1], 1, 0)
+        if (!is.null(wts)) {
+          xgboost::setinfo(x, 'weight', wts)
+        }
 
-                        if(!inherits(x, "xgb.DMatrix"))
-                          x <- xgboost::xgb.DMatrix(x, label = y, missing = NA) else
-                            xgboost::setinfo(x, "label", y)
+        out <- xgboost::xgb.train(
+          list(
+            max_depth = param$max_depth,
+            eta = param$eta,
+            rate_drop = param$rate_drop,
+            skip_drop = param$skip_drop,
+            min_child_weight = param$min_child_weight,
+            gamma = param$gamma,
+            subsample = param$subsample,
+            colsample_bytree = param$colsample_bytree
+          ),
+          data = x,
+          nrounds = param$nrounds,
+          objective = "binary:logistic",
+          booster = 'dart',
+          ...
+        )
+      } else {
+        y <- as.numeric(y) - 1
 
-                        if (!is.null(wts))
-                          xgboost::setinfo(x, 'weight', wts)
+        if (!inherits(x, "xgb.DMatrix")) {
+          x <- xgboost::xgb.DMatrix(x, label = y, missing = NA)
+        } else {
+          xgboost::setinfo(x, "label", y)
+        }
 
-                        out <- xgboost::xgb.train(list(max_depth = param$max_depth,
-                                                       eta = param$eta,
-                                                       rate_drop = param$rate_drop,
-                                                       skip_drop = param$skip_drop,
-                                                       min_child_weight = param$min_child_weight,
-                                                       gamma = param$gamma,
-                                                       subsample = param$subsample,
-                                                       colsample_bytree = param$colsample_bytree),
-                                                  data = x,
-                                                  nrounds = param$nrounds,
-                                                  objective = "binary:logistic",
-                                                  booster = 'dart',
-                                                  ...)
-                      } else {
+        if (!is.null(wts)) {
+          xgboost::setinfo(x, 'weight', wts)
+        }
 
-                        y <- as.numeric(y) - 1
+        out <- xgboost::xgb.train(
+          list(
+            max_depth = param$max_depth,
+            eta = param$eta,
+            rate_drop = param$rate_drop,
+            skip_drop = param$skip_drop,
+            min_child_weight = param$min_child_weight,
+            gamma = param$gamma,
+            subsample = param$subsample,
+            colsample_bytree = param$colsample_bytree
+          ),
+          data = x,
+          num_class = length(lev),
+          nrounds = param$nrounds,
+          objective = "multi:softprob",
+          booster = 'dart',
+          ...
+        )
+      }
+    } else {
+      if (!inherits(x, "xgb.DMatrix")) {
+        x <- xgboost::xgb.DMatrix(x, label = y, missing = NA)
+      } else {
+        xgboost::setinfo(x, "label", y)
+      }
 
-                        if(!inherits(x, "xgb.DMatrix"))
-                          x <- xgboost::xgb.DMatrix(x, label = y, missing = NA) else
-                            xgboost::setinfo(x, "label", y)
+      if (!is.null(wts)) {
+        xgboost::setinfo(x, 'weight', wts)
+      }
 
-                        if (!is.null(wts))
-                          xgboost::setinfo(x, 'weight', wts)
+      out <- xgboost::xgb.train(
+        list(
+          max_depth = param$max_depth,
+          eta = param$eta,
+          rate_drop = param$rate_drop,
+          skip_drop = param$skip_drop,
+          min_child_weight = param$min_child_weight,
+          gamma = param$gamma,
+          subsample = param$subsample,
+          colsample_bytree = param$colsample_bytree
+        ),
+        data = x,
+        nrounds = param$nrounds,
+        objective = "reg:squarederror",
+        booster = "dart",
+        ...
+      )
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!inherits(newdata, "xgb.DMatrix")) {
+      newdata <- as.matrix(newdata)
+      newdata <- xgboost::xgb.DMatrix(data = newdata, missing = NA)
+    }
+    out <- predict(modelFit, newdata, ntreelimit = modelFit$niter)
+    if (modelFit$problemType == "Classification") {
+      if (length(modelFit$obsLevels) == 2) {
+        out <- ifelse(out >= .5, modelFit$obsLevels[1], modelFit$obsLevels[2])
+      } else {
+        out <- matrix(out, ncol = length(modelFit$obsLevels), byrow = TRUE)
+        out <- modelFit$obsLevels[apply(out, 1, which.max)]
+      }
+    }
 
-                        out <- xgboost::xgb.train(list(max_depth = param$max_depth,
-                                                       eta = param$eta,
-                                                       rate_drop = param$rate_drop,
-                                                       skip_drop = param$skip_drop,
-                                                       min_child_weight = param$min_child_weight,
-                                                       gamma = param$gamma,
-                                                       subsample = param$subsample,
-                                                       colsample_bytree = param$colsample_bytree),
-                                                  data = x,
-                                                  num_class = length(lev),
-                                                  nrounds = param$nrounds,
-                                                  objective = "multi:softprob",
-                                                  booster = 'dart',
-                                                  ...)
-                      }
-                    } else {
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
+      for (j in seq(along = submodels$nrounds)) {
+        tmp_pred <- predict(
+          modelFit,
+          newdata,
+          ntreelimit = submodels$nrounds[j]
+        )
+        if (modelFit$problemType == "Classification") {
+          if (length(modelFit$obsLevels) == 2) {
+            tmp_pred <- ifelse(
+              tmp_pred >= .5,
+              modelFit$obsLevels[1],
+              modelFit$obsLevels[2]
+            )
+          } else {
+            tmp_pred <- matrix(
+              tmp_pred,
+              ncol = length(modelFit$obsLevels),
+              byrow = TRUE
+            )
+            tmp_pred <- modelFit$obsLevels[apply(tmp_pred, 1, which.max)]
+          }
+        }
+        tmp[[j + 1]] <- tmp_pred
+      }
+      out <- tmp
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!inherits(newdata, "xgb.DMatrix")) {
+      newdata <- as.matrix(newdata)
+      newdata <- xgboost::xgb.DMatrix(data = newdata, missing = NA)
+    }
 
-                      if(!inherits(x, "xgb.DMatrix"))
-                        x <- xgboost::xgb.DMatrix(x, label = y, missing = NA) else
-                          xgboost::setinfo(x, "label", y)
+    if (
+      !is.null(modelFit$param$objective) &&
+        modelFit$param$objective == 'binary:logitraw'
+    ) {
+      p <- predict(modelFit, newdata, ntreelimit = modelFit$niter)
+      out <- binomial()$linkinv(p) # exp(p)/(1+exp(p))
+    } else {
+      out <- predict(modelFit, newdata, ntreelimit = modelFit$niter)
+    }
+    if (length(modelFit$obsLevels) == 2) {
+      out <- cbind(out, 1 - out)
+      colnames(out) <- modelFit$obsLevels
+    } else {
+      out <- matrix(out, ncol = length(modelFit$obsLevels), byrow = TRUE)
+      colnames(out) <- modelFit$obsLevels
+    }
+    out <- as.data.frame(out, stringsAsFactors = TRUE)
 
-                      if (!is.null(wts))
-                        xgboost::setinfo(x, 'weight', wts)
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
+      for (j in seq(along = submodels$nrounds)) {
+        tmp_pred <- predict(
+          modelFit,
+          newdata,
+          ntreelimit = submodels$nrounds[j]
+        )
+        if (length(modelFit$obsLevels) == 2) {
+          tmp_pred <- cbind(tmp_pred, 1 - tmp_pred)
+          colnames(tmp_pred) <- modelFit$obsLevels
+        } else {
+          tmp_pred <- matrix(
+            tmp_pred,
+            ncol = length(modelFit$obsLevels),
+            byrow = TRUE
+          )
+          colnames(tmp_pred) <- modelFit$obsLevels
+        }
+        tmp_pred <- as.data.frame(tmp_pred, stringsAsFactors = TRUE)
+        tmp[[j + 1]] <- tmp_pred
+      }
+      out <- tmp
+    }
+    out
+  },
+  predictors = function(x, ...) {
+    imp <- xgboost::xgb.importance(x$xNames, model = x)
+    x$xNames[x$xNames %in% imp$Feature]
+  },
+  varImp = function(object, numTrees = NULL, ...) {
+    imp <- xgboost::xgb.importance(object$xNames, model = object)
+    imp <- as.data.frame(imp, stringsAsFactors = TRUE)[, 1:2]
+    rownames(imp) <- as.character(imp[, 1])
+    imp <- imp[, 2, drop = FALSE]
+    colnames(imp) <- "Overall"
 
-                      out <- xgboost::xgb.train(list(max_depth = param$max_depth,
-                                                     eta = param$eta,
-                                                     rate_drop = param$rate_drop,
-                                                     skip_drop = param$skip_drop,
-                                                     min_child_weight = param$min_child_weight,
-                                                     gamma = param$gamma,
-                                                     subsample = param$subsample,
-                                                     colsample_bytree = param$colsample_bytree),
-                                                data = x,
-                                                nrounds = param$nrounds,
-                                                objective = "reg:squarederror",
-                                                booster= "dart",
-                                                ...)
-                    }
-                    out
+    missing <- object$xNames[!(object$xNames %in% rownames(imp))]
+    missing_imp <- data.frame(Overall = rep(0, times = length(missing)))
+    rownames(missing_imp) <- missing
+    imp <- rbind(imp, missing_imp)
 
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!inherits(newdata, "xgb.DMatrix")) {
-                      newdata <- as.matrix(newdata)
-                      newdata <- xgboost::xgb.DMatrix(data=newdata, missing = NA)
-                    }
-                    out <- predict(modelFit, newdata, ntreelimit = modelFit$niter)
-                    if(modelFit$problemType == "Classification") {
-                      if(length(modelFit$obsLevels) == 2) {
-                        out <- ifelse(out >= .5,
-                                      modelFit$obsLevels[1],
-                                      modelFit$obsLevels[2])
-                      } else {
-                        out <- matrix(out, ncol = length(modelFit$obsLevels), byrow = TRUE)
-                        out <- modelFit$obsLevels[apply(out, 1, which.max)]
-                      }
-                    }
-
-                    if(!is.null(submodels)) {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
-                      for(j in seq(along = submodels$nrounds)) {
-                        tmp_pred <- predict(modelFit, newdata, ntreelimit = submodels$nrounds[j])
-                        if(modelFit$problemType == "Classification") {
-                          if(length(modelFit$obsLevels) == 2) {
-                            tmp_pred <- ifelse(tmp_pred >= .5,
-                                               modelFit$obsLevels[1],
-                                               modelFit$obsLevels[2])
-                          } else {
-                            tmp_pred <- matrix(tmp_pred, ncol = length(modelFit$obsLevels), byrow = TRUE)
-                            tmp_pred <- modelFit$obsLevels[apply(tmp_pred, 1, which.max)]
-                          }
-                        }
-                        tmp[[j+1]]  <- tmp_pred
-                      }
-                      out <- tmp
-                    }
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!inherits(newdata, "xgb.DMatrix")) {
-                      newdata <- as.matrix(newdata)
-                      newdata <- xgboost::xgb.DMatrix(data=newdata, missing = NA)
-                    }
-
-                    if( !is.null(modelFit$param$objective) && modelFit$param$objective == 'binary:logitraw'){
-                      p <- predict(modelFit, newdata, ntreelimit = modelFit$niter)
-                      out <- binomial()$linkinv(p) # exp(p)/(1+exp(p))
-                    } else {
-                      out <- predict(modelFit, newdata, ntreelimit = modelFit$niter)
-                    }
-                    if(length(modelFit$obsLevels) == 2) {
-                      out <- cbind(out, 1 - out)
-                      colnames(out) <- modelFit$obsLevels
-                    } else {
-                      out <- matrix(out, ncol = length(modelFit$obsLevels), byrow = TRUE)
-                      colnames(out) <- modelFit$obsLevels
-                    }
-                    out <- as.data.frame(out, stringsAsFactors = TRUE)
-
-                    if(!is.null(submodels)) {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
-                      for(j in seq(along = submodels$nrounds)) {
-                        tmp_pred <- predict(modelFit, newdata, ntreelimit = submodels$nrounds[j])
-                        if(length(modelFit$obsLevels) == 2) {
-                          tmp_pred <- cbind(tmp_pred, 1 - tmp_pred)
-                          colnames(tmp_pred) <- modelFit$obsLevels
-                        } else {
-                          tmp_pred <- matrix(tmp_pred, ncol = length(modelFit$obsLevels), byrow = TRUE)
-                          colnames(tmp_pred) <- modelFit$obsLevels
-                        }
-                        tmp_pred <- as.data.frame(tmp_pred, stringsAsFactors = TRUE)
-                        tmp[[j+1]]  <- tmp_pred
-                      }
-                      out <- tmp
-                    }
-                    out
-                  },
-                  predictors = function(x, ...) {
-                    imp <- xgboost::xgb.importance(x$xNames, model = x)
-                    x$xNames[x$xNames %in% imp$Feature]
-                  },
-                  varImp = function(object, numTrees = NULL, ...) {
-                    imp <- xgboost::xgb.importance(object$xNames, model = object)
-                    imp <- as.data.frame(imp, stringsAsFactors = TRUE)[, 1:2]
-                    rownames(imp) <- as.character(imp[,1])
-                    imp <- imp[,2,drop = FALSE]
-                    colnames(imp) <- "Overall"
-
-                    missing <- object$xNames[!(object$xNames %in% rownames(imp))]
-                    missing_imp <- data.frame(Overall=rep(0, times=length(missing)))
-                    rownames(missing_imp) <- missing
-                    imp <- rbind(imp, missing_imp)
-
-                    imp
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("Tree-Based Model", "Boosting", "Ensemble Model", "Implicit Feature Selection", "Accepts Case Weights"),
-                  sort = function(x) {
-                    x[order(x$nrounds,          x$max_depth, x$eta,              x$rate_drop, x$skip_drop,
-                            x$min_child_weight, x$subsample, x$colsample_bytree, x$gamma),]
-                  })
+    imp
+  },
+  levels = function(x) x$obsLevels,
+  tags = c(
+    "Tree-Based Model",
+    "Boosting",
+    "Ensemble Model",
+    "Implicit Feature Selection",
+    "Accepts Case Weights"
+  ),
+  sort = function(x) {
+    x[
+      order(
+        x$nrounds,
+        x$max_depth,
+        x$eta,
+        x$rate_drop,
+        x$skip_drop,
+        x$min_child_weight,
+        x$subsample,
+        x$colsample_bytree,
+        x$gamma
+      ),
+    ]
+  }
+)

--- a/inst/model_sources/files/xgbLinear.R
+++ b/inst/model_sources/files/xgbLinear.R
@@ -1,141 +1,167 @@
-modelInfo <- list(label = "eXtreme Gradient Boosting",
-                  library = c("xgboost"),
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('nrounds', 'lambda', 'alpha', 'eta'),
-                                          class = rep("numeric", 4),
-                                          label = c('# Boosting Iterations', 'L2 Regularization',
-                                                    'L1 Regularization', 'Learning Rate')),
-                  grid = function(x, y, len = NULL, search = "grid")  {
-                    if(search == "grid") {
-                      out <- expand.grid(lambda = c(0, 10 ^ seq(-1, -4, length = len - 1)),
-                                         alpha = c(0, 10 ^ seq(-1, -4, length = len - 1)),
-                                         nrounds = floor((1:len) * 50),
-                                         eta = 0.3)
-                    } else {
-                      out <- data.frame(lambda = 10^runif(len, min = -5, 0),
-                                        alpha = 10^runif(len, min = -5, 0),
-                                        nrounds = sample(1:100, size = len, replace = TRUE),
-                                        eta = runif(len, max = 3))
-                    }
-                    out
-                  },
-                  loop = NULL,
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    if(!inherits(x, "xgb.DMatrix"))
-                     x <- as.matrix(x)
-                    
-                    if(is.factor(y)) {
-                      if(length(lev) == 2) {
-                        y <- ifelse(y == lev[1], 1, 0) 
-                        
-                        if(!inherits(x, "xgb.DMatrix"))
-                          x <- xgboost::xgb.DMatrix(x, label = y, missing = NA) else
-                            xgboost::setinfo(x, "label", y)
-                        
-                        if (!is.null(wts))
-                          xgboost::setinfo(x, 'weight', wts)
-                        
-                        
-                        out <- xgboost::xgb.train(list(lambda = param$lambda, 
-                                                       alpha = param$alpha), 
-                                                  data = x,
-                                                  nrounds = param$nrounds,
-                                                  objective = "binary:logistic",
-                                                  ...)
-                      } else {
-                        y <- as.numeric(y) - 1
+modelInfo <- list(
+  label = "eXtreme Gradient Boosting",
+  library = c("xgboost"),
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c('nrounds', 'lambda', 'alpha', 'eta'),
+    class = rep("numeric", 4),
+    label = c(
+      '# Boosting Iterations',
+      'L2 Regularization',
+      'L1 Regularization',
+      'Learning Rate'
+    )
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        lambda = c(0, 10^seq(-1, -4, length = len - 1)),
+        alpha = c(0, 10^seq(-1, -4, length = len - 1)),
+        nrounds = floor((1:len) * 50),
+        eta = 0.3
+      )
+    } else {
+      out <- data.frame(
+        lambda = 10^runif(len, min = -5, 0),
+        alpha = 10^runif(len, min = -5, 0),
+        nrounds = sample(1:100, size = len, replace = TRUE),
+        eta = runif(len, max = 3)
+      )
+    }
+    out
+  },
+  loop = NULL,
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (!inherits(x, "xgb.DMatrix")) {
+      x <- as.matrix(x)
+    }
 
-                        if(!inherits(x, "xgb.DMatrix"))
-                          x <- xgboost::xgb.DMatrix(x, label = y, missing = NA) else
-                            xgboost::setinfo(x, "label", y)
-                        
-                        if (!is.null(wts))
-                          xgboost::setinfo(x, 'weight', wts)
-                        
-                        out <- xgboost::xgb.train(list(lambda = param$lambda, 
-                                                       alpha = param$alpha), 
-                                                  data = x,
-                                                  num_class = length(lev),
-                                                  nrounds = param$nrounds,
-                                                  objective = "multi:softprob",
-                                                  ...)
-                      }
-                    } else {
-                      if(!inherits(x, "xgb.DMatrix"))
-                        x <- xgboost::xgb.DMatrix(x, label = y, missing = NA) else
-                          xgboost::setinfo(x, "label", y)
-                      
-                      if (!is.null(wts))
-                        xgboost::setinfo(x, 'weight', wts)
-                      
-                      out <- xgboost::xgb.train(list(lambda = param$lambda, 
-                                                     alpha = param$alpha), 
-                                                data = x,
-                                                nrounds = param$nrounds,
-                                                objective = "reg:squarederror",
-                                                ...)
-                    }
-                    out
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!inherits(newdata, "xgb.DMatrix")) {
-                      newdata <- as.matrix(newdata)
-                      newdata <- xgboost::xgb.DMatrix(data=newdata, missing = NA)
-                    }
-                    out <- predict(modelFit, newdata)
-                    if(modelFit$problemType == "Classification") {
-                      if(length(modelFit$obsLevels) == 2) {
-                        out <- ifelse(out >= .5,
-                                      modelFit$obsLevels[1],
-                                      modelFit$obsLevels[2])
-                      } else {
-                        out <- matrix(out, ncol = length(modelFit$obsLevels), byrow = TRUE)
-                        out <- modelFit$obsLevels[apply(out, 1, which.max)]
-                      }
-                    }
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!inherits(newdata, "xgb.DMatrix")) {
-                      newdata <- as.matrix(newdata)
-                      newdata <- xgboost::xgb.DMatrix(data=newdata, missing = NA)
-                    }
-                    out <- predict(modelFit, newdata)
-                    if(length(modelFit$obsLevels) == 2) {
-                      out <- cbind(out, 1 - out)
-                      colnames(out) <- modelFit$obsLevels
-                    } else {
-                      out <- matrix(out, ncol = length(modelFit$obsLevels), byrow = TRUE)
-                      colnames(out) <- modelFit$obsLevels
-                    }
-                    as.data.frame(out, stringsAsFactors = TRUE)
-                  },
-                  predictors = function(x, ...) {
-                    imp <- xgboost::xgb.importance(x$xNames, model = x)
-                    x$xNames[x$xNames %in% imp$Feature]
-                  },
-                  varImp = function(object, numTrees = NULL, ...) {
-                    imp <- xgboost::xgb.importance(object$xNames, model = object)
-                    imp <- as.data.frame(imp, stringsAsFactors = TRUE)[, 1:2]
-                    rownames(imp) <- as.character(imp[,1])
-                    imp <- imp[,2,drop = FALSE]
-                    colnames(imp) <- "Overall"
+    if (is.factor(y)) {
+      if (length(lev) == 2) {
+        y <- ifelse(y == lev[1], 1, 0)
 
-                    missing <- object$xNames[!(object$xNames %in% rownames(imp))]
-                    missing_imp <- data.frame(Overall=rep(0, times=length(missing)))
-                    rownames(missing_imp) <- missing
-                    imp <- rbind(imp, missing_imp)
+        if (!inherits(x, "xgb.DMatrix")) {
+          x <- xgboost::xgb.DMatrix(x, label = y, missing = NA)
+        } else {
+          xgboost::setinfo(x, "label", y)
+        }
 
-                    imp
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("Linear Classifier Models",
-                           "Linear Regression Models",
-                           "L1 Regularization Models",
-                           "L2 Regularization Models",
-                           "Boosting", "Ensemble Model", "Implicit Feature Selection"),
-                  sort = function(x) {
-                    # This is a toss-up, but the # trees probably adds
-                    # complexity faster than number of splits
-                    x[order(x$nrounds, x$alpha, x$lambda),]
-                  })
+        if (!is.null(wts)) {
+          xgboost::setinfo(x, 'weight', wts)
+        }
+
+        out <- xgboost::xgb.train(
+          list(lambda = param$lambda, alpha = param$alpha),
+          data = x,
+          nrounds = param$nrounds,
+          objective = "binary:logistic",
+          ...
+        )
+      } else {
+        y <- as.numeric(y) - 1
+
+        if (!inherits(x, "xgb.DMatrix")) {
+          x <- xgboost::xgb.DMatrix(x, label = y, missing = NA)
+        } else {
+          xgboost::setinfo(x, "label", y)
+        }
+
+        if (!is.null(wts)) {
+          xgboost::setinfo(x, 'weight', wts)
+        }
+
+        out <- xgboost::xgb.train(
+          list(lambda = param$lambda, alpha = param$alpha),
+          data = x,
+          num_class = length(lev),
+          nrounds = param$nrounds,
+          objective = "multi:softprob",
+          ...
+        )
+      }
+    } else {
+      if (!inherits(x, "xgb.DMatrix")) {
+        x <- xgboost::xgb.DMatrix(x, label = y, missing = NA)
+      } else {
+        xgboost::setinfo(x, "label", y)
+      }
+
+      if (!is.null(wts)) {
+        xgboost::setinfo(x, 'weight', wts)
+      }
+
+      out <- xgboost::xgb.train(
+        list(lambda = param$lambda, alpha = param$alpha),
+        data = x,
+        nrounds = param$nrounds,
+        objective = "reg:squarederror",
+        ...
+      )
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!inherits(newdata, "xgb.DMatrix")) {
+      newdata <- as.matrix(newdata)
+      newdata <- xgboost::xgb.DMatrix(data = newdata, missing = NA)
+    }
+    out <- predict(modelFit, newdata)
+    if (modelFit$problemType == "Classification") {
+      if (length(modelFit$obsLevels) == 2) {
+        out <- ifelse(out >= .5, modelFit$obsLevels[1], modelFit$obsLevels[2])
+      } else {
+        out <- matrix(out, ncol = length(modelFit$obsLevels), byrow = TRUE)
+        out <- modelFit$obsLevels[apply(out, 1, which.max)]
+      }
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!inherits(newdata, "xgb.DMatrix")) {
+      newdata <- as.matrix(newdata)
+      newdata <- xgboost::xgb.DMatrix(data = newdata, missing = NA)
+    }
+    out <- predict(modelFit, newdata)
+    if (length(modelFit$obsLevels) == 2) {
+      out <- cbind(out, 1 - out)
+      colnames(out) <- modelFit$obsLevels
+    } else {
+      out <- matrix(out, ncol = length(modelFit$obsLevels), byrow = TRUE)
+      colnames(out) <- modelFit$obsLevels
+    }
+    as.data.frame(out, stringsAsFactors = TRUE)
+  },
+  predictors = function(x, ...) {
+    imp <- xgboost::xgb.importance(x$xNames, model = x)
+    x$xNames[x$xNames %in% imp$Feature]
+  },
+  varImp = function(object, numTrees = NULL, ...) {
+    imp <- xgboost::xgb.importance(object$xNames, model = object)
+    imp <- as.data.frame(imp, stringsAsFactors = TRUE)[, 1:2]
+    rownames(imp) <- as.character(imp[, 1])
+    imp <- imp[, 2, drop = FALSE]
+    colnames(imp) <- "Overall"
+
+    missing <- object$xNames[!(object$xNames %in% rownames(imp))]
+    missing_imp <- data.frame(Overall = rep(0, times = length(missing)))
+    rownames(missing_imp) <- missing
+    imp <- rbind(imp, missing_imp)
+
+    imp
+  },
+  levels = function(x) x$obsLevels,
+  tags = c(
+    "Linear Classifier Models",
+    "Linear Regression Models",
+    "L1 Regularization Models",
+    "L2 Regularization Models",
+    "Boosting",
+    "Ensemble Model",
+    "Implicit Feature Selection"
+  ),
+  sort = function(x) {
+    # This is a toss-up, but the # trees probably adds
+    # complexity faster than number of splits
+    x[order(x$nrounds, x$alpha, x$lambda), ]
+  }
+)

--- a/inst/model_sources/files/xgbTree.R
+++ b/inst/model_sources/files/xgbTree.R
@@ -1,228 +1,306 @@
-modelInfo <- list(label = "eXtreme Gradient Boosting",
-                  library = c("xgboost", "plyr"),
-                  type = c("Regression", "Classification"),
-                  parameters = data.frame(parameter = c('nrounds', 'max_depth', 'eta',
-                                                        'gamma', 'colsample_bytree',
-                                                        'min_child_weight', 'subsample'),
-                                          class = rep("numeric", 7),
-                                          label = c('# Boosting Iterations', 'Max Tree Depth',
-                                                    'Shrinkage', "Minimum Loss Reduction",
-                                                    'Subsample Ratio of Columns',
-                                                    'Minimum Sum of Instance Weight',
-                                                    'Subsample Percentage')),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(max_depth = seq(1, len),
-                                         nrounds = floor((1:len) * 50),
-                                         eta = c(.3, .4),
-                                         gamma = 0,
-                                         colsample_bytree = c(.6, .8),
-                                         min_child_weight = c(1),
-                                         subsample = seq(.5, 1, length = len))
-                    } else {
-                      out <- data.frame(nrounds = sample(1:1000, size = len, replace = TRUE),
-                                        max_depth = sample(1:10, replace = TRUE, size = len),
-                                        eta = runif(len, min = .001, max = .6),
-                                        gamma = runif(len, min = 0, max = 10),
-                                        colsample_bytree = runif(len, min = .3, max = .7),
-                                        min_child_weight = sample(0:20, size = len, replace = TRUE),
-                                        subsample = runif(len, min = .25, max = 1))
-                      out$nrounds <- floor(out$nrounds)
-                    }
-                    out
-                  },
-                  loop = function(grid) {
-                    loop <- plyr::ddply(grid, c("eta", "max_depth", "gamma",
-                                          "colsample_bytree", "min_child_weight",
-                                          "subsample"),
-                                  function(x) c(nrounds = max(x$nrounds)))
-                    submodels <- vector(mode = "list", length = nrow(loop))
-                    for(i in seq(along = loop$nrounds)) {
-                      index <- which(grid$max_depth == loop$max_depth[i] &
-                                       grid$eta == loop$eta[i] &
-                                       grid$gamma == loop$gamma[i] &
-                                       grid$colsample_bytree == loop$colsample_bytree[i] &
-                                       grid$min_child_weight == loop$min_child_weight[i] &
-                                       grid$subsample == loop$subsample[i])
-                      trees <- grid[index, "nrounds"]
-                      submodels[[i]] <- data.frame(nrounds = trees[trees != loop$nrounds[i]])
-                    }
-                    list(loop = loop, submodels = submodels)
-                  },
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
-                    if(!inherits(x, "xgb.DMatrix"))
-                      x <- as.matrix(x)
+modelInfo <- list(
+  label = "eXtreme Gradient Boosting",
+  library = c("xgboost", "plyr"),
+  type = c("Regression", "Classification"),
+  parameters = data.frame(
+    parameter = c(
+      'nrounds',
+      'max_depth',
+      'eta',
+      'gamma',
+      'colsample_bytree',
+      'min_child_weight',
+      'subsample'
+    ),
+    class = rep("numeric", 7),
+    label = c(
+      '# Boosting Iterations',
+      'Max Tree Depth',
+      'Shrinkage',
+      "Minimum Loss Reduction",
+      'Subsample Ratio of Columns',
+      'Minimum Sum of Instance Weight',
+      'Subsample Percentage'
+    )
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        max_depth = seq(1, len),
+        nrounds = floor((1:len) * 50),
+        eta = c(.3, .4),
+        gamma = 0,
+        colsample_bytree = c(.6, .8),
+        min_child_weight = c(1),
+        subsample = seq(.5, 1, length = len)
+      )
+    } else {
+      out <- data.frame(
+        nrounds = sample(1:1000, size = len, replace = TRUE),
+        max_depth = sample(1:10, replace = TRUE, size = len),
+        eta = runif(len, min = .001, max = .6),
+        gamma = runif(len, min = 0, max = 10),
+        colsample_bytree = runif(len, min = .3, max = .7),
+        min_child_weight = sample(0:20, size = len, replace = TRUE),
+        subsample = runif(len, min = .25, max = 1)
+      )
+      out$nrounds <- floor(out$nrounds)
+    }
+    out
+  },
+  loop = function(grid) {
+    loop <- plyr::ddply(
+      grid,
+      c(
+        "eta",
+        "max_depth",
+        "gamma",
+        "colsample_bytree",
+        "min_child_weight",
+        "subsample"
+      ),
+      function(x) c(nrounds = max(x$nrounds))
+    )
+    submodels <- vector(mode = "list", length = nrow(loop))
+    for (i in seq(along = loop$nrounds)) {
+      index <- which(
+        grid$max_depth == loop$max_depth[i] &
+          grid$eta == loop$eta[i] &
+          grid$gamma == loop$gamma[i] &
+          grid$colsample_bytree == loop$colsample_bytree[i] &
+          grid$min_child_weight == loop$min_child_weight[i] &
+          grid$subsample == loop$subsample[i]
+      )
+      trees <- grid[index, "nrounds"]
+      submodels[[i]] <- data.frame(nrounds = trees[trees != loop$nrounds[i]])
+    }
+    list(loop = loop, submodels = submodels)
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    if (!inherits(x, "xgb.DMatrix")) {
+      x <- as.matrix(x)
+    }
 
-                    if(is.factor(y)) {
+    if (is.factor(y)) {
+      if (length(lev) == 2) {
+        y <- ifelse(y == lev[1], 1, 0)
 
-                      if(length(lev) == 2) {
+        if (!inherits(x, "xgb.DMatrix")) {
+          x <- xgboost::xgb.DMatrix(x, label = y, missing = NA)
+        } else {
+          xgboost::setinfo(x, "label", y)
+        }
 
-                        y <- ifelse(y == lev[1], 1, 0)
+        if (!is.null(wts)) {
+          xgboost::setinfo(x, 'weight', wts)
+        }
 
-                        if(!inherits(x, "xgb.DMatrix"))
-                          x <- xgboost::xgb.DMatrix(x, label = y, missing = NA) else
-                            xgboost::setinfo(x, "label", y)
+        out <- xgboost::xgb.train(
+          list(
+            eta = param$eta,
+            max_depth = param$max_depth,
+            gamma = param$gamma,
+            colsample_bytree = param$colsample_bytree,
+            min_child_weight = param$min_child_weight,
+            subsample = param$subsample
+          ),
+          data = x,
+          nrounds = param$nrounds,
+          objective = "binary:logistic",
+          ...
+        )
+      } else {
+        y <- as.numeric(y) - 1
 
-                        if (!is.null(wts))
-                          xgboost::setinfo(x, 'weight', wts)
+        if (!inherits(x, "xgb.DMatrix")) {
+          x <- xgboost::xgb.DMatrix(x, label = y, missing = NA)
+        } else {
+          xgboost::setinfo(x, "label", y)
+        }
 
-                        out <- xgboost::xgb.train(list(eta = param$eta,
-                                                       max_depth = param$max_depth,
-                                                       gamma = param$gamma,
-                                                       colsample_bytree = param$colsample_bytree,
-                                                       min_child_weight = param$min_child_weight,
-                                                       subsample = param$subsample),
-                                                  data = x,
-                                                  nrounds = param$nrounds,
-                                                  objective = "binary:logistic",
-                                                  ...)
-                      } else {
+        if (!is.null(wts)) {
+          xgboost::setinfo(x, 'weight', wts)
+        }
 
-                        y <- as.numeric(y) - 1
+        out <- xgboost::xgb.train(
+          list(
+            eta = param$eta,
+            max_depth = param$max_depth,
+            gamma = param$gamma,
+            colsample_bytree = param$colsample_bytree,
+            min_child_weight = param$min_child_weight,
+            subsample = param$subsample
+          ),
+          data = x,
+          num_class = length(lev),
+          nrounds = param$nrounds,
+          objective = "multi:softprob",
+          ...
+        )
+      }
+    } else {
+      if (!inherits(x, "xgb.DMatrix")) {
+        x <- xgboost::xgb.DMatrix(x, label = y, missing = NA)
+      } else {
+        xgboost::setinfo(x, "label", y)
+      }
 
-                        if(!inherits(x, "xgb.DMatrix"))
-                          x <- xgboost::xgb.DMatrix(x, label = y, missing = NA) else
-                            xgboost::setinfo(x, "label", y)
+      if (!is.null(wts)) {
+        xgboost::setinfo(x, 'weight', wts)
+      }
 
-                        if (!is.null(wts))
-                          xgboost::setinfo(x, 'weight', wts)
+      out <- xgboost::xgb.train(
+        list(
+          eta = param$eta,
+          max_depth = param$max_depth,
+          gamma = param$gamma,
+          colsample_bytree = param$colsample_bytree,
+          min_child_weight = param$min_child_weight,
+          subsample = param$subsample
+        ),
+        data = x,
+        nrounds = param$nrounds,
+        objective = "reg:squarederror",
+        ...
+      )
+    }
+    out
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    if (!inherits(newdata, "xgb.DMatrix")) {
+      newdata <- as.matrix(newdata)
+      newdata <- xgboost::xgb.DMatrix(data = newdata, missing = NA)
+    }
+    out <- predict(modelFit, newdata)
+    if (modelFit$problemType == "Classification") {
+      if (length(modelFit$obsLevels) == 2) {
+        out <- ifelse(out >= .5, modelFit$obsLevels[1], modelFit$obsLevels[2])
+      } else {
+        out <- matrix(out, ncol = length(modelFit$obsLevels), byrow = TRUE)
+        out <- modelFit$obsLevels[apply(out, 1, which.max)]
+      }
+    }
 
-                        out <- xgboost::xgb.train(list(eta = param$eta,
-                                                       max_depth = param$max_depth,
-                                                       gamma = param$gamma,
-                                                       colsample_bytree = param$colsample_bytree,
-                                                       min_child_weight = param$min_child_weight,
-                                                       subsample = param$subsample),
-                                                       data = x,
-                                                       num_class = length(lev),
-                                                       nrounds = param$nrounds,
-                                                       objective = "multi:softprob",
-                                                       ...)
-                      }
-                    } else {
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
+      for (j in seq(along = submodels$nrounds)) {
+        tmp_pred <- predict(
+          modelFit,
+          newdata,
+          ntreelimit = submodels$nrounds[j]
+        )
+        if (modelFit$problemType == "Classification") {
+          if (length(modelFit$obsLevels) == 2) {
+            tmp_pred <- ifelse(
+              tmp_pred >= .5,
+              modelFit$obsLevels[1],
+              modelFit$obsLevels[2]
+            )
+          } else {
+            tmp_pred <- matrix(
+              tmp_pred,
+              ncol = length(modelFit$obsLevels),
+              byrow = TRUE
+            )
+            tmp_pred <- modelFit$obsLevels[apply(tmp_pred, 1, which.max)]
+          }
+        }
+        tmp[[j + 1]] <- tmp_pred
+      }
+      out <- tmp
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    if (!inherits(newdata, "xgb.DMatrix")) {
+      newdata <- as.matrix(newdata)
+      newdata <- xgboost::xgb.DMatrix(data = newdata, missing = NA)
+    }
 
-                      if(!inherits(x, "xgb.DMatrix"))
-                        x <- xgboost::xgb.DMatrix(x, label = y, missing = NA) else
-                          xgboost::setinfo(x, "label", y)
+    if (
+      !is.null(modelFit$param$objective) &&
+        modelFit$param$objective == 'binary:logitraw'
+    ) {
+      p <- predict(modelFit, newdata)
+      out <- binomial()$linkinv(p) # exp(p)/(1+exp(p))
+    } else {
+      out <- predict(modelFit, newdata)
+    }
+    if (length(modelFit$obsLevels) == 2) {
+      out <- cbind(out, 1 - out)
+      colnames(out) <- modelFit$obsLevels
+    } else {
+      out <- matrix(out, ncol = length(modelFit$obsLevels), byrow = TRUE)
+      colnames(out) <- modelFit$obsLevels
+    }
+    out <- as.data.frame(out, stringsAsFactors = TRUE)
 
-                      if (!is.null(wts))
-                        xgboost::setinfo(x, 'weight', wts)
+    if (!is.null(submodels)) {
+      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
+      tmp[[1]] <- out
+      for (j in seq(along = submodels$nrounds)) {
+        tmp_pred <- predict(
+          modelFit,
+          newdata,
+          ntreelimit = submodels$nrounds[j]
+        )
+        if (length(modelFit$obsLevels) == 2) {
+          tmp_pred <- cbind(tmp_pred, 1 - tmp_pred)
+          colnames(tmp_pred) <- modelFit$obsLevels
+        } else {
+          tmp_pred <- matrix(
+            tmp_pred,
+            ncol = length(modelFit$obsLevels),
+            byrow = TRUE
+          )
+          colnames(tmp_pred) <- modelFit$obsLevels
+        }
+        tmp_pred <- as.data.frame(tmp_pred, stringsAsFactors = TRUE)
+        tmp[[j + 1]] <- tmp_pred
+      }
+      out <- tmp
+    }
+    out
+  },
+  predictors = function(x, ...) {
+    imp <- xgboost::xgb.importance(x$xNames, model = x)
+    x$xNames[x$xNames %in% imp$Feature]
+  },
+  varImp = function(object, numTrees = NULL, ...) {
+    imp <- xgboost::xgb.importance(object$xNames, model = object)
+    imp <- as.data.frame(imp, stringsAsFactors = TRUE)[, 1:2]
+    rownames(imp) <- as.character(imp[, 1])
+    imp <- imp[, 2, drop = FALSE]
+    colnames(imp) <- "Overall"
 
-                      out <- xgboost::xgb.train(list(eta = param$eta,
-                                                     max_depth = param$max_depth,
-                                                     gamma = param$gamma,
-                                                     colsample_bytree = param$colsample_bytree,
-                                                     min_child_weight = param$min_child_weight,
-                                                     subsample = param$subsample),
-                                                 data = x,
-                                                 nrounds = param$nrounds,
-                                                 objective = "reg:squarederror",
-                                                 ...)
-                    }
-                    out
+    missing <- object$xNames[!(object$xNames %in% rownames(imp))]
+    missing_imp <- data.frame(Overall = rep(0, times = length(missing)))
+    rownames(missing_imp) <- missing
+    imp <- rbind(imp, missing_imp)
 
-
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    if(!inherits(newdata, "xgb.DMatrix")) {
-                      newdata <- as.matrix(newdata)
-                      newdata <- xgboost::xgb.DMatrix(data=newdata, missing = NA)
-                    }
-                   out <- predict(modelFit, newdata)
-                    if(modelFit$problemType == "Classification") {
-                      if(length(modelFit$obsLevels) == 2) {
-                        out <- ifelse(out >= .5,
-                                      modelFit$obsLevels[1],
-                                      modelFit$obsLevels[2])
-                      } else {
-                        out <- matrix(out, ncol = length(modelFit$obsLevels), byrow = TRUE)
-                        out <- modelFit$obsLevels[apply(out, 1, which.max)]
-                      }
-                    }
-
-                    if(!is.null(submodels)) {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
-                      for(j in seq(along = submodels$nrounds)) {
-                        tmp_pred <- predict(modelFit, newdata, ntreelimit = submodels$nrounds[j])
-                        if(modelFit$problemType == "Classification") {
-                          if(length(modelFit$obsLevels) == 2) {
-                            tmp_pred <- ifelse(tmp_pred >= .5,
-                                               modelFit$obsLevels[1],
-                                               modelFit$obsLevels[2])
-                          } else {
-                            tmp_pred <- matrix(tmp_pred, ncol = length(modelFit$obsLevels), byrow = TRUE)
-                            tmp_pred <- modelFit$obsLevels[apply(tmp_pred, 1, which.max)]
-                          }
-                        }
-                        tmp[[j+1]]  <- tmp_pred
-                      }
-                      out <- tmp
-                    }
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL) {
-                    if(!inherits(newdata, "xgb.DMatrix")) {
-                      newdata <- as.matrix(newdata)
-                      newdata <- xgboost::xgb.DMatrix(data=newdata, missing = NA)
-                    }
-
-                    if( !is.null(modelFit$param$objective) && modelFit$param$objective == 'binary:logitraw'){
-                      p <- predict(modelFit, newdata)
-                      out <-binomial()$linkinv(p) # exp(p)/(1+exp(p))
-                    } else {
-                      out <- predict(modelFit, newdata)
-                    }
-                   if(length(modelFit$obsLevels) == 2) {
-                     out <- cbind(out, 1 - out)
-                      colnames(out) <- modelFit$obsLevels
-                    } else {
-                      out <- matrix(out, ncol = length(modelFit$obsLevels), byrow = TRUE)
-                      colnames(out) <- modelFit$obsLevels
-                    }
-                    out <- as.data.frame(out, stringsAsFactors = TRUE)
-
-                    if(!is.null(submodels)) {
-                      tmp <- vector(mode = "list", length = nrow(submodels) + 1)
-                      tmp[[1]] <- out
-                      for(j in seq(along = submodels$nrounds)) {
-                        tmp_pred <- predict(modelFit, newdata, ntreelimit = submodels$nrounds[j])
-                        if(length(modelFit$obsLevels) == 2) {
-                          tmp_pred <- cbind(tmp_pred, 1 - tmp_pred)
-                          colnames(tmp_pred) <- modelFit$obsLevels
-                        } else {
-                          tmp_pred <- matrix(tmp_pred, ncol = length(modelFit$obsLevels), byrow = TRUE)
-                          colnames(tmp_pred) <- modelFit$obsLevels
-                        }
-                        tmp_pred <- as.data.frame(tmp_pred, stringsAsFactors = TRUE)
-                        tmp[[j+1]]  <- tmp_pred
-                      }
-                      out <- tmp
-                    }
-                    out
-                  },
-                  predictors = function(x, ...) {
-                    imp <- xgboost::xgb.importance(x$xNames, model = x)
-                    x$xNames[x$xNames %in% imp$Feature]
-                  },
-                  varImp = function(object, numTrees = NULL, ...) {
-                    imp <- xgboost::xgb.importance(object$xNames, model = object)
-                    imp <- as.data.frame(imp, stringsAsFactors = TRUE)[, 1:2]
-                    rownames(imp) <- as.character(imp[,1])
-                    imp <- imp[,2,drop = FALSE]
-                    colnames(imp) <- "Overall"
-
-                    missing <- object$xNames[!(object$xNames %in% rownames(imp))]
-                    missing_imp <- data.frame(Overall=rep(0, times=length(missing)))
-                    rownames(missing_imp) <- missing
-                    imp <- rbind(imp, missing_imp)
-
-                    imp
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("Tree-Based Model", "Boosting", "Ensemble Model", "Implicit Feature Selection", "Accepts Case Weights"),
-                  sort = function(x) {
-                    # This is a toss-up, but the # trees probably adds
-                    # complexity faster than number of splits
-                    x[order(x$nrounds, x$max_depth, x$eta, x$gamma, x$colsample_bytree, x$min_child_weight),]
-                  })
+    imp
+  },
+  levels = function(x) x$obsLevels,
+  tags = c(
+    "Tree-Based Model",
+    "Boosting",
+    "Ensemble Model",
+    "Implicit Feature Selection",
+    "Accepts Case Weights"
+  ),
+  sort = function(x) {
+    # This is a toss-up, but the # trees probably adds
+    # complexity faster than number of splits
+    x[
+      order(
+        x$nrounds,
+        x$max_depth,
+        x$eta,
+        x$gamma,
+        x$colsample_bytree,
+        x$min_child_weight
+      ),
+    ]
+  }
+)

--- a/inst/model_sources/files/xyf.R
+++ b/inst/model_sources/files/xyf.R
@@ -1,61 +1,89 @@
-modelInfo <- list(label = "Self-Organizing Maps",
-                  library = "kohonen",
-                  check = function(pkg) {
-                    requireNamespace("kohonen")
-                    current <- packageDescription("kohonen")$Version
-                    expected <- "3.0.0"
-                    if(compareVersion(current, expected) < 0)
-                      stop("This modeling workflow requires kohonen version ",
-                           expected, "or greater.", call. = FALSE)
-                  },
-                  loop = NULL,
-                  type = c("Classification", "Regression"),
-                  parameters = data.frame(parameter = c("xdim", "ydim", "user.weights", "topo"),
-                                          class = c(rep("numeric", 3), "character"),
-                                          label = c("Rows", "Columns", "Layer Weight", "Topology")),
-                  grid = function(x, y, len = NULL, search = "grid") {
-                    if(search == "grid") {
-                      out <- expand.grid(xdim = 1:len, ydim = 2:(len+1),
-                                         user.weights = seq(.2, .8, length = len),
-                                         topo = "hexagonal")
-                      out <- subset(out, xdim <= ydim)
-                    } else {
-                      out <- data.frame(xdim = sample(1:20, size = len*10, replace = TRUE),
-                                        ydim = sample(1:20, size = len*10, replace = TRUE),
-                                        topo = sample(c("rectangular", "hexagonal"), size = len*10, replace = TRUE),
-                                        user.weights = runif(len*10, min = .01, max = .99))
-                      out <- subset(out, xdim <= ydim & xdim*ydim < nrow(x))
-                      out <- out[1:min(nrow(out), len),]
-                    }
-                    out
-                  }, 
-                  fit = function(x, y, wts, param, lev, last, classProbs, ...) { 
-                    layer_wts <- c(1 - param$user.weights, param$user.weights)
-                    layer_wts <- layer_wts/sum(layer_wts)
-                    if(is.numeric(y))
-                      y <- as.matrix(y, ncol = 1)
-                    kohonen::supersom(list(X = as.matrix(x), Y = y),
-                             user.weights = layer_wts,
-                             grid = kohonen::somgrid(param$xdim, param$ydim, as.character(param$topo)),
-                             ...)
-                  },
-                  predict = function(modelFit, newdata, submodels = NULL) {
-                    out <- predict(modelFit, list(X = as.matrix(newdata)), whatmap = "X")$predictions$Y
-                    if(is.factor(out))
-                      out <- as.character(out)
-                    out
-                  },
-                  prob = function(modelFit, newdata, submodels = NULL){
-                    preds <- predict(modelFit, list(X = as.matrix(newdata)), whatmap = "X")
-                    preds <- preds$unit.predictions$Y[preds$unit.classif,]
-                    as.data.frame(preds)
-                  },
-                  levels = function(x) x$obsLevels,
-                  tags = c("Self-Organising Maps"),
-                  sort = function(x) x[order(x$xdim,  x$ydim),],
-                  notes = paste("As of version 3.0.0 of the kohonen package, the argument `user.weights`",
-                                "replaces the old `alpha` parameter. `user.weights` is usually a vector of",
-                                "relative weights such as `c(1, 3)` but is parameterized here as a proportion",
-                                "such as `c(1-.75, .75)` where the .75 is the value of the tuning parameter",
-                                "passed to `train` and indicates that the outcome layer has 3 times the weight",
-                                "as the predictor layer."))
+modelInfo <- list(
+  label = "Self-Organizing Maps",
+  library = "kohonen",
+  check = function(pkg) {
+    requireNamespace("kohonen")
+    current <- packageDescription("kohonen")$Version
+    expected <- "3.0.0"
+    if (compareVersion(current, expected) < 0) {
+      stop(
+        "This modeling workflow requires kohonen version ",
+        expected,
+        "or greater.",
+        call. = FALSE
+      )
+    }
+  },
+  loop = NULL,
+  type = c("Classification", "Regression"),
+  parameters = data.frame(
+    parameter = c("xdim", "ydim", "user.weights", "topo"),
+    class = c(rep("numeric", 3), "character"),
+    label = c("Rows", "Columns", "Layer Weight", "Topology")
+  ),
+  grid = function(x, y, len = NULL, search = "grid") {
+    if (search == "grid") {
+      out <- expand.grid(
+        xdim = 1:len,
+        ydim = 2:(len + 1),
+        user.weights = seq(.2, .8, length = len),
+        topo = "hexagonal"
+      )
+      out <- subset(out, xdim <= ydim)
+    } else {
+      out <- data.frame(
+        xdim = sample(1:20, size = len * 10, replace = TRUE),
+        ydim = sample(1:20, size = len * 10, replace = TRUE),
+        topo = sample(
+          c("rectangular", "hexagonal"),
+          size = len * 10,
+          replace = TRUE
+        ),
+        user.weights = runif(len * 10, min = .01, max = .99)
+      )
+      out <- subset(out, xdim <= ydim & xdim * ydim < nrow(x))
+      out <- out[1:min(nrow(out), len), ]
+    }
+    out
+  },
+  fit = function(x, y, wts, param, lev, last, classProbs, ...) {
+    layer_wts <- c(1 - param$user.weights, param$user.weights)
+    layer_wts <- layer_wts / sum(layer_wts)
+    if (is.numeric(y)) {
+      y <- as.matrix(y, ncol = 1)
+    }
+    kohonen::supersom(
+      list(X = as.matrix(x), Y = y),
+      user.weights = layer_wts,
+      grid = kohonen::somgrid(param$xdim, param$ydim, as.character(param$topo)),
+      ...
+    )
+  },
+  predict = function(modelFit, newdata, submodels = NULL) {
+    out <- predict(
+      modelFit,
+      list(X = as.matrix(newdata)),
+      whatmap = "X"
+    )$predictions$Y
+    if (is.factor(out)) {
+      out <- as.character(out)
+    }
+    out
+  },
+  prob = function(modelFit, newdata, submodels = NULL) {
+    preds <- predict(modelFit, list(X = as.matrix(newdata)), whatmap = "X")
+    preds <- preds$unit.predictions$Y[preds$unit.classif, ]
+    as.data.frame(preds)
+  },
+  levels = function(x) x$obsLevels,
+  tags = c("Self-Organising Maps"),
+  sort = function(x) x[order(x$xdim, x$ydim), ],
+  notes = paste(
+    "As of version 3.0.0 of the kohonen package, the argument `user.weights`",
+    "replaces the old `alpha` parameter. `user.weights` is usually a vector of",
+    "relative weights such as `c(1, 3)` but is parameterized here as a proportion",
+    "such as `c(1-.75, .75)` where the .75 is the value of the tuning parameter",
+    "passed to `train` and indicates that the outcome layer has 3 times the weight",
+    "as the predictor layer."
+  )
+)

--- a/inst/model_sources/parseModels.R
+++ b/inst/model_sources/parseModels.R
@@ -5,13 +5,12 @@ modelFiles <- list.files(pattern = "\\.R$")
 models <- vector(mode = "list", length = length(modelFiles))
 names(models) <- gsub("\\.R$", "", modelFiles)
 
-for(i in seq(along = modelFiles)) {
+for (i in seq(along = modelFiles)) {
   source(modelFiles[i])
   modelInfo <- lapply(modelInfo, rlang::zap_srcref)
   models[[i]] <- modelInfo
   rm(modelInfo)
 }
-
 
 
 save(models, file = "../../models/models.RData", version = 2)

--- a/inst/model_sources/sampling_methods.R
+++ b/inst/model_sources/sampling_methods.R
@@ -8,16 +8,15 @@ sampling_methods <- list(
   smote = function(x, y) {
     checkInstall("themis")
     library(themis)
-    dat <-
-      if (is.data.frame(x)) {
-        if (inherits(x, "tbl_df")) {
-          as.data.frame(x)
-        } else {
-          x
-        }
+    if (is.data.frame(x)) {
+      if (inherits(x, "tbl_df")) {
+        dat <- as.data.frame(x)
       } else {
-        as.data.frame(x)
+        dat <- x
       }
+    } else {
+      dat <- as.data.frame(x)
+    }
     dat$.y <- y
     dat <- themis::smote(dat, var = ".y")
     list(
@@ -28,12 +27,11 @@ sampling_methods <- list(
   rose = function(x, y) {
     checkInstall("ROSE")
     library(ROSE)
-    dat <-
-      if (is.data.frame(x)) {
-        x
-      } else {
-        as.data.frame(x)
-      }
+    if (is.data.frame(x)) {
+      dat <- x
+    } else {
+      dat <- as.data.frame(x)
+    }
     dat$.y <- y
     dat <- ROSE(.y ~ ., data = dat)$data
     list(

--- a/inst/model_sources/sampling_methods.R
+++ b/inst/model_sources/sampling_methods.R
@@ -1,37 +1,45 @@
 sampling_methods <- list(
-  down = function(x, y)
-    downSample(x, y, list = TRUE),
-  up = function(x, y)
-    upSample(x, y, list = TRUE),
+  down = function(x, y) {
+    downSample(x, y, list = TRUE)
+  },
+  up = function(x, y) {
+    upSample(x, y, list = TRUE)
+  },
   smote = function(x, y) {
     checkInstall("themis")
     library(themis)
     dat <-
       if (is.data.frame(x)) {
-        if (inherits(x, "tbl_df"))
-            as.data.frame(x)
-            else
-              x
+        if (inherits(x, "tbl_df")) {
+          as.data.frame(x)
+        } else {
+          x
+        }
+      } else {
+        as.data.frame(x)
       }
-    else
-      as.data.frame(x)
     dat$.y <- y
     dat <- themis::smote(dat, var = ".y")
-    list(x = dat[,!grepl(".y", colnames(dat), fixed = TRUE), drop = FALSE],
-         y = dat$.y)
+    list(
+      x = dat[, !grepl(".y", colnames(dat), fixed = TRUE), drop = FALSE],
+      y = dat$.y
+    )
   },
   rose = function(x, y) {
     checkInstall("ROSE")
     library(ROSE)
     dat <-
-      if (is.data.frame(x))
+      if (is.data.frame(x)) {
         x
-    else
-      as.data.frame(x)
+      } else {
+        as.data.frame(x)
+      }
     dat$.y <- y
     dat <- ROSE(.y ~ ., data = dat)$data
-    list(x = dat[,!grepl(".y", colnames(dat), fixed = TRUE), drop = FALSE],
-         y = dat$.y)
+    list(
+      x = dat[, !grepl(".y", colnames(dat), fixed = TRUE), drop = FALSE],
+      y = dat$.y
+    )
   }
 )
 save(sampling_methods, file = "inst/models/sampling.RData", version = 2)

--- a/inst/release_process/make_model_Rd.R
+++ b/inst/release_process/make_model_Rd.R
@@ -1,28 +1,36 @@
 print_models <- function(x) {
-
   cat("\\strong{", x$label, "} (\\code{method = '", x$code, "'})\n\n", sep = "")
   cat("For", paste(as.character(tolower(sort(x$type))), collapse = " and "))
-  if(length(x$library) > 0) {
+  if (length(x$library) > 0) {
     pkgs <- paste("\\pkg{", as.character(x$library), "}", sep = "")
     pkgs <- listString(pkgs)
-    if(length(x$library) > 1) 
-      cat(" using packages", pkgs)  else
-        cat(" using package", pkgs)
+    if (length(x$library) > 1) {
+      cat(" using packages", pkgs)
+    } else {
+      cat(" using package", pkgs)
+    }
   }
-  if(all(x$parameters$parameter == "parameter")) {
+  if (all(x$parameters$parameter == "parameter")) {
     cat(" with no tuning parameters.\n\n")
   } else {
-    params <- paste("\\item ", as.character(x$parameters$label), " (\\code{",
-                    as.character(x$parameters$parameter), "}, ",
-                    as.character(x$parameters$class), ")", 
-                    sep = "")
+    params <- paste(
+      "\\item ",
+      as.character(x$parameters$label),
+      " (\\code{",
+      as.character(x$parameters$parameter),
+      "}, ",
+      as.character(x$parameters$class),
+      ")",
+      sep = ""
+    )
     params <- gsub("#", "Number of ", params, fixed = TRUE)
     cat(" with tuning parameters:\n\\itemize{\n")
     cat(paste(params, collapse = "\n", sep = ""))
     cat("\n}\n\n")
   }
-  if(x$note_text != "") 
+  if (x$note_text != "") {
     cat(x$note_text, "\n")
+  }
   cat("\n")
 }
 
@@ -38,33 +46,42 @@ mods <- getModelInfo()
 
 labs <- unlist(lapply(mods, function(x) x$label))
 mods <- mods[order(labs)]
-for(i in seq(along = mods)) {
+for (i in seq(along = mods)) {
   mods[[i]]$code <- names(mods)[i]
-  if(any(names(mods[[i]]) == "notes")) {
+  if (any(names(mods[[i]]) == "notes")) {
     mods[[i]]$note_text <- md2tex(mods[[i]]$notes)
     mods[[i]]$note_text <- paste("Note:", mods[[i]]$note_text)
     mods[[i]]$note_text <- gsub("texttt", "code", mods[[i]]$note_text)
-    mods[[i]]$note_text <- gsub("\\\\textgreater\\{\\}", ">", mods[[i]]$note_text)
-    mods[[i]]$note_text <- gsub("\\ ", " ", mods[[i]]$note_text, fixed = TRUE)    
-    mods[[i]]$note_text <- gsub("\\_", "_", mods[[i]]$note_text, fixed = TRUE)    
-    mods[[i]]$note_text <- gsub("\\$", "$", mods[[i]]$note_text, fixed = TRUE)     
-  } else mods[[i]]$note_text <- ""
+    mods[[i]]$note_text <- gsub(
+      "\\\\textgreater\\{\\}",
+      ">",
+      mods[[i]]$note_text
+    )
+    mods[[i]]$note_text <- gsub("\\ ", " ", mods[[i]]$note_text, fixed = TRUE)
+    mods[[i]]$note_text <- gsub("\\_", "_", mods[[i]]$note_text, fixed = TRUE)
+    mods[[i]]$note_text <- gsub("\\$", "$", mods[[i]]$note_text, fixed = TRUE)
+  } else {
+    mods[[i]]$note_text <- ""
+  }
 }
 
 
-
 sink("~/github/caret/man/models.Rd")
-cat("\\name{train_model_list}\n",
-    "\\alias{train_model_list}\n",
-    "\\alias{models}\n",    
-    "\\title{A List of Available Models in train}\n",
-    "\\description{", 
-    "These models are included in the package via wrappers for ",
-    "\\code{\\link{train}}. Custom models can also be created. See the URL below.\n\n",
-    sep = "")
+cat(
+  "\\name{train_model_list}\n",
+  "\\alias{train_model_list}\n",
+  "\\alias{models}\n",
+  "\\title{A List of Available Models in train}\n",
+  "\\description{",
+  "These models are included in the package via wrappers for ",
+  "\\code{\\link{train}}. Custom models can also be created. See the URL below.\n\n",
+  sep = ""
+)
 tt <- lapply(mods, print_models)
 cat("}\n")
 
-cat("\\references{``Using your own model in \\code{\\link{train}}'' (\\url{https://topepo.github.io/caret/using-your-own-model-in-train.html})}\n")
+cat(
+  "\\references{``Using your own model in \\code{\\link{train}}'' (\\url{https://topepo.github.io/caret/using-your-own-model-in-train.html})}\n"
+)
 cat("\\keyword{models}\n")
 sink()

--- a/inst/release_process/reverse_depends.R
+++ b/inst/release_process/reverse_depends.R
@@ -7,12 +7,14 @@ options(repos = "http://cran.r-project.org")
 ###  Make a time stamped path for the source code
 
 devel_path <- paste0("~/tmp/rev_deps_devel_", format(Sys.time(), "%Y_%m_%d_%H"))
-prod_path  <- paste0("~/tmp/rev_deps_prod_",  format(Sys.time(), "%Y_%m_%d_%H"))
+prod_path <- paste0("~/tmp/rev_deps_prod_", format(Sys.time(), "%Y_%m_%d_%H"))
 
-if(!dir.exists(devel_path))
+if (!dir.exists(devel_path)) {
   dir.create(devel_path)
-if(!dir.exists(prod_path))
+}
+if (!dir.exists(prod_path)) {
   dir.create(prod_path)
+}
 
 ##############################################################
 ### Copy the current tar file of caret sources to this path
@@ -41,7 +43,7 @@ summarize_check_packages_in_dir_results(prod_path)
 ### Look at differences
 
 has_error <- function(x) {
-  txt <- read.delim(x, sep = "\n", stringsAsFactors = FALSE)[,1]
+  txt <- read.delim(x, sep = "\n", stringsAsFactors = FALSE)[, 1]
   status_txt <- grep("^Status", txt, value = TRUE)
   pkg_issue <- any(grepl("but not available:", txt))
   isTRUE(grepl("ERROR", status_txt)) & !pkg_issue
@@ -50,12 +52,12 @@ has_error <- function(x) {
 check_dirs <- list.dirs(prod_path, recursive = FALSE)
 check_dirs <- grep("Rcheck$", basename(check_dirs), value = TRUE)
 
-for(i in check_dirs) {
+for (i in check_dirs) {
   old_check <- file.path(prod_path, i, "00check.log")
   new_check <- file.path(devel_path, i, "00check.log")
-  if(file.exists(old_check) && file.exists(new_check)) {
+  if (file.exists(old_check) && file.exists(new_check)) {
     # look for errors in either
-    if(has_error(old_check) || has_error(new_check)) {
+    if (has_error(old_check) || has_error(new_check)) {
       file_diff <- diffr(old_check, new_check)
       print(file_diff)
     }
@@ -63,21 +65,18 @@ for(i in check_dirs) {
 }
 
 
-
-
 # For the future:
-if(FALSE) {
+if (FALSE) {
   source("https://install-github.me/r-lib/revdepcheck")
   library(revdepcheck)
   library(parallel)
-  
+
   setwd("~/github/caret/")
-  
+
   revdep_check(num_workers = detectCores() - 1)
 }
 
 
-if(!interactive()) q("no")
-
-
-
+if (!interactive()) {
+  q("no")
+}

--- a/inst/release_process/update_biocmanager.R
+++ b/inst/release_process/update_biocmanager.R
@@ -35,7 +35,9 @@ options(repos = "http://cran.r-project.org")
 all_pkg <- rownames(available.packages(type = "source"))
 
 diffs <- libs[!(libs %in% all_pkg)]
-if (length(diffs) > 0) print(diffs)
+if (length(diffs) > 0) {
+  print(diffs)
+}
 
 # ------------------------------------------------------------------------------
 ## Install the files. This might re-install caret so beware.
@@ -70,7 +72,7 @@ for (i in seq_along(libs)) {
 # ------------------------------------------------------------------------------
 # exceptions:
 
-install.packages("CHAID", repos="http://R-Forge.R-project.org")
+install.packages("CHAID", repos = "http://R-Forge.R-project.org")
 
 # ------------------------------------------------------------------------------
 

--- a/inst/release_process/update_pak.R
+++ b/inst/release_process/update_pak.R
@@ -34,7 +34,9 @@ options(repos = "http://cran.r-project.org")
 all_pkg <- rownames(available.packages(type = "source"))
 
 diffs <- libs[!(libs %in% all_pkg)]
-if (length(diffs) > 0) print(diffs)
+if (length(diffs) > 0) {
+  print(diffs)
+}
 
 # ------------------------------------------------------------------------------
 ## Install the files. This might re-install caret so beware.
@@ -63,7 +65,7 @@ for (i in seq_along(libs)) {
 # ------------------------------------------------------------------------------
 # exceptions:
 
-install.packages("CHAID", repos="http://R-Forge.R-project.org")
+install.packages("CHAID", repos = "http://R-Forge.R-project.org")
 
 # ------------------------------------------------------------------------------
 

--- a/plans/2026-07-13-1024-if-brace-formatting-inst.md
+++ b/plans/2026-07-13-1024-if-brace-formatting-inst.md
@@ -1,0 +1,56 @@
+# Brace unbraced `if` statements and rewrite assignment-with-`if/else` in inst/
+
+## Overview
+
+Same pass as `plans/2026-07-13-0853-if-brace-formatting.md` (branch
+`air-if-brace-formatting`, for `R/` and `tests/`), now applied to the R files
+under `inst/` on top of the `air-format-inst` branch: the 239 model-definition
+files in `inst/model_sources/files/`, plus `inst/model_sources/*.R`,
+`inst/bookdown/make_files.R`, and `inst/release_process/*.R` (246 files total).
+
+Scope at start: 143 assignment-with-if sites, ~33 unbraced single-line ifs.
+No `# fmt: skip` guards or non-ASCII content in these files.
+
+Rules (as approved for the R/ pass):
+- Unbraced if branches get braces; `else if` chains stay flat.
+- `lhs <- if (...) ...` (inline and braced forms) becomes an if/else statement
+  with the assignment distributed into each terminal branch; no-op
+  `else lhs <- lhs` arms are dropped (unless the value is consumed); arms
+  ending in `stop()`/`return()` carry no assignment; missing else arms gain
+  `lhs <- NULL` (flagged for review).
+- Value-position ifs (call arguments) are left inline and flagged.
+
+## Checklist
+
+- [x] Branch `air-if-brace-inst` off `air-format-inst`; plan file
+- [x] Run pass A then pass B of the session transformer script on all inst/ R files
+      (116 files changed: 115 model definitions + `sampling_methods.R`)
+- [x] `air format inst`; confirm `air format --check inst` is clean
+- [x] Resolve flagged sites manually (see notes)
+- [x] Verify: all 246 files parse; each changed file sources cleanly and its
+      objects are structurally identical to the HEAD version (element names at
+      all levels, function formals, non-function values); pattern greps clean
+- [x] Commit on `air-if-brace-inst`
+
+## Outcome notes
+
+Sites needing manual handling (all resolved):
+- `pls.R`, `kernelpls.R`, `simpls.R`, `widekernelpls.R` (shared predict
+  template): then arm already assigned `out`; distributed the assignment onto
+  the else arm and dropped the redundant outer `out <-`.
+- `mlpSGD.R` (predict): else arm ended in `out <- apply(...)`; same treatment.
+- `parRF.R` (fit): no-op else arm (`theDots$ntree`); dropped it.
+
+Left as-is by design: value-position ifs used as call arguments
+(`lasso.R`, `leapBackward.R`, `leapForward.R`, `leapSeq.R`, `M5.R`, `plr.R`).
+
+The package R code and tests are untouched on this branch, so the test suite
+does not exercise these files; `models.RData` was not rebuilt.
+
+## Details
+
+The transformer script and its 20-case synthetic validation are described in
+the earlier plan. Note these inst/ files are data/source templates (parsed into
+`models.RData` by `inst/model_sources/parseModels.R`), not package code, so the
+package test suite does not exercise them; verification is parse + source +
+structure comparison plus diff review. `models.RData` is not rebuilt here.


### PR DESCRIPTION
Run `air format` (air 0.9.0) over the R files under inst/ -- primarily the 239 model-definition files in inst/model_sources/files, plus the handful in inst/model_sources, inst/release_process and inst/bookdown.

Split from the R/ + tests/ formatting so the reviewable core change stays separate from this large, blame-churning catalog reformat.