### PR TITLE
Add tests for calibration curves

### DIFF
--- a/tests/testthat/_snaps/calibration.md
+++ b/tests/testthat/_snaps/calibration.md
@@ -1,0 +1,29 @@
+# calibration requires a formula
+
+    Code
+      calibration(lift_data)
+    Condition
+      Error in `calibration.default()`:
+      ! 'x' should be a formula
+
+# calibration needs a factor on the left-hand side
+
+    Code
+      calibration(prob1 ~ prob2, data = lift_data)
+    Condition
+      Error in `calibration.formula()`:
+      ! the left-hand side of the formula must be a factor of classes
+
+# print.calibration reports the models and event
+
+    Code
+      print(cal)
+    Output
+      
+      Call:
+      calibration.formula(x = Class ~ prob1, data = lift_data)
+      
+      Models: prob1 
+      Event:  yes 
+      Cuts: 11 
+

--- a/tests/testthat/test-calibration.R
+++ b/tests/testthat/test-calibration.R
@@ -1,0 +1,42 @@
+# Tests for calibration curves. The computation (calibration.formula / calibCalc)
+# is exercised directly and the plot methods are smoke-tested; the shared
+# lift_data fixture (a Class ~ prob layout) lives in helper-lift.R.
+
+test_that("calibration requires a formula", {
+  expect_snapshot(calibration(lift_data), error = TRUE)
+})
+
+test_that("calibration computes a reliability table for one model", {
+  cal <- calibration(Class ~ prob1, data = lift_data)
+  expect_s3_class(cal, "calibration")
+  expect_identical(
+    colnames(cal$data),
+    c("calibModelVar", "bin", "Percent", "Lower", "Upper", "Count", "midpoint")
+  )
+})
+
+test_that("calibration handles several models and custom cuts", {
+  cal <- calibration(Class ~ prob1 + prob2, data = lift_data)
+  expect_identical(
+    sort(as.character(unique(cal$data$calibModelVar))),
+    c("prob1", "prob2")
+  )
+  # cuts controls the number of probability bins
+  by_count <- calibration(Class ~ prob1, data = lift_data, cuts = 5)
+  expect_identical(nrow(by_count$data), 5L)
+})
+
+test_that("calibration needs a factor on the left-hand side", {
+  expect_snapshot(calibration(prob1 ~ prob2, data = lift_data), error = TRUE)
+})
+
+test_that("calibration plot methods build lattice and ggplot objects", {
+  cal <- calibration(Class ~ prob1, data = lift_data)
+  expect_s3_class(xyplot(cal), "trellis")
+  expect_s3_class(ggplot(cal), "ggplot")
+})
+
+test_that("print.calibration reports the models and event", {
+  cal <- calibration(Class ~ prob1, data = lift_data)
+  expect_snapshot(print(cal))
+})


### PR DESCRIPTION
Cover the calibration computation (calibration.formula, calibCalc, cuts, print) and smoke-test the lattice/ggplot plot methods, reusing the lift_data fixture from helper-lift.R. 