### PR TITLE
Add tests for thresholder

### DIFF
--- a/tests/testthat/_snaps/thresholder.md
+++ b/tests/testthat/_snaps/thresholder.md
@@ -1,0 +1,40 @@
+# thresholder validates its inputs
+
+    Code
+      thresholder(list(), threshold = 0.5)
+    Condition
+      Error:
+      ! `x` should be an object of class 'train'
+
+---
+
+    Code
+      thresholder(fit, threshold = 1.5)
+    Condition
+      Error:
+      ! `threshold` should be on [0,1]
+
+---
+
+    Code
+      thresholder(no_probs, threshold = 0.5)
+    Condition
+      Error:
+      ! `classProbs` must be TRUE in `trainControl`
+
+---
+
+    Code
+      thresholder(no_save, threshold = 0.5)
+    Condition
+      Error in `thresholder()`:
+      ! `savePredictions` should be TRUE, 'all', or 'final'
+
+# thresholder only supports two-class problems
+
+    Code
+      thresholder(fit, threshold = 0.5)
+    Condition
+      Error in `thresholder()`:
+      ! For two class problems only
+

--- a/tests/testthat/helper-thresholder.R
+++ b/tests/testthat/helper-thresholder.R
@@ -1,0 +1,21 @@
+# Shared fixture builder for test-thresholder.R.
+#
+# thresholder() operates on a fitted two-class train object, so this returns a
+# small knn fit. `...` is passed to trainControl so tests can flip classProbs /
+# savePredictions to exercise the validation paths. It is a function (not a
+# top-level fit) so nothing runs at load time and the tests can gate it with
+# skip_on_cran.
+threshold_fit <- function(..., formula = Class ~ ., data = NULL) {
+  if (is.null(data)) {
+    set.seed(1)
+    data <- twoClassSim(200)
+  }
+  set.seed(2)
+  train(
+    formula,
+    data = data,
+    method = "knn",
+    tuneGrid = data.frame(k = c(5, 9)),
+    trControl = trainControl(method = "cv", number = 3, ...)
+  )
+}

--- a/tests/testthat/test-thresholder.R
+++ b/tests/testthat/test-thresholder.R
@@ -1,0 +1,70 @@
+# Tests for thresholder(), which sweeps probability cut-offs for a two-class
+# train object and reports performance at each. The stat values are RNG-
+# dependent, so the tests assert on structure and snapshot only the deterministic
+# validation errors. The threshold_fit() fixture builder lives in
+# helper-thresholder.R.
+
+test_that("thresholder returns performance for each probability cut-off", {
+  skip_on_cran()
+
+  fit <- threshold_fit(classProbs = TRUE, savePredictions = "all")
+  th <- thresholder(fit, threshold = seq(0.3, 0.7, by = 0.1))
+
+  expect_s3_class(th, "data.frame")
+  # one row per threshold (the final tuning parameter is used by default)
+  expect_identical(nrow(th), 5L)
+  expect_true(all(
+    c("prob_threshold", "Sensitivity", "Specificity") %in% colnames(th)
+  ))
+  # sensitivity/specificity are proportions
+  expect_true(all(th$Sensitivity >= 0 & th$Sensitivity <= 1))
+})
+
+test_that("thresholder can report every tuning parameter and a stats subset", {
+  skip_on_cran()
+
+  fit <- threshold_fit(classProbs = TRUE, savePredictions = "all")
+
+  # final = FALSE keeps a row per tuning parameter value (two k's here)
+  all_tunes <- thresholder(fit, threshold = 0.5, final = FALSE)
+  expect_identical(nrow(all_tunes), 2L)
+
+  # a statistics subset limits the reported columns
+  subset <- thresholder(
+    fit,
+    threshold = 0.5,
+    statistics = c("Sensitivity", "Specificity")
+  )
+  expect_true(all(c("Sensitivity", "Specificity") %in% colnames(subset)))
+})
+
+test_that("thresholder validates its inputs", {
+  skip_on_cran()
+
+  # not a train object
+  expect_snapshot(thresholder(list(), threshold = 0.5), error = TRUE)
+
+  fit <- threshold_fit(classProbs = TRUE, savePredictions = "all")
+  # thresholds must be within [0, 1]
+  expect_snapshot(thresholder(fit, threshold = 1.5), error = TRUE)
+
+  # classProbs must have been on
+  no_probs <- threshold_fit(savePredictions = "all")
+  expect_snapshot(thresholder(no_probs, threshold = 0.5), error = TRUE)
+
+  # predictions must have been saved
+  no_save <- threshold_fit(classProbs = TRUE)
+  expect_snapshot(thresholder(no_save, threshold = 0.5), error = TRUE)
+})
+
+test_that("thresholder only supports two-class problems", {
+  skip_on_cran()
+
+  fit <- threshold_fit(
+    classProbs = TRUE,
+    savePredictions = "all",
+    formula = Species ~ .,
+    data = iris
+  )
+  expect_snapshot(thresholder(fit, threshold = 0.5), error = TRUE)
+})


### PR DESCRIPTION
Cover thresholder() over a two-class train object: performance across probability cut-offs, the final = FALSE and statistics-subset options, and all five validation errors (snapshotted). The fixture builder lives in helper-thresholder.R. 