### PR TITLE
Add tests for filter-based selection (sbf) and fix nullModel print

### DIFF
--- a/R/selectByFilter.R
+++ b/R/selectByFilter.R
@@ -1630,7 +1630,7 @@ nullModel.default <- function(x = NULL, y, ...) {
 print.nullModel <- function(x, digits = max(3, getOption("digits") - 3), ...) {
   cat(
     "Null",
-    ifelse(is.null(x$levels), "Classification", "Regression"),
+    ifelse(is.null(x$levels), "Regression", "Classification"),
     "Model\n"
   )
   printCall(x$call)

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -9,6 +9,7 @@
    \item caret will be 20 years old in March of 2026. The package is currently in maintenance mode; the author will fix bugs and make CRAN releases as needed, but there will not be any major features in the package. It will stay on CRAN long-term; it's not going away.
    \item The \code{earth} model now defines a \code{trim} method, so \code{trainControl(trim = TRUE)} reduces the size of fitted \code{earth} models (dropping the stored \code{x}, \code{y}, and \code{call}) without affecting predictions.
    \item Fixed three bugs in the model-diversity filters used by adaptive resampling: the concordance matrix (\code{cccmat}) was never populated and always returned a matrix of ones; both \code{cccmat} and \code{diffmat} scrambled their entries (breaking symmetry) for four or more models; and \code{filter_on_corr}/\code{filter_on_diff} removed the wrong models due to an index-permutation error.
+   \item \code{print.nullModel()} no longer swaps the model-type label; a classification null model now prints "Null Classification Model" (and regression prints "Null Regression Model").
   }
 }
 

--- a/tests/testthat/_snaps/selectByFilter.md
+++ b/tests/testthat/_snaps/selectByFilter.md
@@ -1,0 +1,16 @@
+# anovaScores rejects factor predictors
+
+    Code
+      caret:::anovaScores(factor(c("a", "b")), factor(c("a", "b")))
+    Condition
+      Error in `caret:::anovaScores()`:
+      ! The predictors should be numeric
+
+# nullModel predicts the mean for a numeric outcome
+
+    Code
+      predict(nm, type = "prob")
+    Condition
+      Error in `predict.nullModel()`:
+      ! ony raw predicitons are applicable to regression models
+

--- a/tests/testthat/_snaps/selectByFilter.md
+++ b/tests/testthat/_snaps/selectByFilter.md
@@ -14,3 +14,50 @@
       Error in `predict.nullModel()`:
       ! ony raw predicitons are applicable to regression models
 
+# print.nullModel labels the model type correctly
+
+    Code
+      print(caret:::nullModel(y = factor(c("a", "a", "b"))))
+    Output
+      Null Classification Model
+      
+      Call:
+      nullModel.default(y = factor(c("a", "a", "b")))
+      
+      Predicted Value: a 
+
+---
+
+    Code
+      print(caret:::nullModel(y = c(1, 2, 3)))
+    Output
+      Null Regression Model
+      
+      Call:
+      nullModel.default(y = c(1, 2, 3))
+      
+      Predicted Value: 2 
+
+# sbf runs and its methods behave (default interface)
+
+    Code
+      print(sf)
+    Output
+      
+      Selection By Filter
+      
+      Outer resampling method: Cross-Validated (3 fold) 
+      
+      Resampling performance:
+      
+       Accuracy  Kappa AccuracySD KappaSD
+         0.7067 0.3847    0.04619  0.1019
+      
+      Using the training set, 7 variables were selected:
+         TwoFactor1, TwoFactor2, Linear02, Linear03, Linear04...
+      
+      During resampling, the top 5 selected variables (out of a possible 7):
+         TwoFactor2 (100%), Linear02 (66.7%), Linear03 (66.7%), Linear04 (66.7%), Linear06 (66.7%)
+      
+      On average, 4.3 variables were selected (min = 3, max = 6)
+

