### PR TITLE
Add tests for findLinearCombos and findCorrelation

### DIFF
--- a/tests/testthat/helper-collinearity.R
+++ b/tests/testthat/helper-collinearity.R
@@ -1,0 +1,39 @@
+# Shared fixtures for the collinearity tests
+# (test-findLinearCombos.R and test-findCorrelation.R).
+
+# --- findLinearCombos: numeric matrices with known linear dependencies -------
+# Three columns where the third is the sum of the first two (rank 2)
+flc_x1 <- c(1, 2, 3, 4)
+flc_x2 <- c(2, 1, 4, 3)
+flc_simple <- cbind(flc_x1, flc_x2, flc_x1 + flc_x2)
+
+# A full-rank matrix (no linear combinations)
+flc_full <- diag(3)
+
+# Two linear combinations that require iterative removal (from the docs):
+# column 1 = column 2 + column 3, and column 1 = column 4 + column 5 + column 6
+flc_multi <- matrix(0, nrow = 6, ncol = 6)
+flc_multi[, 1] <- 1
+flc_multi[, 2] <- c(1, 1, 1, 0, 0, 0)
+flc_multi[, 3] <- c(0, 0, 0, 1, 1, 1)
+flc_multi[, 4] <- c(1, 0, 0, 1, 0, 0)
+flc_multi[, 5] <- c(0, 1, 0, 0, 1, 0)
+flc_multi[, 6] <- c(0, 0, 1, 0, 0, 1)
+
+# --- findCorrelation: correlation matrices (from the docs) -------------------
+# fmt: skip
+corr_R1 <- structure(
+  c(1.00, 0.86, 0.56, 0.32, 0.85,
+    0.86, 1.00, 0.01, 0.74, 0.32,
+    0.56, 0.01, 1.00, 0.65, 0.91,
+    0.32, 0.74, 0.65, 1.00, 0.36,
+    0.85, 0.32, 0.91, 0.36, 1.00),
+  .Dim = c(5L, 5L)
+)
+colnames(corr_R1) <- rownames(corr_R1) <- paste0("x", 1:5)
+
+# A correlation matrix with negative off-diagonal entries
+corr_R2 <- diag(rep(1, 5))
+corr_R2[2, 3] <- corr_R2[3, 2] <- 0.7
+corr_R2[5, 3] <- corr_R2[3, 5] <- -0.7
+corr_R2[4, 1] <- corr_R2[1, 4] <- -0.67

--- a/tests/testthat/helper-collinearity.R
+++ b/tests/testthat/helper-collinearity.R
@@ -37,3 +37,10 @@ corr_R2 <- diag(rep(1, 5))
 corr_R2[2, 3] <- corr_R2[3, 2] <- 0.7
 corr_R2[5, 3] <- corr_R2[3, 5] <- -0.7
 corr_R2[4, 1] <- corr_R2[1, 4] <- -0.67
+# Give column 4 an extra sub-cutoff correlation so that, of the highly
+# correlated pair (1, 4), column 4 has the clearly larger mean absolute
+# correlation and is the one dropped. Without this, columns 1 and 4 are
+# symmetric and their mean correlations tie at the floating-point level; the
+# tie then breaks differently across platforms (64- vs 80-bit long double), so
+# findCorrelation removes column 4 on macOS but column 1 on Linux.
+corr_R2[4, 2] <- corr_R2[2, 4] <- 0.5

