### PR TITLE
Add tests for the train lattice plot methods

### DIFF
--- a/tests/testthat/_snaps/lattice-train.md
+++ b/tests/testthat/_snaps/lattice-train.md
@@ -1,0 +1,64 @@
+# the plot methods warn when 'data' is supplied
+
+    Code
+      invisible(densityplot(fit, data = iris))
+    Condition
+      Warning in `densityplot.train()`:
+      explicit 'data' specification ignored
+
+---
+
+    Code
+      invisible(histogram(fit, data = iris))
+    Condition
+      Warning in `histogram.train()`:
+      explicit 'data' specification ignored
+
+---
+
+    Code
+      invisible(stripplot(fit, data = iris))
+    Condition
+      Warning in `stripplot.train()`:
+      explicit 'data' specification ignored
+
+---
+
+    Code
+      invisible(xyplot(fit, data = iris))
+    Condition
+      Warning in `xyplot.train()`:
+      explicit 'data' specification ignored
+
+# the plot methods reject LOOCV/oob resampling
+
+    Code
+      densityplot(fit)
+    Condition
+      Error in `densityplot.train()`:
+      ! Resampling plots cannot be done with leave-out-out CV or out-of-bag resampling
+
+---
+
+    Code
+      histogram(fit)
+    Condition
+      Error in `histogram.train()`:
+      ! Resampling plots cannot be done with leave-out-out CV or out-of-bag resampling
+
+---
+
+    Code
+      stripplot(fit)
+    Condition
+      Error in `stripplot.train()`:
+      ! Resampling plots cannot be done with leave-out-out CV or out-of-bag resampling
+
+---
+
+    Code
+      xyplot(fit)
+    Condition
+      Error in `xyplot.train()`:
+      ! Resampling plots cannot be done with leave-out-out CV or out-of-bag resampling
+

--- a/tests/testthat/helper-lattice-train.R
+++ b/tests/testthat/helper-lattice-train.R
@@ -1,0 +1,26 @@
+# Shared fixture builder for test-lattice-train.R.
+#
+# The lattice plot methods for train objects need retained per-resample results,
+# so this fits a small knn with returnResamp = "all". `...` is forwarded to
+# trainControl so tests can switch the resampling method (e.g. LOOCV) to hit the
+# error paths. It is a function so nothing runs at load time.
+lattice_train_fit <- function(..., tuneLength = 3, data = NULL, method = "cv") {
+  if (is.null(data)) {
+    set.seed(1)
+    data <- twoClassSim(200)
+  }
+  set.seed(2)
+  train(
+    Class ~ .,
+    data = data,
+    method = "knn",
+    tuneLength = tuneLength,
+    trControl = trainControl(
+      method = method,
+      number = 5,
+      returnResamp = "all",
+      classProbs = TRUE,
+      ...
+    )
+  )
+}

--- a/tests/testthat/test-lattice-train.R
+++ b/tests/testthat/test-lattice-train.R
@@ -1,0 +1,37 @@
+# Tests for the lattice plot methods on train objects (densityplot / histogram /
+# stripplot / xyplot). They build trellis objects from the resampled results, so
+# the tests check that a trellis object comes back and snapshot the deterministic
+# data-ignored warning and the LOOCV error. Fixture builder lives in
+# helper-lattice-train.R.
+
+test_that("the resampling plot methods return trellis objects", {
+  skip_on_cran()
+
+  fit <- lattice_train_fit()
+  expect_s3_class(densityplot(fit), "trellis")
+  expect_s3_class(histogram(fit), "trellis")
+  expect_s3_class(stripplot(fit), "trellis")
+  expect_s3_class(xyplot(fit), "trellis")
+  # a non-default metric is accepted
+  expect_s3_class(densityplot(fit, metric = "Kappa"), "trellis")
+})
+
+test_that("the plot methods warn when 'data' is supplied", {
+  skip_on_cran()
+
+  fit <- lattice_train_fit()
+  expect_snapshot(invisible(densityplot(fit, data = iris)))
+  expect_snapshot(invisible(histogram(fit, data = iris)))
+  expect_snapshot(invisible(stripplot(fit, data = iris)))
+  expect_snapshot(invisible(xyplot(fit, data = iris)))
+})
+
+test_that("the plot methods reject LOOCV/oob resampling", {
+  skip_on_cran()
+
+  fit <- lattice_train_fit(method = "LOOCV", tuneLength = 1)
+  expect_snapshot(densityplot(fit), error = TRUE)
+  expect_snapshot(histogram(fit), error = TRUE)
+  expect_snapshot(stripplot(fit), error = TRUE)
+  expect_snapshot(xyplot(fit), error = TRUE)
+})


### PR DESCRIPTION
Cover densityplot/histogram/stripplot/xyplot for train objects: each returns a trellis object from the resampled results, warns when 'data' is supplied, and errors for LOOCV/oob resampling (warnings and errors snapshotted). The fixture builder lives in helper-lattice-train.R. 