### PR TITLE
Add tests for preProcess 

### DIFF
--- a/tests/testthat/_snaps/preProcess-internals.md
+++ b/tests/testthat/_snaps/preProcess-internals.md
@@ -1,0 +1,7 @@
+# check_for_wildcards reports and strips PCA/ICA wildcards
+
+    Code
+      res <- caret:::check_for_wildcards(opts)
+    Output
+      PCA wildcards found for: pca, center ...but should not be in methods: pca, center
+

--- a/tests/testthat/_snaps/preProcess-methods.md
+++ b/tests/testthat/_snaps/preProcess-methods.md
@@ -14,3 +14,16 @@
       Error in `preProcess.default()`:
       ! 'rangeBounds' interval is empty
 
+# print.preProcess summarises the transformations
+
+    Code
+      print(preProcess(x, method = c("center", "scale")))
+    Output
+      Created from 10 samples and 4 variables
+      
+      Pre-processing:
+        - centered (4)
+        - ignored (0)
+        - scaled (4)
+      
+

--- a/tests/testthat/test-preProcess-internals.R
+++ b/tests/testthat/test-preProcess-internals.R
@@ -12,3 +12,46 @@ test_that("handles situation when there's a single column per transformation", {
     data.frame(x = c("a", "a"), y = c(-0.5, 0.5), stringsAsFactors = TRUE)
   )
 })
+
+# ------------------------------------------------------------------------------
+
+test_that("invHyperbolicSineFunc is the inverse hyperbolic sine", {
+  expect_identical(caret:::invHyperbolicSineFunc(0), 0)
+  # computed as log(x + sqrt(x^2 + 1)), so equal (not bit-identical to asinh)
+  expect_equal(caret:::invHyperbolicSineFunc(1), asinh(1))
+})
+
+test_that("convert_method rewrites a legacy character method into a list", {
+  # older preProcess objects stored `method` as a character vector; each entry
+  # maps to the variable names it applies to
+  old <- list(
+    method = c(
+      "center",
+      "scale",
+      "YeoJohnson",
+      "expoTrans",
+      "BoxCox",
+      "medianImpute",
+      "pca",
+      "spatialSign"
+    ),
+    mean = c(a = 1, b = 2),
+    std = c(a = 1, b = 1),
+    yj = c(a = 1),
+    et = c(a = 1),
+    bc = c(a = 1),
+    median = c(a = 1)
+  )
+  new <- caret:::convert_method(old)
+  expect_type(new$method, "list")
+  expect_identical(new$method$center, c("a", "b"))
+  expect_identical(new$method$scale, c("a", "b"))
+  expect_identical(names(new$method), old$method)
+})
+
+test_that("check_for_wildcards reports and strips PCA/ICA wildcards", {
+  opts <- list(pca = "_PC_", center = c("x1", "_PC_"))
+  expect_snapshot(res <- caret:::check_for_wildcards(opts))
+  # the wildcard tokens are removed from the returned options
+  expect_false("_PC_" %in% unlist(res$opts))
+})

--- a/tests/testthat/test-preProcess-methods.R
+++ b/tests/testthat/test-preProcess-methods.R
@@ -541,3 +541,52 @@ test_that('filters', {
   expect_equal(colnames(filter_mean_pred), c("x1", "x3"))
   expect_equal(filter_mean_pred$x1, x1_exp)
 })
+
+###################################################################
+## imputation and additional transforms
+
+test_that("knnImpute fills in missing values", {
+  skip_on_cran()
+  skip_if_not_installed("RANN")
+  set.seed(1)
+  x <- as.data.frame(matrix(rnorm(200), ncol = 5))
+  x[3, 1] <- NA
+  x[7, 4] <- NA
+
+  pp <- preProcess(x, method = "knnImpute")
+  filled <- predict(pp, x)
+  expect_false(any(is.na(filled)))
+})
+
+test_that("bagImpute fills in missing values", {
+  skip_on_cran()
+  skip_if_not_installed("ipred")
+  set.seed(1)
+  x <- as.data.frame(matrix(rnorm(200), ncol = 5))
+  x[3, 1] <- NA
+
+  pp <- preProcess(x, method = "bagImpute")
+  filled <- predict(pp, x)
+  expect_false(any(is.na(filled)))
+})
+
+test_that("expoTrans and invHyperbolicSine transforms run and invert", {
+  skip_on_cran()
+  set.seed(1)
+  x <- data.frame(a = rexp(50) + 1, b = rexp(50) + 1)
+
+  et <- predict(preProcess(x, method = "expoTrans"), x)
+  expect_identical(dim(et), dim(x))
+
+  ihs <- predict(preProcess(x, method = "invHyperbolicSine"), x)
+  # applied elementwise; equal (not identical) since caret uses log(x+sqrt(...))
+  expect_equal(ihs$a, asinh(x$a))
+})
+
+test_that("print.preProcess summarises the transformations", {
+  skip_on_cran()
+  set.seed(1)
+  x <- as.data.frame(matrix(rnorm(40), ncol = 4))
+  # a fixed object with no fitted values -> deterministic print
+  expect_snapshot(print(preProcess(x, method = c("center", "scale"))))
+})


### PR DESCRIPTION
Unit tests for the internal helpers (invHyperbolicSineFunc, convert_method, check_for_wildcards) and integration tests for the previously-untested methods (knnImpute, bagImpute, expoTrans, invHyperbolicSine) plus a print.preProcess snapshot. 