### PR TITLE
Fix model-diversity filter bugs in adaptive resampling and add tests

### DIFF
--- a/R/adaptive.R
+++ b/R/adaptive.R
@@ -1435,13 +1435,12 @@ cccmat <- function(dat) {
   out <- matrix(1, ncol = p, nrow = p)
   for (i in 1:p) {
     for (j in i:p) {
-      if (i > j) {
+      if (i < j) {
         tmp <- ccc(dat[, i], dat[, j])
         out[i, j] <- out[j, i] <- tmp
       }
     }
   }
-  out[lower.tri(out)] <- out[upper.tri(out)]
   colnames(out) <- rownames(out) <- colnames(dat)
   out
 }
@@ -1470,7 +1469,6 @@ diffmat <- function(dat) {
       }
     }
   }
-  out[lower.tri(out)] <- out[upper.tri(out)]
   colnames(out) <- rownames(out) <- colnames(dat)
   out
 }
@@ -1495,14 +1493,12 @@ filter_on_diff <- function(
     return(dat)
   }
   varnum <- dim(x)[1]
-  originalOrder <- 1:varnum
   averageDiff <- function(x) mean(x, na.rm = TRUE)
   tmp <- x
   diag(tmp) <- NA
   maxAbsCorOrder <- order(apply(tmp, 2, averageDiff), decreasing = TRUE)
   x <- x[maxAbsCorOrder, maxAbsCorOrder]
   mns <- mns[maxAbsCorOrder]
