### PR TITLE
Add tests for the bag

### DIFF
--- a/R/bag.R
+++ b/R/bag.R
@@ -538,12 +538,13 @@ svmBag <- list(
   },
 
   pred = function(object, x) {
-    if (is.character(lev(object))) {
-      out <- predict(object, as.matrix(x), type = "probabilities")
-      colnames(out) <- lev(object)
+    loadNamespace("kernlab")
+    if (is.character(kernlab::lev(object))) {
+      out <- kernlab::predict(object, as.matrix(x), type = "probabilities")
+      colnames(out) <- kernlab::lev(object)
       rownames(out) <- NULL
     } else {
-      out <- predict(object, as.matrix(x))[, 1]
+      out <- kernlab::predict(object, as.matrix(x))[, 1]
     }
     out
   },

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -10,6 +10,7 @@
    \item The \code{earth} model now defines a \code{trim} method, so \code{trainControl(trim = TRUE)} reduces the size of fitted \code{earth} models (dropping the stored \code{x}, \code{y}, and \code{call}) without affecting predictions.
    \item Fixed three bugs in the model-diversity filters used by adaptive resampling: the concordance matrix (\code{cccmat}) was never populated and always returned a matrix of ones; both \code{cccmat} and \code{diffmat} scrambled their entries (breaking symmetry) for four or more models; and \code{filter_on_corr}/\code{filter_on_diff} removed the wrong models due to an index-permutation error.
    \item \code{confusionMatrix()} now gives its intended "the table must nrow = ncol" error for non-square tables, instead of an "invalid argument to unary operator" error from a mis-written check.
+   \item Fixed \code{svmBag$pred} so that bagging with \code{svmBag} works: it called an undefined \code{lev()} and dispatched \code{predict()} without loading \pkg{kernlab}; both now use the \code{kernlab} namespace explicitly.
   }
 }
 

--- a/tests/testthat/_snaps/bag.md
+++ b/tests/testthat/_snaps/bag.md
@@ -1,0 +1,63 @@
+# bag validates its control and arguments
+
+    Code
+      bag(iris[, 1:4], iris$Species)
+    Condition
+      Error in `bag.default()`:
+      ! Please specify 'bagControl' with the appropriate functions
+
+---
+
+    Code
+      bag(iris[, 1:4], iris$Species, vars = 0, bagControl = full_ctrl)
+    Condition
+      Error in `bag.default()`:
+      ! vars must be an integer > 0
+
+---
+
+    Code
+      bag(iris[, 1:4], iris$Species, bagControl = bagControl())
+    Condition
+      Error in `bag.default()`:
+      ! The control arguments 'fit', 'predict' and 'aggregate' should have non-NULL values
+
+# bag fits an ensemble and predicts
+
+    Code
+      print(fit)
+    Output
+      
+      Call:
+      bag.default(x = iris[, 1:4], y = iris$Species, B = 5, bagControl
+       = bagControl(fit = ldaBag$fit, predict = ldaBag$pred, aggregate
+       = ldaBag$aggregate))
+      
+      
+      B: 5 
+      Training data: 4 variables and 150 samples
+      All variables were used in each model
+
+---
+
+    Code
+      summary(fit)
+    Output
+      
+      Call:
+      bag.default(x = iris[, 1:4], y = iris$Species, B = 5, bagControl
+       = bagControl(fit = ldaBag$fit, predict = ldaBag$pred, aggregate
+       = ldaBag$aggregate))
+      
+      Out of bag statistics (B = 5):
+      
+             Accuracy  Kappa
+        0.0%   0.9464 0.9190
+        2.5%   0.9484 0.9220
+       25.0%   0.9661 0.9491
+       50.0%   0.9818 0.9726
+       75.0%   1.0000 1.0000
+       97.5%   1.0000 1.0000
+      100.0%   1.0000 1.0000
+      
+

--- a/tests/testthat/test-bag.R
+++ b/tests/testthat/test-bag.R
@@ -87,3 +87,62 @@ test_that("bag works with the formula interface", {
   expect_s3_class(fit, "bag")
   expect_length(predict(fit, iris), nrow(iris))
 })