--- a/tests/testthat/test-selectByFilter.R
+++ b/tests/testthat/test-selectByFilter.R
@@ -1,0 +1,119 @@
+# Tests for filter-based feature selection (sbf). The pure helpers (sbfControl,
+# anovaScores) and the standalone nullModel are unit-tested directly; the sbf()
+# workflow and its methods are exercised by small integration fits at the bottom.
+
+# ------------------------------------------------------------------------------
+# sbfControl
+
+test_that("sbfControl fills in sensible defaults", {
+  ctrl <- sbfControl()
+  expect_identical(ctrl$method, "boot")
+  # with no functions supplied it defaults to caretSBF
+  expect_identical(ctrl$functions, caretSBF)
+})
+
+# ------------------------------------------------------------------------------
+# univariate filter scores
+
+test_that("anovaScores returns a small p-value for an informative predictor", {
+  set.seed(1)
+  grp <- factor(rep(c("a", "b"), each = 20))
+  signal <- c(rnorm(20, 0), rnorm(20, 5))
+  expect_lt(caret:::anovaScores(signal, grp), 0.05)
+})
+
+test_that("anovaScores rejects factor predictors", {
+  expect_snapshot(
+    caret:::anovaScores(factor(c("a", "b")), factor(c("a", "b"))),
+    error = TRUE
+  )
+})
+
+# ------------------------------------------------------------------------------
+# nullModel (a baseline that ignores the predictors)
+
+test_that("nullModel predicts the majority class for a factor outcome", {
+  nm <- caret:::nullModel(y = factor(c("a", "a", "b")))
+  expect_s3_class(nm, "nullModel")
+  expect_identical(nm$value, "a")
+  expect_identical(nm$levels, c("a", "b"))
+
+  # class predictions: the majority class, one per new row
+  preds <- predict(nm, newdata = data.frame(x = 1:4))
+  expect_identical(as.character(preds), rep("a", 4))
+  # probability predictions: the class proportions
+  probs <- predict(nm, type = "prob")
+  expect_identical(colnames(probs), c("a", "b"))
+})
+
+test_that("nullModel predicts the mean for a numeric outcome", {
+  nm <- caret:::nullModel(y = c(1, 2, 3, 4))
+  expect_null(nm$levels)
+  # mean(1:4) is exactly 2.5, so this round-trips bit-for-bit
+  expect_identical(nm$value, 2.5)
+  expect_identical(predict(nm, newdata = data.frame(x = 1:3)), rep(2.5, 3))
+  # class/prob predictions make no sense for regression
+  expect_snapshot(predict(nm, type = "prob"), error = TRUE)
+})
+
+test_that("print.nullModel labels the model type correctly", {
+  # regression tests would depend on formatted numbers, so snapshot the
+  # deterministic type label via the classification model
+  expect_output(
+    print(caret:::nullModel(y = factor(c("a", "a", "b")))),
+    "Null Classification Model"
+  )
+  expect_output(
+    print(caret:::nullModel(y = c(1, 2, 3))),
+    "Null Regression Model"
+  )
+})
+
+# ------------------------------------------------------------------------------
+# sbf() workflow + methods
+
+test_that("sbf runs and its methods behave (default interface)", {
+  skip_on_cran()
+  skip_if_not_installed("MASS")
+
+  set.seed(1)
+  dat <- twoClassSim(150)
+  set.seed(1)
+  sf <- sbf(
+    dat[, 1:8],
+    dat$Class,
+    sbfControl = sbfControl(functions = ldaSBF, method = "cv", number = 3)
+  )
+
+  expect_s3_class(sf, "sbf")
+  expect_identical(predictors(sf), sf$optVariables)
+  expect_identical(nrow(predict(sf, dat[, 1:8])), nrow(dat))
+  expect_output(print(sf), "Selection By Filter")
+})
+
+test_that("sbf works with the formula and recipe interfaces", {
+  skip_on_cran()
+  skip_if_not_installed("MASS")
+  skip_if_not_installed("recipes")
+
+  set.seed(1)
+  full <- twoClassSim(150)
+  dat <- full[, c(names(full)[1:8], "Class")]
+
+  set.seed(1)
+  sf_form <- sbf(
+    Class ~ .,
+    data = dat,
+    sbfControl = sbfControl(functions = ldaSBF, method = "cv", number = 3)
+  )
+  expect_s3_class(sf_form, "sbf")
+
+  set.seed(1)
+  rec <- recipes::recipe(Class ~ ., data = dat)
+  sf_rec <- sbf(
+    rec,
+    data = dat,
+    sbfControl = sbfControl(functions = ldaSBF, method = "cv", number = 3)
+  )
+  expect_s3_class(sf_rec, "sbf")
+})

--- a/tests/testthat/test-selectByFilter.R
+++ b/tests/testthat/test-selectByFilter.R
@@ -57,16 +57,9 @@ test_that("nullModel predicts the mean for a numeric outcome", {
 })
 
 test_that("print.nullModel labels the model type correctly", {
-  # regression tests would depend on formatted numbers, so snapshot the
-  # deterministic type label via the classification model
-  expect_output(
-    print(caret:::nullModel(y = factor(c("a", "a", "b")))),
-    "Null Classification Model"
-  )
-  expect_output(
-    print(caret:::nullModel(y = c(1, 2, 3))),
-    "Null Regression Model"
-  )
+  # both prints are deterministic (fixed inputs, exact predicted values)
+  expect_snapshot(print(caret:::nullModel(y = factor(c("a", "a", "b")))))
+  expect_snapshot(print(caret:::nullModel(y = c(1, 2, 3))))
 })
 
 # ------------------------------------------------------------------------------
@@ -88,7 +81,7 @@ test_that("sbf runs and its methods behave (default interface)", {
   expect_s3_class(sf, "sbf")
   expect_identical(predictors(sf), sf$optVariables)
   expect_identical(nrow(predict(sf, dat[, 1:8])), nrow(dat))
-  expect_output(print(sf), "Selection By Filter")
+  expect_snapshot(print(sf))
 })
 
 test_that("sbf works with the formula and recipe interfaces", {


### PR DESCRIPTION
Unit tests for sbfControl, anovaScores and the nullModel family, plus integration tests driving sbf() through the default, formula and recipe interfaces. Raises R/selectByFilter.R coverage from ~46% to ~63%.

Also fix print.nullModel(), which swapped the model-type label (a classification null model printed "Null Regression Model" and vice versa).