-  newOrder <- originalOrder[maxAbsCorOrder]
   deletecol <- 0
   for (i in 1:(varnum - 1)) {
     for (j in (i + 1):varnum) {
@@ -1520,7 +1516,7 @@ filter_on_diff <- function(
 
   deletecol <- deletecol[deletecol != 0]
   if (length(deletecol) > 0) {
-    dumped <- colnames(x)[newOrder[deletecol]]
+    dumped <- colnames(x)[deletecol]
     if (verbose) {
       cat(paste(
         "o",
@@ -1549,13 +1545,11 @@ filter_on_corr <- function(dat, metric, cutoff, verbose = FALSE) {
     stop("only one variable given")
   }
   x <- abs(x)
-  originalOrder <- 1:varnum
   averageCorr <- function(x) mean(x, na.rm = TRUE)
   tmp <- x
   diag(tmp) <- NA
   maxAbsCorOrder <- order(apply(tmp, 2, averageCorr), decreasing = TRUE)
   x <- x[maxAbsCorOrder, maxAbsCorOrder]
-  newOrder <- originalOrder[maxAbsCorOrder]
   deletecol <- 0
   for (i in 1:(varnum - 1)) {
     for (j in (i + 1):varnum) {
@@ -1572,7 +1566,7 @@ filter_on_corr <- function(dat, metric, cutoff, verbose = FALSE) {
   }
   deletecol <- deletecol[deletecol != 0]
   if (length(deletecol) > 0) {
-    dumped <- colnames(x)[newOrder[deletecol]]
+    dumped <- colnames(x)[deletecol]
     if (verbose) {
       cat(paste(
         "o",

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -8,6 +8,7 @@
    \item CRAN mandated update.
    \item caret will be 20 years old in March of 2026. The package is currently in maintenance mode; the author will fix bugs and make CRAN releases as needed, but there will not be any major features in the package. It will stay on CRAN long-term; it's not going away.
    \item The \code{earth} model now defines a \code{trim} method, so \code{trainControl(trim = TRUE)} reduces the size of fitted \code{earth} models (dropping the stored \code{x}, \code{y}, and \code{call}) without affecting predictions.
+   \item Fixed three bugs in the model-diversity filters used by adaptive resampling: the concordance matrix (\code{cccmat}) was never populated and always returned a matrix of ones; both \code{cccmat} and \code{diffmat} scrambled their entries (breaking symmetry) for four or more models; and \code{filter_on_corr}/\code{filter_on_diff} removed the wrong models due to an index-permutation error.
   }
 }
 

--- a/tests/testthat/_snaps/adaptive.md
+++ b/tests/testthat/_snaps/adaptive.md
@@ -1,0 +1,8 @@
+# filter_on_corr errors with a single model
+
+    Code
+      caret:::filter_on_corr(one, "RMSE", cutoff = 0.9)
+    Condition
+      Error in `matrix()`:
+      ! non-numeric matrix extent
+

--- a/tests/testthat/helper-adaptive.R
+++ b/tests/testthat/helper-adaptive.R
@@ -1,0 +1,57 @@
+# Test data shared by test-adaptive.R.
+#
+# The tests here poke at the internal model-diversity helpers in R/adaptive.R:
+# ccc, cccmat, diffmat, long2wide, get_id, filter_on_corr and filter_on_diff.
+
+# RMSE for four candidate models, one column each, scored across five resamples
+# (the rows). Lower is better. Everything else is built from this matrix, so if
+# you want to tweak the data, tweak it here.
+#
+#   m1 - our best model
+#   m2 - basically a copy of m1: it moves up and down with m1 and is only ~0.05
+#        worse, so it's redundant and the filters should drop it
+#   m3 - a different, middling model
+#   m4 - a different, clearly worse model
+adapt_wide <- cbind(
+  m1 = c(1.00, 1.20, 0.90, 1.10, 1.00),
+  m2 = c(1.05, 1.25, 0.95, 1.15, 1.05),
+  m3 = c(2.00, 1.80, 2.20, 1.90, 2.10),
+  m4 = c(3.00, 2.70, 3.30, 2.80, 3.20)
+)
+rownames(adapt_wide) <- paste0("Fold", 1:5)
+
+# The same numbers, reshaped into the long form adaptiveWorkflow() actually
+# works with: one row per model per resample. Building it straight from
+# adapt_wide keeps the two views in sync and lines the columns up automatically.
+adapt_results <- data.frame(
+  model_id = rep(colnames(adapt_wide), each = nrow(adapt_wide)),
+  Resample = rep(rownames(adapt_wide), times = ncol(adapt_wide)),
+  RMSE = as.numeric(adapt_wide),
+  stringsAsFactors = FALSE
+)
+
+# For reference, here's what the helpers make of this data (rounded):
+#
+# cccmat() measures how concordant two models are. m1 and m2 land around 0.91
+# because they're near-copies; every other pair sits close to 0:
+#        m1     m2     m3     m4
+#   m1 1.000  0.912 -0.036 -0.014
+#   m2 0.912  1.000 -0.040 -0.015
+#   m3 ...    ...    1.000  0.073
+#   m4 ...    ...    0.073  1.000
+#
+# diffmat() measures the standardised gap in performance. m1 and m2 differ by
+# the same amount everywhere, so their gap is 0; every other pair is far apart
+# (the diagonal is NA):
+#        m1    m2     m3     m4
+#   m1   NA  0.000  3.553  5.374
+#   m2 0.000   NA   3.368  5.237
+#   ...
+#
+# Either way m2 looks redundant next to m1, so both filters keep {m1, m3, m4}:
+#   filter_on_corr(adapt_results, "RMSE", cutoff = 0.9)         -> m1 m3 m4
+#   filter_on_diff(adapt_results, "RMSE", cutoff = 0.1, FALSE)  -> m1 m3 m4
+
+# A little tuning grid with a repeated row, for get_id() - the two k = 3 rows
+# should collapse into a single model.
+adapt_grid <- data.frame(k = c(3, 3, 5, 7, 9))

--- a/tests/testthat/test-adaptive-train.R
+++ b/tests/testthat/test-adaptive-train.R
@@ -1,0 +1,51 @@
+# These run adaptive resampling the way someone actually would - through train()
+# - and check we get a sensible model back. It's the only route that reaches
+# adaptiveWorkflow() (and the diversity filters underneath it), so we keep the
+# runs tiny and skip when the optional racing packages aren't around.
+
+adaptive_knn_fit <- function(eval_method) {
+  set.seed(1)
+  suppressWarnings(train(
+    Species ~ .,
+    data = iris,
+    method = "knn",
+    tuneGrid = data.frame(k = c(1, 5, 9, 13, 17)),
+    trControl = trainControl(
+      method = "adaptive_cv",
+      number = 10,
+      adaptive = list(
+        min = 3,
+        alpha = 0.05,
+        method = eval_method,
+        complete = TRUE
+      )
+    )
+  ))
+}
+
+test_that("adaptive_cv tuning runs end to end with the gls racer", {
+  skip_on_cran()
+  skip_if_not_installed("nlme")
+
+  fit <- adaptive_knn_fit("gls")
+
+  expect_s3_class(fit, "train")
+  expect_equal(fit$control$method, "adaptive_cv")
+  expect_false(is.null(fit$finalModel))
+  # every candidate still shows up in the results, and the winner is one of them
+  expect_equal(sort(fit$results$k), c(1, 5, 9, 13, 17))
+  expect_true(fit$bestTune$k %in% fit$results$k)
+  # and the model we get back can actually make predictions
+  expect_length(predict(fit, iris), nrow(iris))
+})
+
+test_that("adaptive_cv tuning runs end to end with the Bradley-Terry racer", {
+  skip_on_cran()
+  skip_if_not_installed("BradleyTerry2")
+
+  fit <- adaptive_knn_fit("BT")
+
+  expect_s3_class(fit, "train")
+  expect_true(fit$bestTune$k %in% fit$results$k)
+  expect_length(predict(fit, iris), nrow(iris))
+})

--- a/tests/testthat/test-adaptive.R
+++ b/tests/testthat/test-adaptive.R
@@ -1,0 +1,137 @@
+# The fixtures (adapt_results, adapt_wide, adapt_grid) live in helper-adaptive.R.
+# These check the little model-picking helpers behind adaptiveWorkflow() - the
+# workflow itself is tested elsewhere.
+
+# --- ccc --------------------------------------------------------------------
+
+test_that("ccc returns Lin's concordance correlation coefficient", {
+  # two identical vectors agree perfectly, so we should get exactly 1
+  expect_equal(caret:::ccc(1:5, 1:5), 1)
+  # a pair that disagrees, with a value we can work out by hand
+  expect_equal(caret:::ccc(1:5, c(5, 3, 1, 2, 4)), -0.3)
+  # shifting every value by a constant should pull ccc below 1, even though the
+  # plain correlation would still be a perfect 1
+  expect_lt(caret:::ccc(1:5, (1:5) + 1), 1)
+})
+
+# --- cccmat -----------------------------------------------------------------
+
+test_that("cccmat builds a symmetric concordance matrix with unit diagonal", {
+  cc <- caret:::cccmat(adapt_wide)
+  expect_equal(dim(cc), c(4, 4))
+  expect_equal(unname(diag(cc)), rep(1, 4))
+  expect_equal(cc, t(cc))
+  expect_equal(colnames(cc), colnames(adapt_wide))
+})
+
+test_that("cccmat off-diagonals match ccc() and reflect the data", {
+  cc <- caret:::cccmat(adapt_wide)
+  # each cell should be the real pairwise score - before the fix this matrix
+  # came back as all 1s
+  expect_equal(
+    cc["m1", "m2"],
+    caret:::ccc(adapt_wide[, "m1"], adapt_wide[, "m2"])
+  )
+  expect_equal(
+    cc["m1", "m3"],
+    caret:::ccc(adapt_wide[, "m1"], adapt_wide[, "m3"])
+  )
+  # m1 and m2 look almost the same; m1 and m3 don't
+  expect_gt(cc["m1", "m2"], 0.9)
+  expect_lt(abs(cc["m1", "m3"]), 0.1)
+})
+
+# --- diffmat ----------------------------------------------------------------
+
+test_that("diffmat is symmetric with an NA diagonal", {
+  dm <- caret:::diffmat(adapt_wide)
+  expect_equal(dim(dm), c(4, 4))
+  expect_true(all(is.na(diag(dm))))
+  # it should match its own transpose (leaving the NA diagonal aside)
+  expect_equal(dm[lower.tri(dm)], t(dm)[lower.tri(dm)])
+})
+
+test_that("diffmat returns 0 when two columns differ by a constant", {
+  # if two columns differ by the same amount everywhere, there's no spread in
+  # the difference, so the gap comes out as 0
+  m <- cbind(a = c(1, 2, 3), b = c(1, 2, 3) + 5)
+  dm <- caret:::diffmat(m)
+  expect_equal(dm["a", "b"], 0)
+})
+
+# --- long2wide --------------------------------------------------------------
+
+test_that("long2wide reshapes resampling results to one row per resample", {
+  w <- caret:::long2wide(adapt_results, "RMSE")
+  expect_equal(colnames(w), c("Resample", "m1", "m2", "m3", "m4"))
+  expect_equal(nrow(w), length(unique(adapt_results$Resample)))
+  expect_equal(w$Resample, sort(unique(adapt_results$Resample)))
+  # pick one cell and make sure it survived the reshape intact
+  expect_equal(w$m3[w$Resample == "Fold1"], 2.0)
+})
+
+# --- get_id -----------------------------------------------------------------
+
+test_that("get_id assigns one id per unique parameter combination", {
+  ids <- caret:::get_id(adapt_grid, "k")
+  # the two k = 3 rows should fold into one
+  expect_equal(ids$k, c(3, 5, 7, 9))
+  expect_equal(ids$model_id, c("m1", "m2", "m3", "m4"))
+})
+
+test_that("get_id zero-pads ids so they sort correctly", {
+  ids <- caret:::get_id(data.frame(k = 1:12), "k")
+  expect_equal(ids$model_id[1], "m01")
+  expect_equal(ids$model_id[12], "m12")
+})
+
+# --- filter_on_corr ---------------------------------------------------------
+
+test_that("filter_on_corr drops a redundant (highly concordant) model", {
+  keep <- sort(unique(
+    caret:::filter_on_corr(adapt_results, "RMSE", cutoff = 0.9)$model_id
+  ))
+  # m2 just echoes m1, so it gets dropped and the distinct models stay
+  expect_equal(keep, c("m1", "m3", "m4"))
+})
+
+test_that("filter_on_corr keeps everything when nothing exceeds the cutoff", {
+  keep <- sort(unique(
+    caret:::filter_on_corr(adapt_results, "RMSE", cutoff = 1)$model_id
+  ))
+  expect_equal(keep, c("m1", "m2", "m3", "m4"))
+})
+
+test_that("filter_on_corr errors with a single model", {
+  one <- adapt_results[adapt_results$model_id == "m1", ]
+  expect_error(caret:::filter_on_corr(one, "RMSE", cutoff = 0.9))
+})
+
+# --- filter_on_diff ---------------------------------------------------------
+
+test_that("filter_on_diff drops the weaker of two indistinguishable models", {
+  keep <- sort(unique(
+    caret:::filter_on_diff(
+      adapt_results,
+      "RMSE",
+      cutoff = 0.1,
+      maximize = FALSE
+    )$model_id
+  ))
+  # m1 and m2 are basically the same; keep the better one (m1), drop m2
+  expect_equal(keep, c("m1", "m3", "m4"))
+})
+
+test_that("filter_on_diff keeps everything when nothing is below the cutoff", {
+  # nothing is closer than the cutoff, so it should bail out early and leave
+  # every model in place
+  keep <- sort(unique(
+    caret:::filter_on_diff(
+      adapt_results,
+      "RMSE",
+      cutoff = 0,
+      maximize = FALSE
+    )$model_id
+  ))
+  expect_equal(keep, c("m1", "m2", "m3", "m4"))
+})

--- a/tests/testthat/test-adaptive.R
+++ b/tests/testthat/test-adaptive.R
@@ -104,7 +104,10 @@ test_that("filter_on_corr keeps everything when nothing exceeds the cutoff", {
 
 test_that("filter_on_corr errors with a single model", {
   one <- adapt_results[adapt_results$model_id == "m1", ]
-  expect_error(caret:::filter_on_corr(one, "RMSE", cutoff = 0.9))
+  expect_snapshot(
+    caret:::filter_on_corr(one, "RMSE", cutoff = 0.9),
+    error = TRUE
+  )
 })
 
 # --- filter_on_diff ---------------------------------------------------------


### PR DESCRIPTION
Three related bugs in the internal helpers used by adaptiveWorkflow():

- `cccmat()` used `if (i > j)` inside a `for (j in i:p)` loop, so the body never ran and it always returned a matrix of ones.
- `cccmat()` and diffmat() ran `out[lower.tri] <- out[upper.tri]` on an already-symmetric matrix; the two triangles index in different orders, which scrambled entries (and broke symmetry) for four or more models.
- `filter_on_diff()` and `filter_on_corr()` indexed the reordered column names with `newOrder[deletecol]`, permuting the selection twice and removing the wrong models.

Add test-adaptive.R / helper-adaptive.R covering `ccc`, `cccmat`, `diffmat`, `long2wide`, `get_id`, `filter_on_corr` and `filter_on_diff`, plus a NEWS entry.