### PR TITLE
Extend resamples tests to plot, PCA, cluster and diff methods

### DIFF
--- a/tests/testthat/_snaps/resamples.md
+++ b/tests/testthat/_snaps/resamples.md
@@ -10,3 +10,81 @@
       Error in `as.matrix.resamples()`:
       ! no columns fit that metric
 
+# resamples print methods render
+
+    Code
+      print(rs_fixture)
+    Output
+      
+      Call:
+      resamples(list(A = A, B = B, C = C))
+      
+      Models: A, B, C 
+      Number of resamples: 5 
+      Performance metrics: RMSE, Rsquared 
+
+---
+
+    Code
+      print(summary(rs_fixture))
+    Output
+      
+      Call:
+      summary.resamples(object = rs_fixture)
+      
+      Models: A, B, C 
+      Number of resamples: 5 
+      
+      RMSE 
+        Min. 1st Qu. Median Mean 3rd Qu. Max. NA's
+      A    1       2      3    3       4    5    0
+      B    3       3      4    4       5    5    0
+      C    3       4      5    5       6    7    0
+      
+      Rsquared 
+        Min. 1st Qu. Median Mean 3rd Qu. Max. NA's
+      A 0.70    0.75   0.80 0.80    0.85 0.90    0
+      B 0.63    0.66   0.71 0.72    0.78 0.82    0
+      C 0.50    0.55   0.60 0.60    0.65 0.70    0
+      
+
+---
+
+    Code
+      print(diff(rs_fixture))
+    Output
+      
+      Call:
+      diff.resamples(x = rs_fixture)
+      
+      Models: A, B, C 
+      Metrics: RMSE, Rsquared 
+      Number of differences: 3 
+      p-value adjustment: bonferroni 
+
+---
+
+    Code
+      print(summary(diff(rs_fixture)))
+    Output
+      
+      Call:
+      summary.diff.resamples(object = diff(rs_fixture))
+      
+      p-value adjustment: bonferroni 
+      Upper diagonal: estimates of the difference
+      Lower diagonal: p-value for H0: difference = 0
+      
+      RMSE 
+        A      B      C 
+      A        -1     -2
+      B 0.1023        -1
+      C 0.6906 1.0000   
+      
+      Rsquared 
+        A         B         C   
+      A           0.08      0.20
+      B 0.0001722           0.12
+      C 0.1422620 0.4967353     
+      
+

--- a/tests/testthat/test-resamples.R
+++ b/tests/testthat/test-resamples.R
@@ -206,7 +206,13 @@ test_that("resamples plot methods return trellis objects", {
   expect_s3_class(densityplot(rs_fixture), "trellis")
   expect_s3_class(splom(rs_fixture), "trellis")
   expect_s3_class(parallelplot(rs_fixture), "trellis")
-  expect_s3_class(plot(prcomp(rs_fixture)), "trellis")
+})
+
+test_that("plot.prcomp.resamples draws each type of PCA plot", {
+  pc <- prcomp(rs_fixture)
+  for (what in c("scree", "cumulative", "loadings", "components")) {
+    expect_s3_class(plot(pc, what = what), "trellis")
+  }
 })
 
 test_that("diff.resamples plot methods return trellis objects", {

--- a/tests/testthat/test-resamples.R
+++ b/tests/testthat/test-resamples.R
@@ -165,3 +165,53 @@ test_that("compare_models runs a paired test between two fitted models", {
   expect_s3_class(cmp, "htest")
   expect_false(is.null(cmp$p.value))
 })
+
+# ------------------------------------------------------------------------------
+# PCA, clustering and diff summaries (computations)
+
+test_that("prcomp.resamples runs a PCA on the resampled results", {
+  pc <- prcomp(rs_fixture)
+  expect_s3_class(pc, "prcomp.resamples")
+  expect_identical(pc$metric, "RMSE")
+})
+
+test_that("cluster.resamples clusters the models", {
+  cl <- cluster(rs_fixture)
+  expect_s3_class(cl, "cluster.resamples")
+})
+
+test_that("summary.diff.resamples summarises the pairwise differences", {
+  sm <- summary(diff(rs_fixture))
+  expect_s3_class(sm, "summary.diff.resamples")
+  expect_identical(names(sm$table), c("RMSE", "Rsquared"))
+})
+
+# ------------------------------------------------------------------------------
+# print methods (deterministic fixture -> snapshot)
+
+test_that("resamples print methods render", {
+  expect_snapshot(print(rs_fixture))
+  expect_snapshot(print(summary(rs_fixture)))
+  expect_snapshot(print(diff(rs_fixture)))
+  expect_snapshot(print(summary(diff(rs_fixture))))
+})
+
+# ------------------------------------------------------------------------------
+# plot methods (smoke tests: they should build a trellis object)
+
+test_that("resamples plot methods return trellis objects", {
+  expect_s3_class(xyplot(rs_fixture), "trellis")
+  expect_s3_class(dotplot(rs_fixture), "trellis")
+  expect_s3_class(bwplot(rs_fixture), "trellis")
+  expect_s3_class(densityplot(rs_fixture), "trellis")
+  expect_s3_class(splom(rs_fixture), "trellis")
+  expect_s3_class(parallelplot(rs_fixture), "trellis")
+  expect_s3_class(plot(prcomp(rs_fixture)), "trellis")
+})
+
+test_that("diff.resamples plot methods return trellis objects", {
+  d <- diff(rs_fixture)
+  expect_s3_class(densityplot(d), "trellis")
+  expect_s3_class(bwplot(d), "trellis")
+  expect_s3_class(dotplot(d), "trellis")
+})


### PR DESCRIPTION
Add more tests for prcomp/cluster.resamples, summary.diff.resamples, the print methods (snapshotted), and smoke tests that the lattice plot methods (xyplot/dotplot/bwplot/densityplot/splom/parallelplot and the diff variants) return trellis objects. 