### PR TITLE
Add tests for the train print

### DIFF
--- a/tests/testthat/_snaps/print.train.md
+++ b/tests/testthat/_snaps/print.train.md
@@ -1,0 +1,28 @@
+# pp_list prints the expanded pre-processing names
+
+    Code
+      caret:::pp_list(c("center", "scale"))
+    Output
+      Pre-processing: centered, scaled 
+
+---
+
+    Code
+      caret:::pp_list("BoxCox")
+    Output
+      Pre-processing: Box-Cox transformation 
+
+# print.train handles a model fit without resampling
+
+    Code
+      print(fit)
+    Output
+      k-Nearest Neighbors 
+      
+      150 samples
+        4 predictor
+        3 classes: 'setosa', 'versicolor', 'virginica' 
+      
+      No pre-processing
+      Resampling: None 
+

--- a/tests/testthat/_snaps/print.train.md
+++ b/tests/testthat/_snaps/print.train.md
@@ -12,6 +12,51 @@
     Output
       Pre-processing: Box-Cox transformation 
 
+# print.train describes a classification model with tuning
+
+    Code
+      print(fit)
+    Output
+      k-Nearest Neighbors 
+      
+      150 samples
+        4 predictor
+        3 classes: 'setosa', 'versicolor', 'virginica' 
+      
+      Pre-processing: centered (4), scaled (4) 
+      Resampling: Cross-Validated (3 fold) 
+      Summary of sample sizes: 100, 101, 99 
+      Resampling results across tuning parameters:
+      
+        k  Accuracy   Kappa    
+        5  0.9399840  0.9099884
+        7  0.9533173  0.9299724
+        9  0.9601200  0.9401616
+      
+      Accuracy was used to select the optimal model using the largest value.
+      The final value used for the model was k = 9.
+
+# print.train abbreviates the sample sizes with many resamples
+
+    Code
+      print(fit)
+    Output
+      k-Nearest Neighbors 
+      
+      150 samples
+        4 predictor
+        3 classes: 'setosa', 'versicolor', 'virginica' 
+      
+      No pre-processing
+      Resampling: Cross-Validated (10 fold) 
+      Summary of sample sizes: 135, 135, 135, 135, 135, 135, ... 
+      Resampling results:
+      
+        Accuracy  Kappa
+        0.96      0.94 
+      
+      Tuning parameter 'k' was held constant at a value of 5
+
 # print.train handles a model fit without resampling
 
     Code
@@ -25,4 +70,24 @@
       
       No pre-processing
       Resampling: None 
+
+# print.train reports regression metrics
+
+    Code
+      print(fit)
+    Output
+      Linear Regression 
+      
+      120 samples
+       20 predictor
+      
+      No pre-processing
+      Resampling: Cross-Validated (3 fold) 
+      Summary of sample sizes: 80, 80, 80 
+      Resampling results:
+      
+        RMSE    Rsquared   MAE     
+        23.241  0.1239973  17.10724
+      
+      Tuning parameter 'intercept' was held constant at a value of TRUE
 

