### PR TITLE
Add tests for plot.train

### DIFF
--- a/tests/testthat/_snaps/plot.train.md
+++ b/tests/testthat/_snaps/plot.train.md
@@ -1,0 +1,16 @@
+# plot.train draws scatter and line plots for a tuned model
+
+    Code
+      plot(fit, plotType = "nope")
+    Condition
+      Error in `plot.train()`:
+      ! plotType must be either level, scatter or line
+
+# plot.train errors when no tuning parameter varies
+
+    Code
+      plot(fit)
+    Condition
+      Error in `plot.train()`:
+      ! There are no tuning parameters with more than 1 value.
+

--- a/tests/testthat/test-plot.train.R
+++ b/tests/testthat/test-plot.train.R
@@ -1,0 +1,54 @@
+# Tests for plot.train. The function builds lattice objects, so the tests check
+# that a trellis object is returned for each plot type (and cover the data-prep
+# and error paths); the visual output itself isn't asserted.
+
+test_that("plot.train draws scatter and line plots for a tuned model", {
+  skip_on_cran()
+
+  set.seed(1)
+  fit <- train(
+    Species ~ .,
+    data = iris,
+    method = "knn",
+    tuneLength = 4,
+    trControl = trainControl(method = "cv", number = 3)
+  )
+
+  expect_s3_class(plot(fit, plotType = "scatter"), "trellis")
+  expect_s3_class(plot(fit, plotType = "line"), "trellis")
+  # an unknown plot type is rejected
+  expect_snapshot(plot(fit, plotType = "nope"), error = TRUE)
+})
+
+test_that("plot.train draws a level plot for two tuning parameters", {
+  skip_on_cran()
+  skip_if_not_installed("earth")
+
+  set.seed(1)
+  dat <- SLC14_1(80)
+  fit <- suppressWarnings(suppressMessages(train(
+    y ~ .,
+    data = dat,
+    method = "earth",
+    tuneGrid = expand.grid(nprune = 2:4, degree = 1:2),
+    trControl = trainControl(method = "cv", number = 3)
+  )))
+
+  expect_s3_class(plot(fit, plotType = "level"), "trellis")
+  expect_s3_class(plot(fit, plotType = "scatter"), "trellis")
+})
+
+test_that("plot.train errors when no tuning parameter varies", {
+  skip_on_cran()
+
+  set.seed(1)
+  dat <- SLC14_1(80)
+  fit <- train(
+    y ~ .,
+    data = dat,
+    method = "lm",
+    trControl = trainControl(method = "cv", number = 3)
+  )
+
+  expect_snapshot(plot(fit), error = TRUE)
+})


### PR DESCRIPTION
Cover plot.train across scatter, line and level plot types plus the invalid-plotType and no-varying-parameter error paths. 