### PR TITLE
Add tests for confusionMatrix and fix non-square table check

### DIFF
--- a/R/confusionMatrix.R
+++ b/R/confusionMatrix.R
@@ -236,7 +236,7 @@ confusionMatrix.table <- function(
   if (length(dim(data)) != 2) {
     stop("the table must have two dimensions")
   }
-  if (!all.equal(nrow(data), ncol(data))) {
+  if (!isTRUE(all.equal(nrow(data), ncol(data)))) {
     stop("the table must nrow = ncol")
   }
   if (!isTRUE(all.equal(rownames(data), colnames(data)))) {

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -8,6 +8,7 @@
    \item CRAN mandated update.
    \item caret will be 20 years old in March of 2026. The package is currently in maintenance mode; the author will fix bugs and make CRAN releases as needed, but there will not be any major features in the package. It will stay on CRAN long-term; it's not going away.
    \item The \code{earth} model now defines a \code{trim} method, so \code{trainControl(trim = TRUE)} reduces the size of fitted \code{earth} models (dropping the stored \code{x}, \code{y}, and \code{call}) without affecting predictions.
+   \item \code{confusionMatrix()} now gives its intended "the table must nrow = ncol" error for non-square tables, instead of an "invalid argument to unary operator" error from a mis-written check.
   }
 }
 

--- a/tests/testthat/_snaps/confusionMatrix.md
+++ b/tests/testthat/_snaps/confusionMatrix.md
@@ -22,3 +22,280 @@
       Error in `confusionMatrix.default()`:
       ! The data contain levels not found in the data.
 
+# confusionMatrix.table rejects bad input
+
+    Code
+      confusionMatrix(cm_tab2, mode = "nope")
+    Condition
+      Error in `confusionMatrix.table()`:
+      ! `mode` should be either 'sens_spec', 'prec_recall', or 'everything'
+
+---
+
+    Code
+      confusionMatrix(as.table(matrix(1:6, nrow = 2)))
+    Condition
+      Error in `confusionMatrix.table()`:
+      ! the table must nrow = ncol
+
+---
+
+    Code
+      confusionMatrix(one)
+    Condition
+      Error in `confusionMatrix.table()`:
+      ! there must be at least 2 factors levels in the data
+
+---
+
+    Code
+      confusionMatrix(cm_tab2, positive = 1)
+    Condition
+      Error in `confusionMatrix.table()`:
+      ! positive argument must be character
+
+---
+
+    Code
+      confusionMatrix(mismatched)
+    Condition
+      Error in `confusionMatrix.table()`:
+      ! the table must the same classes in the same order
+
+# confusionMatrix.table rejects mis-sized prevalence vectors
+
+    Code
+      confusionMatrix(cm_tab2, prevalence = c(0.2, 0.3))
+    Condition
+      Error in `confusionMatrix.table()`:
+      ! with two levels, one prevalence probability must be specified
+
+---
+
+    Code
+      confusionMatrix(cm_tab3, prevalence = c(0.5, 0.5))
+    Condition
+      Error in `confusionMatrix.table()`:
+      ! the number of prevalence probability must be the same as the number of levels
+
+---
+
+    Code
+      confusionMatrix(cm_tab3, prevalence = c(0.3, 0.3, 0.4))
+    Condition
+      Error in `confusionMatrix.table()`:
+      ! with >2 classes, the prevalence vector must have names
+
+# as.matrix.confusionMatrix returns each requested piece
+
+    Code
+      as.matrix(cm, what = "nope")
+    Condition
+      Error in `as.matrix.confusionMatrix()`:
+      ! what must be either xtabs, overall or classes
+
+# print.confusionMatrix renders each mode
+
+    Code
+      print(confusionMatrix(cm_tab2, mode = "sens_spec"))
+    Output
+      Confusion Matrix and Statistics
+      
+                Reference
+      Prediction yes no
+             yes   8  1
+             no    2  9
+                                                
+                     Accuracy : 0.85            
+                       95% CI : (0.6211, 0.9679)
+          No Information Rate : 0.5             
+          P-Value [Acc > NIR] : 0.001288        
+                                                
+                        Kappa : 0.7             
+                                                
+       Mcnemar's Test P-Value : 1.000000        
+                                                
+                  Sensitivity : 0.8000          
+                  Specificity : 0.9000          
+               Pos Pred Value : 0.8889          
+               Neg Pred Value : 0.8182          
+                   Prevalence : 0.5000          
+               Detection Rate : 0.4000          
+         Detection Prevalence : 0.4500          
+            Balanced Accuracy : 0.8500          
+                                                
+             'Positive' Class : yes             
+                                                
+
+---
+
+    Code
+      print(confusionMatrix(cm_tab2, mode = "prec_recall"))
+    Output
+      Confusion Matrix and Statistics
+      
+                Reference
+      Prediction yes no
+             yes   8  1
+             no    2  9
+                                                
+                     Accuracy : 0.85            
+                       95% CI : (0.6211, 0.9679)
+          No Information Rate : 0.5             
+          P-Value [Acc > NIR] : 0.001288        
+                                                
+                        Kappa : 0.7             
+                                                
+       Mcnemar's Test P-Value : 1.000000        
+                                                
+                    Precision : 0.8889          
+                       Recall : 0.8000          
+                           F1 : 0.8421          
+                   Prevalence : 0.5000          
+               Detection Rate : 0.4000          
+         Detection Prevalence : 0.4500          
+            Balanced Accuracy : 0.8500          
+                                                
+             'Positive' Class : yes             
+                                                
+
+---
+
+    Code
+      print(confusionMatrix(cm_tab2, mode = "everything"))
+    Output
+      Confusion Matrix and Statistics
+      
+                Reference
+      Prediction yes no
+             yes   8  1
+             no    2  9
+                                                
+                     Accuracy : 0.85            
+                       95% CI : (0.6211, 0.9679)
+          No Information Rate : 0.5             
+          P-Value [Acc > NIR] : 0.001288        
+                                                
+                        Kappa : 0.7             
+                                                
+       Mcnemar's Test P-Value : 1.000000        
+                                                
+                  Sensitivity : 0.8000          
+                  Specificity : 0.9000          
+               Pos Pred Value : 0.8889          
+               Neg Pred Value : 0.8182          
+                    Precision : 0.8889          
+                       Recall : 0.8000          
+                           F1 : 0.8421          
+                   Prevalence : 0.5000          
+               Detection Rate : 0.4000          
+         Detection Prevalence : 0.4500          
+            Balanced Accuracy : 0.8500          
+                                                
+             'Positive' Class : yes             
+                                                
+
+---
+
+    Code
+      print(confusionMatrix(cm_tab3))
+    Output
+      Confusion Matrix and Statistics
+      
+                Reference
+      Prediction A B C
+               A 5 1 0
+               B 1 4 1
+               C 1 1 6
+      
+      Overall Statistics
+                                               
+                     Accuracy : 0.75           
+                       95% CI : (0.509, 0.9134)
+          No Information Rate : 0.35           
+          P-Value [Acc > NIR] : 0.0003106      
+                                               
+                        Kappa : 0.6241         
+                                               
+       Mcnemar's Test P-Value : 0.8012520      
+      
+      Statistics by Class:
+      
+                           Class: A Class: B Class: C
+      Sensitivity            0.7143   0.6667   0.8571
+      Specificity            0.9231   0.8571   0.8462
+      Pos Pred Value         0.8333   0.6667   0.7500
+      Neg Pred Value         0.8571   0.8571   0.9167
+      Prevalence             0.3500   0.3000   0.3500
+      Detection Rate         0.2500   0.2000   0.3000
+      Detection Prevalence   0.3000   0.3000   0.4000
+      Balanced Accuracy      0.8187   0.7619   0.8516
+
+---
+
+    Code
+      print(confusionMatrix(cm_tab2), printStats = FALSE)
+    Output
+      Confusion Matrix and Statistics
+      
+                Reference
+      Prediction yes no
+             yes   8  1
+             no    2  9
+
+# confusionMatrix.default validates its arguments
+
+    Code
+      confusionMatrix(a, b, mode = "nope")
+    Condition
+      Error in `confusionMatrix.default()`:
+      ! `mode` should be either 'sens_spec', 'prec_recall', or 'everything'
+
+---
+
+    Code
+      confusionMatrix(1:4, b)
+    Condition
+      Error:
+      ! `data` and `reference` should be factors with the same levels.
+
+---
+
+    Code
+      confusionMatrix(a, b, positive = 1)
+    Condition
+      Error in `confusionMatrix.default()`:
+      ! positive argument must be character
+
+---
+
+    Code
+      confusionMatrix(more, b)
+    Condition
+      Error in `confusionMatrix.default()`:
+      ! the data cannot have more levels than the reference
+
+---
+
+    Code
+      confusionMatrix(x, y)
+    Condition
+      Error in `confusionMatrix.default()`:
+      ! The data must contain some levels that overlap the reference.
+
+# confusionMatrix errors on regression and non-resampled fits
+
+    Code
+      confusionMatrix(reg_fit)
+    Condition
+      Error in `confusionMatrix.train()`:
+      ! confusion matrices are only valid for classification models
+
+---
+
+    Code
+      confusionMatrix(loo_fit)
+    Condition
+      Error in `confusionMatrix.train()`:
+      ! cannot compute confusion matrices for leave-one-out, out-of-bag resampling, or no resampling
+

--- a/tests/testthat/helper-confusionMatrix.R
+++ b/tests/testthat/helper-confusionMatrix.R
@@ -1,0 +1,20 @@
+# Test data shared by test-confusionMatrix.R.
+#
+# Deterministic confusion tables let the confusionMatrix() methods be tested
+# without fitting a model. The train / rfe / sbf paths need real fitted objects,
+# so those are exercised by the integration tests (which fit small models).
+
+# A 2x2 table with positive class "yes":
+#   sensitivity = 8 / (8 + 2) = 0.8, specificity = 9 / (9 + 1) = 0.9
+cm_tab2 <- as.table(matrix(
+  c(8, 2, 1, 9),
+  nrow = 2,
+  dimnames = list(Prediction = c("yes", "no"), Reference = c("yes", "no"))
+))
+
+# A 3x3 table for the multiclass path.
+cm_tab3 <- as.table(matrix(
+  c(5, 1, 1, 1, 4, 1, 0, 1, 6),
+  nrow = 3,
+  dimnames = list(Prediction = LETTERS[1:3], Reference = LETTERS[1:3])
+))

--- a/tests/testthat/test-confusionMatrix.R
+++ b/tests/testthat/test-confusionMatrix.R
@@ -53,3 +53,287 @@ test_that("Confusion matrix works", {
   cm11 <- confusionMatrix(mat1)
   expect_equal(cm1, cm11)
 })
+
+# ------------------------------------------------------------------------------
+# confusionMatrix.table / .matrix on fixed tables (cm_tab2, cm_tab3 live in
+# helper-confusionMatrix.R)
+
+test_that("confusionMatrix.table computes two-class statistics", {
+  cm <- confusionMatrix(cm_tab2)
+  expect_s3_class(cm, "confusionMatrix")
+  # first level is the default positive class
+  expect_identical(cm$positive, "yes")
+  expect_identical(cm$mode, "sens_spec")
+  # computed ratios: expect_equal (tolerance) rather than expect_identical, so
+  # the test survives future changes to how the statistic is derived
+  expect_equal(cm$byClass["Sensitivity"], c(Sensitivity = 0.8))
+  expect_equal(cm$byClass["Specificity"], c(Specificity = 0.9))
+  expect_identical(
+    names(cm$overall),
+    c(
+      "Accuracy",
+      "Kappa",
+      "AccuracyLower",
+      "AccuracyUpper",
+      "AccuracyNull",
+      "AccuracyPValue",
+      "McnemarPValue"
+    )
+  )
+})
+
+test_that("confusionMatrix.table honours the positive and prevalence args", {
+  # choose the other class as positive: sensitivity/specificity swap
+  cm <- confusionMatrix(cm_tab2, positive = "no")
+  expect_identical(cm$positive, "no")
+  # computed ratio, so keep the tolerant comparison
+  expect_equal(cm$byClass["Sensitivity"], c(Sensitivity = 0.9))
+
+  # a supplied prevalence overrides the value taken from the table (a pass
+  # through, so it round-trips exactly)
+  cm_prev <- confusionMatrix(cm_tab2, prevalence = 0.25)
+  expect_identical(cm_prev$byClass["Prevalence"], c(Prevalence = 0.25))
+})
+
+test_that("confusionMatrix.table handles the multiclass case", {
+  cm <- confusionMatrix(cm_tab3)
+  # per-class stats come back as a matrix, one row per class
+  expect_true(is.matrix(cm$byClass))
+  expect_identical(nrow(cm$byClass), 3L)
+  expect_identical(rownames(cm$byClass), paste("Class:", LETTERS[1:3]))
+
+  # a named per-class prevalence vector is accepted and used
+  cm_prev <- confusionMatrix(cm_tab3, prevalence = c(A = 0.3, B = 0.3, C = 0.4))
+  expect_identical(cm_prev$byClass["Class: A", "Prevalence"], 0.3)
+})
+
+test_that("confusionMatrix.matrix matches confusionMatrix.table", {
+  from_matrix <- confusionMatrix(unclass(cm_tab2))
+  from_table <- confusionMatrix(cm_tab2)
+  expect_identical(from_matrix$table, from_table$table)
+  expect_identical(from_matrix$byClass, from_table$byClass)
+})
+
+test_that("confusionMatrix.table rejects bad input", {
+  expect_snapshot(confusionMatrix(cm_tab2, mode = "nope"), error = TRUE)
+  expect_snapshot(
+    confusionMatrix(as.table(matrix(1:6, nrow = 2))),
+    error = TRUE
+  )
+  # a one-level table has too few classes
+  one <- as.table(matrix(
+    5,
+    dimnames = list(Prediction = "a", Reference = "a")
+  ))
+  expect_snapshot(confusionMatrix(one), error = TRUE)
+  # positive must be a string
+  expect_snapshot(confusionMatrix(cm_tab2, positive = 1), error = TRUE)
+  # row and column classes must match
+  mismatched <- as.table(matrix(
+    c(8, 2, 1, 9),
+    nrow = 2,
+    dimnames = list(c("a", "b"), c("a", "c"))
+  ))
+  expect_snapshot(confusionMatrix(mismatched), error = TRUE)
+})
+
+test_that("confusionMatrix.table rejects mis-sized prevalence vectors", {
+  # two classes need a single prevalence
+  expect_snapshot(
+    confusionMatrix(cm_tab2, prevalence = c(0.2, 0.3)),
+    error = TRUE
+  )
+  # multiclass needs one prevalence per class...
+  expect_snapshot(
+    confusionMatrix(cm_tab3, prevalence = c(0.5, 0.5)),
+    error = TRUE
+  )
+  # ...and it must be named
+  expect_snapshot(
+    confusionMatrix(cm_tab3, prevalence = c(0.3, 0.3, 0.4)),
+    error = TRUE
+  )
+})
+
+# ------------------------------------------------------------------------------
+# as.matrix / as.table methods
+
+test_that("as.matrix.confusionMatrix returns each requested piece", {
+  cm <- confusionMatrix(cm_tab2)
+  expect_identical(dim(as.matrix(cm, what = "xtabs")), c(2L, 2L))
+  expect_identical(nrow(as.matrix(cm, what = "overall")), 7L)
+  expect_identical(nrow(as.matrix(cm, what = "classes")), 11L)
+  # the multiclass "classes" matrix is transposed to one column per class
+  cm3 <- confusionMatrix(cm_tab3)
+  expect_identical(colnames(as.matrix(cm3, what = "classes")), LETTERS[1:3])
+  expect_snapshot(as.matrix(cm, what = "nope"), error = TRUE)
+})
+
+test_that("as.table.confusionMatrix returns the underlying table", {
+  cm <- confusionMatrix(cm_tab2)
+  expect_identical(as.table(cm), cm$table)
+})
+
+# ------------------------------------------------------------------------------
+# print methods (deterministic tables -> safe to snapshot)
+
+test_that("print.confusionMatrix renders each mode", {
+  expect_snapshot(print(confusionMatrix(cm_tab2, mode = "sens_spec")))
+  expect_snapshot(print(confusionMatrix(cm_tab2, mode = "prec_recall")))
+  expect_snapshot(print(confusionMatrix(cm_tab2, mode = "everything")))
+  expect_snapshot(print(confusionMatrix(cm_tab3)))
+  # the table can be printed on its own, without the statistics block
+  expect_snapshot(print(confusionMatrix(cm_tab2), printStats = FALSE))
+})
+
+# ------------------------------------------------------------------------------
+# confusionMatrix.default input validation
+
+test_that("confusionMatrix.default validates its arguments", {
+  a <- factor(c("a", "b", "a", "b"))
+  b <- factor(c("a", "a", "b", "b"))
+  expect_snapshot(confusionMatrix(a, b, mode = "nope"), error = TRUE)
+  # non-factor input
+  expect_snapshot(confusionMatrix(1:4, b), error = TRUE)
+  # positive must be a string
+  expect_snapshot(confusionMatrix(a, b, positive = 1), error = TRUE)
+  # data has a level the reference does not
+  more <- factor(c("a", "b", "c", "b"))
+  expect_snapshot(confusionMatrix(more, b), error = TRUE)
+  # data and reference share no levels
+  x <- factor(c("x", "y"), levels = c("x", "y"))
+  y <- factor(c("a", "b"), levels = c("a", "b"))
+  expect_snapshot(confusionMatrix(x, y), error = TRUE)
+})
+
+# ------------------------------------------------------------------------------
+# resampName text for each resampling scheme (pure helper, fake control objects)
+
+test_that("resampName describes each resampling method", {
+  mk <- function(method, ...) {
+    list(
+      control = c(
+        list(method = method, index = list(1:3, 1:3, 1:3)),
+        list(...)
+      )
+    )
+  }
+  rn <- function(...) caret:::resampName(...)
+
+  # no control element -> empty string
+  expect_identical(caret:::resampName(list()), "")
+
+  expect_identical(rn(mk("cv", number = 10)), "Cross-Validated (10 fold)")
+  expect_identical(
+    rn(mk("repeatedcv", number = 10, repeats = 5)),
+    "Cross-Validated (10 fold, repeated 5 times)"
+  )
+  expect_identical(rn(mk("boot")), "Bootstrapped (3 reps)")
+  expect_identical(rn(mk("boot632")), "Bootstrapped (3 reps)")
+  expect_identical(
+    rn(mk("LGOCV", p = 0.75)),
+    "Repeated Train/Test Splits Estimated (3 reps, 75%)"
+  )
+  expect_identical(rn(mk("LOOCV")), "Leave-One-Out Cross-Validation")
+  expect_identical(rn(mk("none")), "None")
+  expect_identical(rn(mk("apparent")), "Apparent")
+  expect_identical(rn(mk("custom")), "Custom Resampling (3 reps)")
+  expect_identical(
+    rn(mk("timeslice", horizon = 5, fixedWindow = TRUE)),
+    "Rolling Forecasting Origin Resampling (5 held-out with a fixed window)"
+  )
+  expect_identical(rn(mk("oob")), "Out of Bag Resampling")
+  expect_identical(
+    rn(mk("adaptive_cv", number = 10, repeats = 5)),
+    "Adaptively Cross-Validated (10 fold, repeated 5 times)"
+  )
+
+  # numbers = FALSE gives the short form
+  expect_identical(
+    rn(mk("cv", number = 10), numbers = FALSE),
+    "(Cross-Validation)"
+  )
+})
+
+# ------------------------------------------------------------------------------
+# resampled confusion matrices from train / rfe / sbf objects
+
+test_that("confusionMatrix.train summarises the resampled matrix", {
+  skip_on_cran()
+
+  set.seed(1)
+  dat <- twoClassSim(200)
+  fit <- train(
+    Class ~ .,
+    data = dat,
+    method = "knn",
+    tuneLength = 2,
+    trControl = trainControl(method = "cv", number = 3, classProbs = TRUE)
+  )
+
+  cm <- confusionMatrix(fit)
+  expect_s3_class(cm, "confusionMatrix.train")
+  expect_identical(cm$norm, "overall")
+  # percentages, so the whole table sums to ~100 (floating point -> expect_equal)
+  expect_equal(sum(cm$table), 100)
+
+  # the other normalisations run and print without error
+  expect_identical(confusionMatrix(fit, norm = "none")$norm, "none")
+  expect_identical(confusionMatrix(fit, norm = "average")$norm, "average")
+  expect_output(print(cm), "Confusion Matrix")
+})
+
+test_that("confusionMatrix errors on regression and non-resampled fits", {
+  skip_on_cran()
+
+  set.seed(1)
+  reg <- SLC14_1(100)
+  reg_fit <- train(
+    y ~ .,
+    data = reg,
+    method = "lm",
+    trControl = trainControl(method = "cv", number = 3)
+  )
+  expect_snapshot(confusionMatrix(reg_fit), error = TRUE)
+
+  set.seed(1)
+  dat <- twoClassSim(120)
+  loo_fit <- train(
+    Class ~ .,
+    data = dat,
+    method = "knn",
+    tuneLength = 1,
+    trControl = trainControl(method = "LOOCV")
+  )
+  expect_snapshot(confusionMatrix(loo_fit), error = TRUE)
+})
+
+test_that("confusionMatrix works for rfe and sbf objects", {
+  skip_on_cran()
+  skip_if_not_installed("MASS")
+
+  set.seed(1)
+  dat <- twoClassSim(200)
+
+  set.seed(1)
+  rf <- rfe(
+    dat[, 1:6],
+    dat$Class,
+    sizes = c(2, 4),
+    rfeControl = rfeControl(functions = lrFuncs, method = "cv", number = 3)
+  )
+  expect_s3_class(confusionMatrix(rf), "confusionMatrix.rfe")
+
+  set.seed(1)
+  sf <- sbf(
+    dat[, 1:6],
+    dat$Class,
+    sbfControl = sbfControl(
+      functions = ldaSBF,
+      method = "cv",
+      number = 3,
+      saveDetails = TRUE
+    )
+  )
+  expect_s3_class(confusionMatrix(sf), "confusionMatrix.sbf")
+})


### PR DESCRIPTION
Cover confusionMatrix.table/.matrix/.default, as.matrix/as.table, the print methods, resampName, and the resampled matrices from train/rfe/sbf objects (helper-confusionMatrix.R holds deterministic fixtures). Raises R/confusionMatrix.R coverage from ~37% to ~91%.

Also fix confusionMatrix.table(): the non-square check used '!all.equal(nrow, ncol)', which errored with 'invalid argument to unary operator' instead of the intended message. Wrap it in isTRUE().