--- a/tests/testthat/test-print.train.R
+++ b/tests/testthat/test-print.train.R
@@ -1,0 +1,102 @@
+# Tests for the train print method and its text helpers. The helpers are pure
+# and deterministic; print.train() itself is exercised by small fits, matched on
+# stable substrings (the resampled metric values are RNG-dependent, so the full
+# output can't be snapshotted).
+
+# ------------------------------------------------------------------------------
+# text helpers
+
+test_that("stringFunc joins a vector into readable text", {
+  expect_identical(caret:::stringFunc("a"), "a")
+  expect_identical(caret:::stringFunc(c("a", "b")), "a and b")
+  expect_identical(caret:::stringFunc(c("a", "b", "c")), "a, b and c")
+  expect_identical(caret:::stringFunc(character(0)), "")
+  # non-character input is formatted first
+  expect_identical(caret:::stringFunc(c(1, 2)), "1 and 2")
+})
+
+test_that("truncateText wraps only when the text is wider than the console", {
+  expect_identical(caret:::truncateText("short text"), "short text")
+  # a very long string is wrapped onto multiple lines
+  long <- paste(rep("word", 40), collapse = " ")
+  expect_match(caret:::truncateText(long), "\n")
+})
+
+test_that("pp_list prints the expanded pre-processing names", {
+  expect_snapshot(caret:::pp_list(c("center", "scale")))
+  expect_snapshot(caret:::pp_list("BoxCox"))
+})
+
+# ------------------------------------------------------------------------------
+# print.train across model types
+
+test_that("print.train describes a classification model with tuning", {
+  skip_on_cran()
+
+  set.seed(1)
+  fit <- train(
+    Species ~ .,
+    data = iris,
+    method = "knn",
+    preProc = c("center", "scale"),
+    tuneLength = 3,
+    trControl = trainControl(method = "cv", number = 3)
+  )
+
+  expect_output(print(fit), "150 samples")
+  expect_output(print(fit), "3 classes")
+  expect_output(print(fit), "Pre-processing: centered")
+  expect_output(print(fit), "Resampling: Cross-Validated")
+  expect_output(print(fit), "Resampling results across tuning parameters")
+  expect_output(print(fit), "select the optimal model")
+})
+
+test_that("print.train abbreviates the sample sizes with many resamples", {
+  skip_on_cran()
+
+  set.seed(1)
+  fit <- train(
+    Species ~ .,
+    data = iris,
+    method = "knn",
+    tuneGrid = data.frame(k = 5),
+    trControl = trainControl(method = "cv", number = 10)
+  )
+
+  # more than five resamples -> the sample-size list is truncated with "..."
+  expect_output(print(fit), "Summary of sample sizes:.*\\.\\.\\.")
+})
+
+test_that("print.train handles a model fit without resampling", {
+  skip_on_cran()
+
+  set.seed(1)
+  fit <- train(
+    Species ~ .,
+    data = iris,
+    method = "knn",
+    tuneGrid = data.frame(k = 5),
+    trControl = trainControl(method = "none")
+  )
+
+  # with no resampling there is no metric table, so the whole print is
+  # deterministic and can be snapshotted
+  expect_snapshot(print(fit))
+})
+
+test_that("print.train reports regression metrics", {
+  skip_on_cran()
+
+  set.seed(1)
+  dat <- SLC14_1(120)
+  fit <- train(
+    y ~ .,
+    data = dat,
+    method = "lm",
+    trControl = trainControl(method = "cv", number = 3)
+  )
+
+  expect_output(print(fit), "predictor")
+  expect_output(print(fit), "Resampling results")
+  expect_output(print(fit), "RMSE")
+})

--- a/tests/testthat/test-print.train.R
+++ b/tests/testthat/test-print.train.R
@@ -43,12 +43,7 @@ test_that("print.train describes a classification model with tuning", {
     trControl = trainControl(method = "cv", number = 3)
   )
 
-  expect_output(print(fit), "150 samples")
-  expect_output(print(fit), "3 classes")
-  expect_output(print(fit), "Pre-processing: centered")
-  expect_output(print(fit), "Resampling: Cross-Validated")
-  expect_output(print(fit), "Resampling results across tuning parameters")
-  expect_output(print(fit), "select the optimal model")
+  expect_snapshot(print(fit))
 })
 
 test_that("print.train abbreviates the sample sizes with many resamples", {
@@ -64,7 +59,7 @@ test_that("print.train abbreviates the sample sizes with many resamples", {
   )
 
   # more than five resamples -> the sample-size list is truncated with "..."
-  expect_output(print(fit), "Summary of sample sizes:.*\\.\\.\\.")
+  expect_snapshot(print(fit))
 })
 
 test_that("print.train handles a model fit without resampling", {
@@ -96,7 +91,5 @@ test_that("print.train reports regression metrics", {
     trControl = trainControl(method = "cv", number = 3)
   )
 
-  expect_output(print(fit), "predictor")
-  expect_output(print(fit), "Resampling results")
-  expect_output(print(fit), "RMSE")
+  expect_snapshot(print(fit))
 })


### PR DESCRIPTION
Unit tests for the text helpers (stringFunc, truncateText, pp_list) plus integration tests that print train objects across model types (classification with tuning, no-resampling, regression, many-resample truncation). 