### PR TITLE
Add tests for pcaNNet

### DIFF
--- a/tests/testthat/_snaps/pcaNNet.md
+++ b/tests/testthat/_snaps/pcaNNet.md
@@ -1,0 +1,22 @@
+# print.pcaNNet reports the PCA and network structure
+
+    Code
+      print(fit)
+    Output
+      Neural Network Model with PCA Pre-Processing
+      
+      Created from 150 samples and 4 variables
+      PCA needed 3 components to capture 99 percent of the variance
+      
+      a 3-3-3 network with 24 weights
+      options were -
+      
+
+# predict.pcaNNet rejects objects of the wrong class
+
+    Code
+      caret:::predict.pcaNNet(structure(list(), class = "notPcaNNet"), iris)
+    Condition
+      Error in `caret:::predict.pcaNNet()`:
+      ! object not of class "pcaNNet"
+

--- a/tests/testthat/test-pcaNNet.R
+++ b/tests/testthat/test-pcaNNet.R
@@ -1,0 +1,54 @@
+# Tests for pcaNNet (PCA pre-processing followed by a neural network). Fits are
+# RNG-dependent, so the tests assert on structure and prediction shape and
+# snapshot only the deterministic print output.
+
+test_that("pcaNNet fits a classifier and predicts each type", {
+  skip_on_cran()
+  skip_if_not_installed("nnet")
+
+  set.seed(1)
+  fit <- pcaNNet(iris[, 1:4], iris$Species, size = 3, trace = FALSE)
+
+  expect_s3_class(fit, "pcaNNet")
+  expect_length(predict(fit, iris[, 1:4], type = "class"), nrow(iris))
+  probs <- predict(fit, iris[, 1:4], type = "prob")
+  expect_identical(colnames(probs), levels(iris$Species))
+  expect_identical(dim(predict(fit, iris[, 1:4], type = "raw")), c(150L, 3L))
+})
+
+test_that("pcaNNet works with the formula interface", {
+  skip_on_cran()
+  skip_if_not_installed("nnet")
+
+  set.seed(1)
+  fit <- pcaNNet(Species ~ ., data = iris, size = 3, trace = FALSE)
+  expect_s3_class(fit, "pcaNNet.formula")
+  expect_length(predict(fit, iris, type = "class"), nrow(iris))
+})
+
+test_that("pcaNNet fits a regression model", {
+  skip_on_cran()
+  skip_if_not_installed("nnet")
+
+  set.seed(1)
+  dat <- SLC14_1(80)
+  fit <- pcaNNet(dat[, 1:5], dat$y, size = 3, linout = TRUE, trace = FALSE)
+  expect_s3_class(fit, "pcaNNet")
+  expect_length(predict(fit, dat[, 1:5]), nrow(dat))
+})
+
+test_that("print.pcaNNet reports the PCA and network structure", {
+  skip_on_cran()
+  skip_if_not_installed("nnet")
+
+  set.seed(1)
+  fit <- pcaNNet(iris[, 1:4], iris$Species, size = 3, trace = FALSE)
+  expect_snapshot(print(fit))
+})
+
+test_that("predict.pcaNNet rejects objects of the wrong class", {
+  expect_snapshot(
+    caret:::predict.pcaNNet(structure(list(), class = "notPcaNNet"), iris),
+    error = TRUE
+  )
+})

--- a/tests/testthat/test-pcaNNet.R
+++ b/tests/testthat/test-pcaNNet.R
@@ -52,3 +52,27 @@ test_that("predict.pcaNNet rejects objects of the wrong class", {
     error = TRUE
   )
 })
+
+test_that("pcaNNet handles a single predictor and single-row prediction", {
+  skip_on_cran()
+  skip_if_not_installed("nnet")
+
+  # a single predictor drops the PCA step (a group transform needs >= 2 cols),
+  # but the network still fits and predicts
+  set.seed(1)
+  fit <- suppressWarnings(
+    pcaNNet(iris[, 1, drop = FALSE], iris$Species, size = 3, trace = FALSE)
+  )
+  expect_length(
+    predict(fit, iris[, 1, drop = FALSE], type = "class"),
+    nrow(iris)
+  )
+
+  # a single new row returns a single set of class probabilities
+  set.seed(1)
+  full <- pcaNNet(iris[, 1:4], iris$Species, size = 3, trace = FALSE)
+  expect_identical(
+    nrow(predict(full, iris[1, 1:4, drop = FALSE], type = "prob")),
+    1L
+  )
+})


### PR DESCRIPTION
Integration tests for the PCA-plus-neural-network model across the default, formula, classification and regression paths, all predict types, the print method and the wrong-class predict error (both snapshotted).