### PR TITLE
Fix recipe sbf boot632 resampling

### DIFF
--- a/R/selectByFilter.R
+++ b/R/selectByFilter.R
@@ -642,9 +642,9 @@ sbf_rec <- function(rec, data, ctrl, lev, ...) {
   loadNamespace("caret")
 
   resampleIndex <- ctrl$index
-  if (ctrl$method %in% c("boot632")) {
-    resampleIndex <- c(list("AllData" = rep(0, nrow(x))), resampleIndex)
-    ctrl$indexOut <- c(list("AllData" = rep(0, nrow(x))), ctrl$indexOut)
+  if (ctrl$method == "boot632") {
+    resampleIndex <- c(list("AllData" = rep(0, nrow(data))), resampleIndex)
+    ctrl$indexOut <- c(list("AllData" = rep(0, nrow(data))), ctrl$indexOut)
   }
 
   `%op%` <- getOper(ctrl$allowParallel && getDoParWorkers() > 1)
@@ -748,33 +748,30 @@ sbf_rec <- function(rec, data, ctrl, lev, ...) {
   } else {
     pred <- NULL
   }
-  performance <- MeanSD(resamples[,
-    !grepl("Resample", colnames(resamples)),
+  if (ctrl$method == "boot632") {
+    apparent <- resamples[
+      resamples$Resample == "AllData",
+      !grepl("Resample", colnames(resamples)),
+      drop = FALSE
+    ]
+    performanceResamples <- resamples[resamples$Resample != "AllData", ]
+  } else {
+    performanceResamples <- resamples
+  }
+  performance <- MeanSD(performanceResamples[,
+    !grepl("Resample", colnames(performanceResamples)),
     drop = FALSE
   ])
 
-  if (ctrl$method %in% c("boot632")) {
-    modelIndex <- seq_len(nrow(x))
-    holdoutIndex <- modelIndex
-    appResults <- sbfIter(
-      x = x_tr,
-      y = y_tr,
-      testX = x_te,
-      testY = y_te,
-      testPerf = perf_te,
-      ctrl,
-      ...
-    )
-    apparent <- ctrl$functions$summary(appResults$pred, lev = lev)
+  if (ctrl$method == "boot632") {
     perfNames <- names(apparent)
-    perfNames <- perfNames[perfNames != "Resample"]
 
     const <- 1 - exp(-1)
 
     for (p in seq(along.with = perfNames)) {
       performance[perfNames[p]] <-
         (const * performance[perfNames[p]]) +
-        ((1 - const) * apparent[perfNames[p]])
+        ((1 - const) * apparent[[perfNames[p]]])
     }
   }
 

--- a/tests/testthat/test-recipe-fs.R
+++ b/tests/testthat/test-recipe-fs.R
@@ -24,6 +24,30 @@ test_that("sbf with recipes", {
 
 # ------------------------------------------------------------------------------
 
+test_that("sbf with recipes and boot632 resampling", {
+  skip_on_cran()
+
+  rec <- recipe(y ~ ., data = recipe_fs_dat) %>% step_log(mw)
+
+  set.seed(3997)
+  sbf_rec <- sbf(
+    rec,
+    data = recipe_fs_dat[-(1:100), ],
+    sbfControl = sbfControl(functions = lmSBF, method = "boot632", number = 5)
+  )
+
+  metrics <- c("RMSE", "Rsquared", "MAE")
+  apparent <- sbf_rec$resample$Resample == "AllData"
+  expected <- (1 - exp(-1)) *
+    colMeans(sbf_rec$resample[!apparent, metrics]) +
+    exp(-1) * unlist(sbf_rec$resample[apparent, metrics])
+
+  expect_equal(unlist(sbf_rec$results[metrics]), expected)
+})
+
+
+# ------------------------------------------------------------------------------
+
 test_that("safs with recipes", {
   skip_on_cran()
   ctrl <- safsControl(functions = caretSA, method = "cv", number = 3)


### PR DESCRIPTION
Recipe-based SBF referenced an undefined data object and loop-local transformed values when calculating the apparent error for boot632 resampling. This caused the workflow to fail before returning results.\n\nReuse the existing seeded AllData resample as the apparent estimate and exclude it from the bootstrap average before applying the .632 weighting. The regression test now verifies the resulting weighted metrics.

Found with https://github.com/sims1253/ry