### PR TITLE
Update codecov-action to v7.0.0 to fix GPG signature verification

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -36,7 +36,7 @@ jobs:
           covr::to_cobertura(cov)
         shell: Rscript {0}
 
-      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           # Fail if error if not on PR, or if on PR and token is given
           fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
The test-coverage workflow has been failing at the codecov upload step:

```
==> Verifying GPG signature integrity
==> Could not verify signature. Please contact Codecov if problem continues
##[error]Process completed with exit code 1.
```

Example failure: https://github.com/topepo/caret/actions/runs/29355518471/job/87162039168

The workflow pins `codecov/codecov-action` at v6.0.0, which verifies the downloaded Codecov CLI against a GPG key that no longer works. Per the [v7.0.0 release notes](https://github.com/codecov/codecov-action/releases/tag/v7.0.0), Codecov deleted their `codecovsecurity` keybase account and moved signing to `codecovsecops`, so older action versions can no longer verify the signature. Note that the `CODECOV_TOKEN` secret itself is fine — the log shows `Token set from input` before the failure.

This updates the pin to the v7.0.0 commit (`fb8b3582`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)