### PR TITLE
Add tests for icr and fix its broken formula interface

### DIFF
--- a/R/icr.R
+++ b/R/icr.R
@@ -72,7 +72,7 @@ icr.formula <- function(
   }
   y <- model.response(m)
 
-  res <- icr.default(x, y, weights = w, thresh = thresh, ...)
+  res <- icr.default(x, y, ...)
   res$terms <- Terms
   res$coefnames <- colnames(x)
   res$na.action <- attr(m, "na.action")

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -12,6 +12,7 @@
    \item \code{confusionMatrix()} now gives its intended "the table must nrow = ncol" error for non-square tables, instead of an "invalid argument to unary operator" error from a mis-written check.
    \item \code{print.nullModel()} no longer swaps the model-type label; a classification null model now prints "Null Classification Model" (and regression prints "Null Regression Model").
    \item Fixed \code{svmBag$pred} so that bagging with \code{svmBag} works: it called an undefined \code{lev()} and dispatched \code{predict()} without loading \pkg{kernlab}; both now use the \code{kernlab} namespace explicitly.
+   \item The formula interface for \code{icr()} now works; it previously forwarded an unused \code{weights} argument (and an undefined \code{thresh}) into \code{fastICA}, which errored with "unused argument (weights = ...)".
   }
 }
 

--- a/tests/testthat/_snaps/icr.md
+++ b/tests/testthat/_snaps/icr.md
@@ -1,0 +1,8 @@
+# icr requires a numeric outcome
+
+    Code
+      icr(iris[, 1:4], iris$Species, n.comp = 2)
+    Condition
+      Error in `icr.default()`:
+      ! y must be numeric
+

--- a/tests/testthat/test-icr.R
+++ b/tests/testthat/test-icr.R
@@ -1,0 +1,52 @@
+# Tests for independent component regression (icr). Needs fastICA. Fits are
+# RNG-dependent, so the tests assert on structure/prediction shape and snapshot
+# only the deterministic error output.
+
+test_that("icr fits from the default and formula interfaces", {
+  skip_on_cran()
+  skip_if_not_installed("fastICA")
+
+  set.seed(1)
+  fit <- icr(mtcars[, -1], mtcars$mpg, n.comp = 3)
+  expect_s3_class(fit, "icr")
+  expect_length(predict(fit, mtcars[, -1]), nrow(mtcars))
+
+  set.seed(1)
+  fit_form <- icr(mpg ~ ., data = mtcars, n.comp = 3)
+  expect_s3_class(fit_form, "icr.formula")
+  expect_length(predict(fit_form, mtcars), nrow(mtcars))
+})
+
+test_that("icr handles a single predictor and single-row prediction", {
+  skip_on_cran()
+  skip_if_not_installed("fastICA")
+
+  # with one predictor, n.comp cannot exceed 1
+  set.seed(1)
+  fit <- icr(mtcars[, "hp", drop = FALSE], mtcars$mpg, n.comp = 1)
+  expect_length(predict(fit, mtcars[, "hp", drop = FALSE]), nrow(mtcars))
+
+  # a single new row returns a single prediction
+  set.seed(1)
+  full <- icr(mtcars[, -1], mtcars$mpg, n.comp = 3)
+  expect_length(predict(full, mtcars[1, -1, drop = FALSE]), 1)
+})
+
+test_that("icr requires a numeric outcome", {
+  skip_on_cran()
+  skip_if_not_installed("fastICA")
+
+  set.seed(1)
+  expect_snapshot(icr(iris[, 1:4], iris$Species, n.comp = 2), error = TRUE)
+})
+
+test_that("print.icr identifies the model", {
+  skip_on_cran()
+  skip_if_not_installed("fastICA")
+
+  set.seed(1)
+  fit <- icr(mtcars[, -1], mtcars$mpg, n.comp = 3)
+  # the coefficients are RNG-/BLAS-dependent floats, so match the stable header
+  # rather than snapshotting the whole print
+  expect_output(print(fit), "Independent Component Regression")
+})


### PR DESCRIPTION
Cover independent component regression across the default and formula interfaces, single-predictor and single-row prediction, the numeric-outcome error and print. Testing the formula interface surfaced a bug: icr.formula forwarded an unused weights argument (and an undefined thresh) into fastICA, which errored; it now forwards ... cleanly.