### PR TITLE
Add tests for lift/gain curves

### DIFF
--- a/tests/testthat/_snaps/lift.md
+++ b/tests/testthat/_snaps/lift.md
@@ -1,0 +1,44 @@
+# lift requires a formula
+
+    Code
+      lift(lift_data)
+    Condition
+      Error in `lift.default()`:
+      ! 'x' should be a formula
+
+# lift validates the formula and labels
+
+    Code
+      lift(prob1 ~ prob2, data = lift_data)
+    Condition
+      Error in `lift.formula()`:
+      ! the left-hand side of the formula must be a factor of classes
+
+---
+
+    Code
+      lift(Class ~ prob1, data = lift_data, labels = c("a", "b"))
+    Condition
+      Error in `lift.formula()`:
+      ! labels should have an element for each term on the rhs of the formula
+
+# xyplot.lift rejects an unknown plot type
+
+    Code
+      caret:::xyplot.lift(lf, plot = "nope")
+    Condition
+      Error:
+      ! `plot`` should be either 'lift' or 'gain'
+
+# print.lift reports the models and event rate
+
+    Code
+      print(lf)
+    Output
+      
+      Call:
+      lift.formula(x = Class ~ prob1, data = lift_data)
+      
+      Models: prob1 
+      Event: yes (50%)
+

--- a/tests/testthat/helper-lift.R
+++ b/tests/testthat/helper-lift.R
@@ -1,0 +1,10 @@
+# Test data shared by test-lift.R.
+#
+# Ten samples, balanced two-class outcome ("yes" is the event). prob1 ranks the
+# cases perfectly (all events sit above all non-events), while prob2 ranks them
+# poorly. This lets the lift/gain numbers be worked out by hand.
+lift_data <- data.frame(
+  Class = factor(rep(c("yes", "no"), each = 5), levels = c("yes", "no")),
+  prob1 = c(0.90, 0.80, 0.70, 0.60, 0.55, 0.50, 0.40, 0.30, 0.20, 0.10),
+  prob2 = c(0.40, 0.30, 0.60, 0.20, 0.50, 0.55, 0.70, 0.10, 0.90, 0.80)
+)

--- a/tests/testthat/test-lift.R
+++ b/tests/testthat/test-lift.R
@@ -1,0 +1,83 @@
+# Tests for lift/gain curves. The computation (lift.formula / liftCalc) is
+# exercised directly; the lattice plot methods are not tested beyond their
+# argument validation. Fixture lift_data lives in helper-lift.R.
+
+# ------------------------------------------------------------------------------
+
+test_that("lift requires a formula", {
+  expect_snapshot(lift(lift_data), error = TRUE)
+})
+
+test_that("lift computes a gain table for one model", {
+  lf <- lift(Class ~ prob1, data = lift_data)
+  expect_s3_class(lf, "lift")
+  # first factor level ("yes") is the event; half the samples are events
+  expect_identical(lf$class, "yes")
+  expect_identical(lf$pct, 50)
+  expect_identical(lf$probNames, "prob1")
+  expect_identical(
+    colnames(lf$data),
+    c(
+      "liftModelVar",
+      "cuts",
+      "events",
+      "n",
+      "Sn",
+      "Sp",
+      "EventPct",
+      "CumEventPct",
+      "lift",
+      "CumTestedPct"
+    )
+  )
+  # prob1 ranks perfectly, so 100% of events are eventually found
+  expect_identical(max(lf$data$CumEventPct), 100)
+})
+
+test_that("lift handles several models on the right-hand side", {
+  lf <- lift(Class ~ prob1 + prob2, data = lift_data)
+  expect_identical(lf$probNames, c("prob1", "prob2"))
+  expect_identical(
+    as.character(sort(unique(lf$data$liftModelVar))),
+    c("prob1", "prob2")
+  )
+})
+
+test_that("lift relabels models and honours custom cuts", {
+  # a named labels vector renames the model in the output
+  relabelled <- lift(
+    Class ~ prob1,
+    data = lift_data,
+    labels = c(prob1 = "Model A")
+  )
+  expect_identical(
+    as.character(unique(relabelled$data$liftModelVar)),
+    "Model A"
+  )
+
+  # cuts can be a count or an explicit set of cut-offs
+  by_count <- lift(Class ~ prob1, data = lift_data, cuts = 5)
+  expect_identical(nrow(by_count$data), 5L)
+  by_values <- lift(Class ~ prob1, data = lift_data, cuts = c(0.25, 0.5, 0.75))
+  expect_identical(nrow(by_values$data), 5L)
+})
+
+test_that("lift validates the formula and labels", {
+  # left-hand side must be a factor of classes
+  expect_snapshot(lift(prob1 ~ prob2, data = lift_data), error = TRUE)
+  # one label is required per right-hand-side term
+  expect_snapshot(
+    lift(Class ~ prob1, data = lift_data, labels = c("a", "b")),
+    error = TRUE
+  )
+})
+
+test_that("xyplot.lift rejects an unknown plot type", {
+  lf <- lift(Class ~ prob1, data = lift_data)
+  expect_snapshot(caret:::xyplot.lift(lf, plot = "nope"), error = TRUE)
+})
+
+test_that("print.lift reports the models and event rate", {
+  lf <- lift(Class ~ prob1, data = lift_data)
+  expect_snapshot(print(lf))
+})


### PR DESCRIPTION
Cover the lift computation directly: lift.formula (single/multi model, labels, custom cuts), liftCalc, print.lift, and the formula/plot-type validation errors. Fixture lift_data lives in helper-lift.R. Raises R/lift.R coverage from 0% to ~32% (the remainder is lattice/ggplot plotting). 