--- a/tests/testthat/test-findCorrelation.R
+++ b/tests/testthat/test-findCorrelation.R
@@ -1,0 +1,70 @@
+# Fixtures (corr_R1, corr_R2) live in helper-collinearity.R
+
+# --- findCorrelation --------------------------------------------------------
+
+test_that("findCorrelation (exact) flags the expected columns", {
+  expect_equal(findCorrelation(corr_R1, cutoff = 0.6, exact = TRUE), c(1, 5, 4))
+})
+
+test_that("findCorrelation (fast) flags the expected columns", {
+  expect_equal(
+    findCorrelation(corr_R1, cutoff = 0.6, exact = FALSE),
+    c(4, 5, 1, 3)
+  )
+})
+
+test_that("findCorrelation can return column names", {
+  expect_equal(
+    findCorrelation(corr_R1, cutoff = 0.6, exact = TRUE, names = TRUE),
+    c("x1", "x5", "x4")
+  )
+})
+
+test_that("findCorrelation handles negative correlations", {
+  expect_equal(findCorrelation(corr_R2, cutoff = 0.65), c(3, 4))
+})
+
+test_that("findCorrelation returns nothing when nothing exceeds the cutoff", {
+  expect_length(findCorrelation(corr_R2, cutoff = 0.99), 0)
+})
+
+test_that("findCorrelation errors when names are requested but unavailable", {
+  m <- corr_R2
+  dimnames(m) <- NULL
+  expect_error(findCorrelation(m, names = TRUE), "must have column names")
+})
+
+test_that("findCorrelation prints details when verbose", {
+  expect_output(findCorrelation(corr_R2, cutoff = 0.65, verbose = TRUE))
+  # the exact method prints which column it flags at each comparison
+  expect_output(
+    findCorrelation(corr_R1, cutoff = 0.6, exact = TRUE, verbose = TRUE)
+  )
+  # the fast method has its own verbose output
+  expect_output(
+    findCorrelation(corr_R1, cutoff = 0.6, exact = FALSE, verbose = TRUE)
+  )
+  # the exact method reports when every correlation is below the cutoff
+  expect_output(
+    findCorrelation(corr_R2, cutoff = 0.99, verbose = TRUE),
+    "All correlations"
+  )
+})
+
+# --- internal helpers -------------------------------------------------------
+
+test_that("findCorrelation_fast rejects missing values", {
+  m <- corr_R1
+  m[1, 2] <- NA
+  expect_error(caret:::findCorrelation_fast(m, cutoff = 0.6), "missing values")
+})
+
+test_that("findCorrelation_exact rejects non-symmetric and singleton input", {
+  ns <- corr_R1
+  ns[1, 2] <- 0.1 # break symmetry
+  expect_error(caret:::findCorrelation_exact(ns), "not symmetric")
+  expect_error(
+    caret:::findCorrelation_exact(matrix(1, 1, 1)),
+    "only one variable"
+  )
+})

--- a/tests/testthat/test-findLinearCombos.R
+++ b/tests/testthat/test-findLinearCombos.R
@@ -1,0 +1,43 @@
+# Fixtures (flc_simple, flc_full, flc_multi) live in helper-collinearity.R
+
+# --- findLinearCombos -------------------------------------------------------
+
+test_that("findLinearCombos finds a single dependency", {
+  res <- findLinearCombos(flc_simple)
+  expect_equal(res$linearCombos, list(c(3, 1, 2)))
+  expect_equal(res$remove, 3)
+})
+
+test_that("findLinearCombos reports nothing for a full-rank matrix", {
+  res <- findLinearCombos(flc_full)
+  expect_equal(res$linearCombos, list())
+  expect_null(res$remove)
+})
+
+test_that("findLinearCombos resolves multiple dependencies iteratively", {
+  res <- findLinearCombos(flc_multi)
+  expect_equal(res$linearCombos, list(c(3, 1, 2), c(6, 1, 4, 5)))
+  expect_equal(res$remove, c(3, 6))
+})
+
+test_that("findLinearCombos coerces non-matrix input", {
+  res <- findLinearCombos(as.data.frame(flc_simple))
+  expect_equal(res$remove, 3)
+})
+
+# --- enumLC methods ---------------------------------------------------------
+
+test_that("enumLC errors for unsupported objects", {
+  expect_error(caret:::enumLC("nope"), "does not support")
+})
+
+test_that("enumLC works for lm and formula objects", {
+  set.seed(1)
+  x1 <- rnorm(20)
+  x2 <- rnorm(20)
+  y <- x1 + x2 + rnorm(20)
+  # the formula method routes through the lm method, and both end up in
+  # internalEnumLC; a full-rank fit has no linear combinations
+  expect_type(caret:::enumLC(y ~ x1 + x2), "list")
+  expect_type(caret:::enumLC(lm(y ~ x1 + x2)), "list")
+})


### PR DESCRIPTION
Cover the two collinearity/redundant-predictor functions, sharing a single helper-collinearity.R for their fixtures:

- findLinearCombos: 0% -> 100%
- findCorrelation: ~48% -> ~99%

The only uncovered line is an effectively-unreachable 'next' branch in findCorrelation_exact. The corr_R1 fixture uses '# fmt: skip' to keep its grid layout.