+
+# ------------------------------------------------------------------------------
+# the other built-in base learners (each behind its Suggests package)
+
+# fit a small bagged classifier on iris with the given function set
+fit_iris_bag <- function(funcs, ...) {
+  set.seed(1)
+  suppressWarnings(bag(
+    iris[, 1:4],
+    iris$Species,
+    B = 3,
+    bagControl = bagControl(
+      fit = funcs$fit,
+      predict = funcs$pred,
+      aggregate = funcs$aggregate
+    ),
+    ...
+  ))
+}
+
+test_that("bag works with plsBag", {
+  skip_on_cran()
+  skip_if_not_installed("pls")
+  fit <- fit_iris_bag(plsBag)
+  expect_s3_class(fit, "bag")
+  expect_length(predict(fit, iris[, 1:4]), nrow(iris))
+})
+
+test_that("bag works with nnetBag", {
+  skip_on_cran()
+  skip_if_not_installed("nnet")
+  fit <- fit_iris_bag(nnetBag, size = 3)
+  expect_s3_class(fit, "bag")
+  expect_length(predict(fit, iris[, 1:4]), nrow(iris))
+})
+
+test_that("bag works with svmBag", {
+  skip_on_cran()
+  skip_if_not_installed("kernlab")
+  fit <- fit_iris_bag(svmBag)
+  expect_s3_class(fit, "bag")
+  expect_length(predict(fit, iris[, 1:4]), nrow(iris))
+})
+
+test_that("bag works with ctreeBag", {
+  skip_on_cran()
+  skip_if_not_installed("party")
+  fit <- fit_iris_bag(ctreeBag)
+  expect_s3_class(fit, "bag")
+  expect_length(predict(fit, iris[, 1:4]), nrow(iris))
+})
+
+test_that("bag works with nbBag", {
+  skip_on_cran()
+  skip_if_not_installed("klaR")
+  fit <- fit_iris_bag(nbBag)
+  expect_s3_class(fit, "bag")
+  expect_length(predict(fit, iris[, 1:4]), nrow(iris))
+})

--- a/tests/testthat/test-bag.R
+++ b/tests/testthat/test-bag.R
@@ -1,0 +1,89 @@
+# Tests for the general bagging function. bagControl and the argument-validation
+# errors are unit-tested directly; bag() itself is fit with the ldaBag base
+# learner and its predict/print methods are exercised.
+
+# ------------------------------------------------------------------------------
+# bagControl
+
+test_that("bagControl fills in sensible defaults", {
+  ctrl <- bagControl()
+  expect_true(ctrl$oob)
+  expect_false(ctrl$downSample)
+  expect_true(ctrl$allowParallel)
+  # the model functions have no default and must be supplied
+  expect_null(ctrl$fit)
+  expect_null(ctrl$predict)
+  expect_null(ctrl$aggregate)
+})
+
+# ------------------------------------------------------------------------------
+# argument validation
+
+test_that("bag validates its control and arguments", {
+  # bagControl is required
+  expect_snapshot(bag(iris[, 1:4], iris$Species), error = TRUE)
+
+  full_ctrl <- bagControl(
+    fit = ldaBag$fit,
+    predict = ldaBag$pred,
+    aggregate = ldaBag$aggregate
+  )
+  # vars must be a positive integer
+  expect_snapshot(
+    bag(iris[, 1:4], iris$Species, vars = 0, bagControl = full_ctrl),
+    error = TRUE
+  )
+  # fit/predict/aggregate must all be supplied
+  expect_snapshot(
+    bag(iris[, 1:4], iris$Species, bagControl = bagControl()),
+    error = TRUE
+  )
+})
+
+# ------------------------------------------------------------------------------
+# bag() workflow + methods
+
+test_that("bag fits an ensemble and predicts", {
+  skip_on_cran()
+  skip_if_not_installed("MASS")
+
+  set.seed(1)
+  fit <- suppressWarnings(bag(
+    iris[, 1:4],
+    iris$Species,
+    B = 5,
+    bagControl = bagControl(
+      fit = ldaBag$fit,
+      predict = ldaBag$pred,
+      aggregate = ldaBag$aggregate
+    )
+  ))
+
+  expect_s3_class(fit, "bag")
+  expect_length(predict(fit, iris[, 1:4]), nrow(iris))
+  # the print output has no fitted metrics, so it is deterministic
+  expect_snapshot(print(fit))
+
+  # summary reports out-of-bag performance (seeded, so reproducible in CI)
+  expect_snapshot(summary(fit))
+})
+
+test_that("bag works with the formula interface", {
+  skip_on_cran()
+  skip_if_not_installed("MASS")
+
+  set.seed(1)
+  fit <- suppressWarnings(bag(
+    Species ~ .,
+    data = iris,
+    B = 5,
+    bagControl = bagControl(
+      fit = ldaBag$fit,
+      predict = ldaBag$pred,
+      aggregate = ldaBag$aggregate
+    )
+  ))
+
+  expect_s3_class(fit, "bag")
+  expect_length(predict(fit, iris), nrow(iris))
+})


### PR DESCRIPTION
Unit tests for bagControl and bag()'s argument validation, plus integration tests that fit an ldaBag ensemble through the default and formula interfaces and exercise predict/print/summary (all snapshotted). 