### PR TITLE
Add tests for modelLookup utilities and fix its error message

### DIFF
--- a/R/modelLookup.R
+++ b/R/modelLookup.R
@@ -55,7 +55,7 @@ modelLookup <- function(model = NULL) {
     if (!(model %in% names(models))) {
       stop(paste(
         "Model '",
-        method,
+        model,
         "' is not in the ",
         "set of existing models",
         sep = ""

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -12,6 +12,7 @@
    \item \code{confusionMatrix()} now gives its intended "the table must nrow = ncol" error for non-square tables, instead of an "invalid argument to unary operator" error from a mis-written check.
    \item \code{print.nullModel()} no longer swaps the model-type label; a classification null model now prints "Null Classification Model" (and regression prints "Null Regression Model").
    \item Fixed \code{svmBag$pred} so that bagging with \code{svmBag} works: it called an undefined \code{lev()} and dispatched \code{predict()} without loading \pkg{kernlab}; both now use the \code{kernlab} namespace explicitly.
+   \item \code{modelLookup()} now gives its intended "Model '...' is not in the set of existing models" error for an unknown model, instead of an "object 'method' not found" error from a mistyped variable name.
   }
 }
 

--- a/tests/testthat/_snaps/modelLookup.md
+++ b/tests/testthat/_snaps/modelLookup.md
@@ -1,0 +1,24 @@
+# modelLookup errors for an unknown model
+
+    Code
+      modelLookup("nnnotamodel")
+    Condition
+      Error in `modelLookup()`:
+      ! Model 'nnnotamodel' is not in the set of existing models
+
+# getModelInfo returns the model definition
+
+    Code
+      getModelInfo("zzznomatchxyz")
+    Condition
+      Error in `getModelInfo()`:
+      ! That model is not in caret's built-in library
+
+# checkInstall is silent for installed packages and errors otherwise
+
+    Code
+      caret:::checkInstall("nopkg99xyz")
+    Condition
+      Error:
+      ! Required packages are missing: nopkg99xyz
+

--- a/tests/testthat/test-modelLookup.R
+++ b/tests/testthat/test-modelLookup.R
@@ -1,0 +1,49 @@
+# Tests for the model-metadata utilities in R/modelLookup.R: modelLookup,
+# getModelInfo, checkInstall and missing_packages. These are pure lookups (no
+# model fitting), so the results are deterministic.
+
+test_that("modelLookup returns the tuning parameters for a model", {
+  ml <- modelLookup("knn")
+  expect_identical(
+    colnames(ml),
+    c("model", "parameter", "label", "forReg", "forClass", "probModel")
+  )
+  expect_identical(unique(ml$model), "knn")
+  expect_identical(ml$parameter, "k")
+})
+
+test_that("modelLookup with no argument lists every model", {
+  all <- modelLookup()
+  expect_s3_class(all, "data.frame")
+  expect_gt(nrow(all), 100)
+  expect_true(all(c("knn", "rf", "glm") %in% all$model))
+})
+
+test_that("modelLookup errors for an unknown model", {
+  expect_snapshot(modelLookup("nnnotamodel"), error = TRUE)
+})
+
+test_that("getModelInfo returns the model definition", {
+  # an exact lookup returns one model with fit/predict functions
+  info <- getModelInfo("knn", regex = FALSE)
+  expect_named(info, "knn")
+  expect_type(info$knn$fit, "closure")
+  expect_type(info$knn$predict, "closure")
+
+  # a regex lookup can match several models
+  expect_gte(length(getModelInfo("rpart")), 1)
+
+  # a pattern that matches nothing is an error
+  expect_snapshot(getModelInfo("zzznomatchxyz"), error = TRUE)
+})
+
+test_that("checkInstall is silent for installed packages and errors otherwise", {
+  expect_null(caret:::checkInstall("stats"))
+  # in a non-interactive session a missing package is a hard error
+  expect_snapshot(caret:::checkInstall("nopkg99xyz"), error = TRUE)
+})
+
+test_that("missing_packages reports nothing when the model's deps are present", {
+  # knn only needs base packages, so nothing is missing
+  expect_null(caret:::missing_packages(getModelInfo("knn", regex = FALSE)))
+})


### PR DESCRIPTION
Cover modelLookup, getModelInfo, checkInstall and missing_packages (pure model-metadata lookups), including the unknown-model and no-match errors. Testing the unknown-model path surfaced a bug: modelLookup referenced a mistyped 'method' in its error, throwing 'object method not found' instead of the intended message; now fixed. 